### PR TITLE
Updated JSSKeyStoreSpi.engineDeleteEntry()

### DIFF
--- a/lib/jss.def
+++ b/lib/jss.def
@@ -336,6 +336,7 @@ Java_org_mozilla_jss_pkcs11_PK11RSAPrivateKey_getModulusByteArray;
 Java_org_mozilla_jss_pkcs11_PK11Token_importPublicKey;
 Java_org_mozilla_jss_pkcs11_PK11Store_loadPrivateKeys;
 Java_org_mozilla_jss_pkcs11_PK11Store_loadPublicKeys;
+Java_org_mozilla_jss_pkcs11_PK11Store_deletePublicKey;
 ;+    local:
 ;+       *;
 ;+};

--- a/org/mozilla/jss/crypto/CryptoStore.java
+++ b/org/mozilla/jss/crypto/CryptoStore.java
@@ -96,6 +96,18 @@ public interface CryptoStore {
         throws NoSuchItemOnTokenException, TokenException;
 
     /**
+     * Permanently deletes a public key from the token.
+     *
+     * @param publicKey A public key to be permanently deleted.
+     * @exception NoSuchItemOnTokenException If the given public key does
+     *      not reside on this token.
+     * @exception TokenException If an error occurs on the token while
+     *      deleting the key.
+     */
+    public void deletePublicKey(PublicKey publicKey)
+            throws NoSuchItemOnTokenException, TokenException;
+
+    /**
      * Get an encrypted private key for the given cert.
      *
      * @param cert Certificate of key to be exported

--- a/org/mozilla/jss/crypto/CryptoStore.java
+++ b/org/mozilla/jss/crypto/CryptoStore.java
@@ -64,6 +64,17 @@ public interface CryptoStore {
     public PublicKey[] getPublicKeys() throws TokenException;
 
     /**
+     * Returns the public key corresponding to the private key.
+     *
+     * @param privateKey
+     * @return The corresponding public key.
+     * @throws ObjectNotFoundException If the corresponding public key is not found.
+     * @throws TokenException If an error occurs on the token.
+     */
+    public PublicKey findPublicKey(PrivateKey privateKey)
+            throws ObjectNotFoundException, TokenException;
+
+    /**
      * Returns all symmetric keys stored on this token.
      *
      * @return An array of all symmetric keys stored on this token.

--- a/org/mozilla/jss/pkcs11/PK11Store.c
+++ b/org/mozilla/jss/pkcs11/PK11Store.c
@@ -436,6 +436,47 @@ finish:
 }
 
 /**********************************************************************
+ * PK11Store.deletePublicKey
+ */
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_pkcs11_PK11Store_deletePublicKey
+    (JNIEnv *env, jobject this, jobject publicKeyObj)
+{
+    PK11SlotInfo *slot;
+    SECKEYPublicKey *publicKey;
+
+    PR_ASSERT(env != NULL && this != NULL);
+
+    if (publicKeyObj == NULL) {
+        JSS_throw(env, NO_SUCH_ITEM_ON_TOKEN_EXCEPTION);
+        goto finish;
+    }
+
+    if (JSS_PK11_getStoreSlotPtr(env, this, &slot) != PR_SUCCESS) {
+        PR_ASSERT((*env)->ExceptionOccurred(env) != NULL);
+        goto finish;
+    }
+
+    if (JSS_PK11_getPubKeyPtr(env, publicKeyObj, &publicKey) != PR_SUCCESS) {
+        PR_ASSERT((*env)->ExceptionOccurred(env) != NULL);
+        goto finish;
+    }
+
+    if (slot != publicKey->pkcs11Slot) {
+        JSS_throw(env, NO_SUCH_ITEM_ON_TOKEN_EXCEPTION);
+        goto finish;
+    }
+
+    if (PK11_DestroyTokenObject(publicKey->pkcs11Slot, publicKey->pkcs11ID) != SECSuccess) {
+        JSS_throwMsg(env, TOKEN_EXCEPTION, "Unable to remove public key");
+        goto finish;
+    }
+
+finish:
+    return;
+}
+
+/**********************************************************************
  * PK11Store.deleteCert
  *
  * This function deletes the specified certificate and its associated 

--- a/org/mozilla/jss/pkcs11/PK11Store.java
+++ b/org/mozilla/jss/pkcs11/PK11Store.java
@@ -135,6 +135,9 @@ public final class PK11Store implements CryptoStore {
     public native void deletePrivateKey(PrivateKey privateKey)
         throws NoSuchItemOnTokenException, TokenException;
 
+    public native void deletePublicKey(PublicKey publicKey)
+            throws NoSuchItemOnTokenException, TokenException;
+
     public byte[] getEncryptedPrivateKeyInfo(
             X509Certificate cert,
             PBEAlgorithm pbeAlg,


### PR DESCRIPTION
Updated JSSKeyStoreSpi.engineDeleteEntry()

The JSSKeyStoreSpi.engineDeleteEntry() has been modified such that:
* if the given alias is a cert nickname, it will delete the cert without deleting the public and private keys
* if the given alias is a key ID, it will delete the public and private keys without deleting the cert
