### PR TITLE
PK11Store.importEncryptedPrivateKeyInfo: import public key

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11Store.c
+++ b/org/mozilla/jss/pkcs11/PK11Store.c
@@ -745,6 +745,10 @@ Java_org_mozilla_jss_pkcs11_PK11Store_importEncryptedPrivateKeyInfo(
         goto finish;
     }
 
+    // Attempt to store the public key in the token.
+    // Failure is non-fatal (some tokens cannot store the public key).
+    PK11_ImportPublicKey(slot, pubKey, PR_TRUE /* isToken (permanent) */);
+
 finish:
     if (epkiItem != NULL) {
         SECITEM_FreeItem(epkiItem, PR_TRUE /*freeit*/);


### PR DESCRIPTION
There is a regression in SQL NSSDB backend which causes certificates
to not be properly associated with the private keys (i.e. now
showing ultimate trust with 'u,u,u' in trust flags).

For example, after replica install the replica has an NSSDB that
looks like:

```
  # certutil -L -d /etc/pki/pki-tomcat/alias/

  Certificate Nickname                                         Trust
  Attributes
                                                               SSL,S/MIME,JAR/XPI

  caSigningCert cert-pki-ca                                    CT,C,C
  ocspSigningCert cert-pki-ca                                  ,,
  auditSigningCert cert-pki-ca                                 ,,P
  subsystemCert cert-pki-ca                                    ,,
  Server-Cert cert-pki-ca                                      u,u,u
```

pk12util does not exhibit this problem because of an explicit call
to PK11_ImportPublicKey. Therefore change the JSS key import method
to explicitly import the public key via the same.

Fixes: https://pagure.io/jss/issue/13
Related: https://pagure.io/freeipa/issue/7589
Related: https://pagure.io/freeipa/issue/7590

Change-Id: Icf24f6384ccf3905145c1954f57b47894dd94f0f