### PR TITLE
Align jss with make standard targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,6 @@ include $(CORE_DEPTH)/coreconf/config.mk
 # built first
 all:: buildJava
 
-test_jss: testJava
-
 include $(CORE_DEPTH)/coreconf/rules.mk
 
 #######################################################################

--- a/rules.mk
+++ b/rules.mk
@@ -3,8 +3,14 @@
 .PHONY: releaseJava
 .PHONY: testJava
 
+distclean:: cleanJava
 clean:: cleanJava
+
+dist:: releaseJava
 release_classes:: releaseJava
+
+check:: testJava
+test_jss:: testJava
 
 # always do a private_export
 export:: private_export


### PR DESCRIPTION
A common pattern across projects is to use `make check` to execute
tests, `make dist` to build a release, and `make distclean` to
clean the tree after a release. This adds targets to `rules.mk`
which support these targets and moves a target from the `Makefile`
to `rules.mk`.

This help aligns the project with the GNU coding standards: https://www.gnu.org/prep/standards/html_node/Standard-Targets.html

Signed-off-by: Alexander Scheel <ascheel@redhat.com>