### PR TITLE
Add documentation about JSS

### DIFF
--- a/docs/build_system.md
+++ b/docs/build_system.md
@@ -1,0 +1,72 @@
+# Build System
+
+There are three interfaces to the build system:
+
+ - `build_java.pl`
+ - `build.sh`
+ - `Makefile`
+
+Each of these are described in further detail below.
+
+
+## `build_java.pl`
+
+This is the primary script that drive the build system. It contains all logic
+for compiling the Java files and producing the output artifacts. It supports
+five primary operations:
+
+ - `clean` -- removes build artifacts from the directory, including `dist`
+   directory.
+ - `build` -- builds JSS by finding java files, compiling them, and creating
+    JNI headers
+ - `release` -- creates a release with all classes in one location.
+ - `javadoc` -- build documentation from the in-source javadocs
+   This creates an HTML version in `sandbox/dist/jssdoc`.
+ - `test` -- runs the JSS test suite. Note that the NSS and NSPR
+   test suites are run as part of their build processes.
+
+The build is affected by several environment variables:
+
+ - `JAVA_HOME` -- required to point to the path to the JDK installation
+   that they are building against.
+ - `USE_64` -- whether or not to build a 64-bit distribution. Note that
+   this is required to be set to true on 64-bit systems (i.e., you cannot
+   build JSS for `i386/i686` on `x86_64`.
+ - `BUILD_OPT` -- whether or not to build optimized binaries (`-O` as a
+   compiler flag; by default (if not present or false), binaries are
+   built with debug flags (`-g`).
+ - `DEBIAN_BUILD` -- whether or not to use Debian dependency locations.
+ - `CHECK_DEPRECATION` -- if set, checks for use of deprecated objects
+   during the Java build.
+ - `USE_INSTALLED_NSPR` -- if set, use the system NSPR instead of the
+   version in the sandbox.
+ - `USE_INSTALLED_NSS` -- if set, use the system NSS instead of the version
+   in the sandbox.
+ - `NSS_LIB_DIR` -- location to NSS libraries; required if `USE_INSTALLED_NSS`
+   is set.
+ - `HTML_HEADER` -- HTML header for use with `javadoc` target; passed by
+   `-header HTML_HEADER` to `javadoc` command.
+
+
+## `build.sh`
+
+This script uses the rpmbuild to transform the in-source spec file into an
+RPM which triggers the build and test processes. The result is a set of RPMs
+which mirror the current state of the source tree. Using this interface adds
+an additional dependency on `rpmbuild`; it is also suggested to install
+all dependencies via `dnf build-dep --spec jss.spec`.
+
+
+## `make`
+
+Using `make `from the root of the source tree provides a wrapper over the
+`build_java.pl` interface. This is used by the spec file to build JSS and
+exposes several targets similar to `build_java.pl`:
+
+ - `all` (default target) -- build jss and rebuild dependencies if not
+   present.
+ - `clean` -- remove
+ - `check` or `test_jss` -- run jss test suite on built objects; note that
+   jss must be built prior to running the test suite.
+ - `dist` or `release_classes` -- build jss for release.
+ - `javadoc` -- build java documentation.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,25 @@
+# Containers and Continuous Integration
+
+JSS uses [Travis CI](https://travis-ci.org/dogtagpki/jss) for PR gating. We use
+Linux containers to ensure a consistent build environment and to allow us
+to test locally and in Travis on various platforms.
+
+The Docker images are built in Travis using the Dockerfiles in
+`tools/Dockerfiles`; they are not pushed to DockerHub or similar platforms
+at this time. To test locally, we recommend using `buildah` and `podman`.
+For a brief example:
+
+```bash
+cd /path/to/sandbox/jss
+export BASE_IMAGE=fedora_28
+buildah bud --tag jss_$BASE_IMAGE:latest -f tools/Dockerfiles/$BASE_IMAGE . 
+podman run jss_$BASE_IMAGE:latest
+```
+
+For more extensive documentation, please refer to the
+[Buildah](https://github.com/containers/buildah/blob/master/docs/) and
+[Podman docs](https://github.com/containers/libpod/tree/master/docs).
+
+To skip running CI for a given commit (e.g., for updating documentation),
+append `[skip ci]` to the commit summary. Note that the `ubuntu_jdk8` image
+does not affect build status; it is included for reference only.

--- a/docs/gh_pages.md
+++ b/docs/gh_pages.md
@@ -1,0 +1,34 @@
+# GitHub Pages
+
+JSS uses the GitHub pages functionality to host our generated javadocs. This
+allows developers to browse our documentation online without pulling down
+the JSS sources.
+
+Periodically, this documentation will need to be updated and will mirror the
+latest contents of master. To do so:
+
+ 1. Checkout the master branch and make sure it is up to date with `upstream`:
+    ```
+    cd sandbox/jss
+    git remote add upstream https://github.com/dogtagpki/jss
+    git fetch --all
+    git checkout upstream/master
+    ```
+
+ 2. Build the javadocs; note that they are placed in `../dist/jssdocs`:
+    ```
+    export JAVA_HOME=/etc/alternatives/java_sdk_1.8.0_openjdk
+    export USE_64=1
+    make javadoc
+    ```
+
+ 3. Copy the new-docs into the gh-pages branch:
+    ```
+    git clean -xdf && git checkout gh-pages
+    rm -rf javadoc && cp ../dist/jssdoc javadoc -rv
+    git add javadoc && git commit -m "Update javadocs from master at $(date '+%Y-%m-%d %H:%M')" && git push origin gh-pages
+    ```
+
+ 4. Open a PR against `dogtagpki/jss` with the updates. This will
+    get reviewed, merged, and then automatically propagated to
+    GitHub Pages.

--- a/docs/using_jss.md
+++ b/docs/using_jss.md
@@ -1,0 +1,13 @@
+# Using JSS
+
+To use JSS in your project after installation, you'll need to ensure the
+following dependencies are available in your `CLASSPATH`:
+
+ - `jss4.jar` -- provided by the `jss` package and installed to
+   `/usr/lib/java/jss4.jar`.
+ - `slf4j-api.jar` -- provided by the `slf4j` package and installed to
+   `/usr/share/java/slf4j/slf4j-api.jar`.
+ - `apache-commons-lang.jar` -- provided by the `apache-commons-lang` package
+   and installed to `/usr/share/java/apache-commons-lang.jar`.
+ - `apache-commons-codec.jar` -- provided by the `apache-commons-codec`
+   package and installed to `/usr/share/java/apache-commons-codec.jar`.


### PR DESCRIPTION
This is the initial step in improving documentation about JSS. In particular, this PR documents two aspects:

 - The build system and the various parts of it. It will be expanded as more information is acquired.
 - Using JSS in an external project. This documents the CLASSPATH dependencies of JSS.

The latter is important as [389-console](https://pagure.io/389-console) appears to be using JSS [without including `slf4j-api.jar` in the classpath](https://pagure.io/389-console/blob/master/f/build.xml#_39).