### PR TITLE
Fixed package declarations

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,5 +3,8 @@
 	<classpathentry excluding="samples/" kind="src" path=""/>
 	<classpathentry kind="src" path="samples"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="/usr/share/java/commons-lang.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/commons-codec.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/ldapjdk.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org/mozilla/jss/netscape/security/acl/AclEntryImpl.java
+++ b/org/mozilla/jss/netscape/security/acl/AclEntryImpl.java
@@ -15,7 +15,7 @@
 // (C) 2007 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package netscape.security.acl;
+package org.mozilla.jss.netscape.security.acl;
 
 import java.security.Principal;
 import java.security.acl.AclEntry;

--- a/org/mozilla/jss/netscape/security/acl/AclImpl.java
+++ b/org/mozilla/jss/netscape/security/acl/AclImpl.java
@@ -15,7 +15,7 @@
 // (C) 2007 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package netscape.security.acl;
+package org.mozilla.jss.netscape.security.acl;
 
 import java.security.Principal;
 import java.security.acl.Acl;

--- a/org/mozilla/jss/netscape/security/acl/AllPermissionsImpl.java
+++ b/org/mozilla/jss/netscape/security/acl/AllPermissionsImpl.java
@@ -15,7 +15,7 @@
 // (C) 2007 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package netscape.security.acl;
+package org.mozilla.jss.netscape.security.acl;
 
 import java.security.acl.Permission;
 

--- a/org/mozilla/jss/netscape/security/acl/GroupImpl.java
+++ b/org/mozilla/jss/netscape/security/acl/GroupImpl.java
@@ -15,7 +15,7 @@
 // (C) 2007 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package netscape.security.acl;
+package org.mozilla.jss.netscape.security.acl;
 
 import java.security.Principal;
 import java.security.acl.Group;

--- a/org/mozilla/jss/netscape/security/acl/OwnerImpl.java
+++ b/org/mozilla/jss/netscape/security/acl/OwnerImpl.java
@@ -15,7 +15,7 @@
 // (C) 2007 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package netscape.security.acl;
+package org.mozilla.jss.netscape.security.acl;
 
 import java.security.Principal;
 import java.security.acl.Group;

--- a/org/mozilla/jss/netscape/security/acl/PermissionImpl.java
+++ b/org/mozilla/jss/netscape/security/acl/PermissionImpl.java
@@ -15,7 +15,7 @@
 // (C) 2007 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package netscape.security.acl;
+package org.mozilla.jss.netscape.security.acl;
 
 import java.security.acl.Permission;
 

--- a/org/mozilla/jss/netscape/security/acl/PrincipalImpl.java
+++ b/org/mozilla/jss/netscape/security/acl/PrincipalImpl.java
@@ -15,7 +15,7 @@
 // (C) 2007 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package netscape.security.acl;
+package org.mozilla.jss.netscape.security.acl;
 
 import java.security.Principal;
 

--- a/org/mozilla/jss/netscape/security/acl/WorldGroupImpl.java
+++ b/org/mozilla/jss/netscape/security/acl/WorldGroupImpl.java
@@ -15,7 +15,7 @@
 // (C) 2007 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package netscape.security.acl;
+package org.mozilla.jss.netscape.security.acl;
 
 import java.security.Principal;
 


### PR DESCRIPTION
Some classes in org/mozilla/jss/netscape/security/acl folder have
been modified to use the correct package.

The Eclipse .classpath has been fixed to remove some build errors.

https://bugzilla.redhat.com/show_bug.cgi?id=1560682