### PR TITLE
Added .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# BEGIN COPYRIGHT BLOCK
+# (C) 2018 Red Hat, Inc.
+# All rights reserved.
+# END COPYRIGHT BLOCK
+
+services:
+  - docker
+
+install:
+  - docker pull registry.fedoraproject.org/fedora:28
+  - docker run
+      --name=container
+      --detach
+      -i
+      -v $(pwd):/root/jss
+      registry.fedoraproject.org/fedora:28
+  - docker exec container dnf install -y dnf-plugins-core gcc make rpm-build
+  - docker exec container dnf builddep -y --spec /root/jss/jss.spec.in
+  - docker exec container /root/jss/build.sh --with-timestamp --with-commit-id rpm
+
+script:
+  - docker exec container rpm -Uvh /root/build/jss/RPMS/*


### PR DESCRIPTION
A Travis CI configuration has been added to build JSS and run a
basic installation test. Additional tests will be added later.

@mharmsen99, could you take a look at this patch? Thanks.