### PR TITLE
Strip leading null byte from public key when unwrapping key

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
+++ b/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.jss.pkcs11;
 
+import java.util.Arrays;
+
 import org.mozilla.jss.crypto.*;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.InvalidAlgorithmParameterException;
@@ -394,6 +396,11 @@ final class PK11KeyWrapper implements KeyWrapper {
         }
 
         byte[] publicValue = extractPublicValue(publicKey, type);
+        /* If first byte is null, omit it.
+         * It can be null due to how BigInteger.toByteArray() is specified. */
+        if (publicValue.length > 0 && publicValue[0] == 0) {
+            publicValue = Arrays.copyOfRange(publicValue, 1, publicValue.length);
+        }
 
         if( symKey != null ) {
             Assert._assert(pubKey==null && privKey==null);


### PR DESCRIPTION
NSS identifies RSA private keys by setting the PKCS #11 CKA_ID
attribute to the SHA-1 digest of the public key (modulus).

PK11KeyWrapper can receive this modulus value (a byte[]) with a
leading null byte.  This results in the digest (CKA_ID) not matching
what the rest of NSS expects, e.g. when adding the corresponding
certificate, NSS fails to associate it with the private key, because
it is looking for a different CKA_ID.

This results in Dogtag lightweight CA key replication failures.

Apparently the problem did not occur with the old DB backend, only
with the new SQL backend.  Or there was some other change in NSS
that landed in Fedora 28, which prompted this issue.  In either
case, the resolve the problem by dropping the leading null byte from
the modulus byte[].

Fixes: https://pagure.io/jss/issue/5
Change-Id: I4685d7e091b0adc72d5ca067f2d65c3c068c8f7a