### PR TITLE
Add -notimestamp option to javadoc creation

### DIFF
--- a/build_java.pl
+++ b/build_java.pl
@@ -454,7 +454,7 @@ sub javadoc {
     ensure_dir_exists("$dist_dir/jssdoc");
     my $targets = join(" ", @packages);
     print "$targets\n";
-    print_do("$javadoc -breakiterator $classpath -sourcepath . -d $dist_dir/jssdoc $html_header_opt $targets");
+    print_do("$javadoc -notimestamp -breakiterator $classpath -sourcepath . -d $dist_dir/jssdoc $html_header_opt $targets");
     print_do("cp $dist_dir/jssdoc/index.html $dist_dir/jssdoc/index.html.bak");
     print_do("cp $dist_dir/jssdoc/overview-summary.html $dist_dir/jssdoc/index.html");
 }


### PR DESCRIPTION
This prevents reproducible builds for the `jss-javadoc` sub-package; in particular, any compilation at a slightly different time will produce javadocs which differ in contents by a hidden comment. This is undesirable and thus should be prevented with the `-notimestamp` feature. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`