### PR TITLE
Fix docstring for org.mozilla.jss.pkix.cms.SignedData

### DIFF
--- a/org/mozilla/jss/pkix/cms/SignedData.java
+++ b/org/mozilla/jss/pkix/cms/SignedData.java
@@ -20,7 +20,7 @@ import org.mozilla.jss.pkix.cert.Certificate;
 */
 
 /**
- * A CMS <i>SignedData</i> structure. 
+ * A CMS <i>SignedData</i> structure.
  * <p>The certificates field should only contain X.509 certificates.
  * PKCS #6 extended certificates will fail to decode properly.
  * @author stevep
@@ -164,7 +164,7 @@ public class SignedData implements ASN1Value {
 
     /**
      * Returns the signerInfos field, which is a SET of
-     *  org.mozilla.jss.pkcs7.SignerInfo.
+     *  org.mozilla.jss.pkix.cms.SignerInfo.
      */
     public SET getSignerInfos() {
         return signerInfos;
@@ -372,7 +372,7 @@ public class SignedData implements ASN1Value {
             return TAG.equals(tag);
         }
 
-        public ASN1Value decode(InputStream istream) 
+        public ASN1Value decode(InputStream istream)
             throws IOException, InvalidBERException
             {
                 return decode(TAG, istream);


### PR DESCRIPTION
Note that the patch in mbz#384470 is incorrect as the type is:

	org.mozilla.jss.pkix.cms.SignerInfo

and not:

	org.mozilla.jss.cms.SignerInfo

rhbz: 1534765
url: https://bugzilla.redhat.com/show_bug.cgi?id=1534765
mbz: 384470
url: https://bugzilla.mozilla.org/show_bug.cgi?id=384470

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`