### PR TITLE
build_java.pl improvements

### DIFF
--- a/build_java.pl
+++ b/build_java.pl
@@ -474,26 +474,24 @@ sub test {
     our $nss_bin_dir;
     our $nss_lib_dir;
 
-    if( $os eq 'Linux' || $os eq 'Darwin' ) {
-        # Test JSS presuming that it has already been built
-
-        if(( -d $dist_dir )  &&
-           ( -d $jss_objdir || -l $jss_objdir )) {
-            my $cmd = "cd $jss_dir/org/mozilla/jss/tests;"
-                    . "perl all.pl dist \"$dist_dir\" \"$nss_bin_dir\" \"$nss_lib_dir\" \"$jss_lib_dir\";"
-                    . "cd $jss_dir";
-
-            print("#######################\n" .
-                  "# BEGIN:  Testing JSS #\n" .
-                  "#######################\n");
-            print_do($cmd);
-            print("#####################\n" .
-                  "# END:  Testing JSS #\n" .
-                  "#####################\n");
-        } else {
-            die "JSS builds are not available at $jss_objdir.";
-        }
-    } else {
+    if( $os ne 'Linux' && $os eq 'Darwin' ) {
         die "make test_jss is only available on Linux and MacOS platforms.";
     }
+
+    # Ensure that JSS is built prior to tests.
+    if (( ! -d $dist_dir )  && ( ! -d $jss_objdir && ! -l $jss_objdir )) {
+        die "JSS builds are not available at $jss_objdir.";
+    }
+
+    my $cmd = "cd $jss_dir/org/mozilla/jss/tests;"
+            . "perl all.pl dist \"$dist_dir\" \"$nss_bin_dir\" \"$nss_lib_dir\" \"$jss_lib_dir\";"
+            . "cd $jss_dir";
+
+    print("#######################\n" .
+          "# BEGIN:  Testing JSS #\n" .
+          "#######################\n");
+    print_do($cmd);
+    print("#####################\n" .
+          "# END:  Testing JSS #\n" .
+          "#####################\n");
 }

--- a/build_java.pl
+++ b/build_java.pl
@@ -288,15 +288,11 @@ sub build {
     chop($jss_revision);
     $jss_revision      = substr($jss_revision, 22, 3);
     my $build_revision = $jss_revision;
-    my $append = 0;
 
     ensure_dir_exists($dist_dir);
 
-    if ($append) {
-        open(MYOUTFILE, ">>$manifest_file"); #open for write, append
-    } else {
-        open(MYOUTFILE, ">$manifest_file");  #open for write, overwrite
-    }
+    # Always overwrite the manifest file.
+    open(MYOUTFILE, ">$manifest_file");
 
     #*** Print freeform text, semicolon required ***
 print MYOUTFILE <<"MyLabel";

--- a/tools/test_perl_style.sh
+++ b/tools/test_perl_style.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+#
+# Usage:
+# test_perl_style.sh [path]
+#
+# Tests the style of Perl scripts in the build tree for compliance with strict
+# guidance. Runs:
+#
+#     perl -Mstrict -Mdiagnostics -cw <file>
+#
+# On all checked files. If [path] is specified, assumed to be the root of the
+# jss repository. Otherwise, defaults to `pwd`.
+#
+
+root_source_dir="$1"
+if [ "x$root_source_dir" = "x" ]; then
+    root_source_dir="$(pwd)"
+fi
+
+perl_check() {
+    target_file="$1"
+
+    perl -Mstrict -Mdiagnostics -cw "$root_source_dir/$target_file"
+}
+
+
+perl_check "build_java.pl"


### PR DESCRIPTION
A few improvements to the `build_java.pl` script: 

 - Linting it with Perl `-Mstrict` flag
    - New tool introduced in `tools/check_perl_style.sh` to validate this.
 - Remove the unnecessary `eval` just to call a function inside the script.
 - Removed the logic around appending to manifest.
 - Simplified the logic around the test suite to avoid nested `if` statements.

(The `B::Lint` module was giving what I believe to be a false positive and wouldn't install cleanly from `cpan` so I decided against it). 

The second change introduces a hash to map `name->subroutine`; this would need to be kept in sync if more commands are introduced, but I don't think this is likely. Secondly, it drops passing `ARGV` into the function. This would be easy to add, but I don't believe any of the functions use this behavior. 