### PR TITLE
Fixed JSSKeyStoreSpi.engineLoad()

### DIFF
--- a/org/mozilla/jss/provider/java/security/JSSLoadStoreParameter.java
+++ b/org/mozilla/jss/provider/java/security/JSSLoadStoreParameter.java
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.jss.provider.java.security;
+
+import java.security.KeyStore.LoadStoreParameter;
+import java.security.KeyStore.ProtectionParameter;
+
+import org.mozilla.jss.crypto.CryptoToken;
+
+public class JSSLoadStoreParameter implements LoadStoreParameter {
+
+    CryptoToken token;
+
+    public JSSLoadStoreParameter(CryptoToken token) {
+        this.token = token;
+    }
+
+    @Override
+    public ProtectionParameter getProtectionParameter() {
+        return null;
+    }
+
+    public CryptoToken getToken() {
+        return token;
+    }
+}


### PR DESCRIPTION
The JSSKeyStoreSpi.engineLoad() has been modified to store the
token provided via JSSLoadStoreParameter in the keystore. The
token later will be used to execute various operations in the
keystore (i.e. retrieving certs and keys from the token).

https://pagure.io/jss/issue/10