### PR TITLE
Import public key when unwrapping private key

### DIFF
--- a/lib/jss.def
+++ b/lib/jss.def
@@ -330,3 +330,9 @@ Java_org_mozilla_jss_pkcs11_PK11Store_importEncryptedPrivateKeyInfo;
 ;+    local:
 ;+       *;
 ;+};
+;+JSS_4.4.5 {     # JSS 4.4.5 release
+;+    global:
+Java_org_mozilla_jss_pkcs11_PK11Token_importPublicKey;
+;+    local:
+;+       *;
+;+};

--- a/org/mozilla/jss/pkcs11/PK11Token.java
+++ b/org/mozilla/jss/pkcs11/PK11Token.java
@@ -559,6 +559,11 @@ public final class PK11Token implements CryptoToken {
     protected TokenProxy tokenProxy;
 
     protected PK11Store cryptoStore;
+
+    public native void importPublicKey(
+        org.mozilla.jss.pkcs11.PK11PubKey pubKey,
+        boolean permanent)
+        throws TokenException;
 }
 
 /**


### PR DESCRIPTION
The NSS SQL backend, unlike the DBM backend that preceded it, does
not automatically create PKCS #11 public key objects when unwrapping
private keys.  When certificates are added, this can result in a
failure to properly associate the certificate with a private key in
the token.

When unwrapping a private key, if the given public key wraps an NSS
SECKEYPublicKey object, import the public key to the token as well.

Change-Id: I146952382d535ad71d9914f3a43d7df5c0a0f510
Related: https://pagure.io/jss/issue/13