### PR TITLE
Deprecated bsd source and svid source warnings

### DIFF
--- a/coreconf/Linux.mk
+++ b/coreconf/Linux.mk
@@ -127,7 +127,7 @@ endif
 # Place -ansi and *_SOURCE before $(DSO_CFLAGS) so DSO_CFLAGS can override
 # -ansi on platforms like Android where the system headers are C99 and do
 # not build with -ansi.
-STANDARDS_CFLAGS	= -D_POSIX_SOURCE -D_BSD_SOURCE -D_XOPEN_SOURCE
+STANDARDS_CFLAGS	= -D_POSIX_SOURCE -D_DEFAULT_SOURCE -D_XOPEN_SOURCE
 OS_CFLAGS		= $(STANDARDS_CFLAGS) $(DSO_CFLAGS) $(OS_REL_CFLAGS) $(ARCHFLAG) -Wall -Werror-implicit-function-declaration -Wno-switch -pipe -DLINUX -Dlinux -DHAVE_STRERROR
 OS_LIBS			= $(OS_PTHREAD) -ldl -lc
 


### PR DESCRIPTION
This one line change gets rid of all those warnings.