### PR TITLE
lib/Common.pm - Common library for build_java.pl and tests/all.pl

### DIFF
--- a/build_java.pl
+++ b/build_java.pl
@@ -14,48 +14,48 @@ samples/
 );
 
 my @javah_classes = qw(
-org.mozilla.jss.DatabaseCloser        
-org.mozilla.jss.CryptoManager          
-org.mozilla.jss.crypto.Algorithm        
-org.mozilla.jss.crypto.EncryptionAlgorithm      
-org.mozilla.jss.crypto.PQGParams     
+org.mozilla.jss.DatabaseCloser
+org.mozilla.jss.CryptoManager
+org.mozilla.jss.crypto.Algorithm
+org.mozilla.jss.crypto.EncryptionAlgorithm
+org.mozilla.jss.crypto.PQGParams
 org.mozilla.jss.crypto.SecretDecoderRing
 org.mozilla.jss.asn1.ASN1Util
-org.mozilla.jss.pkcs11.CertProxy        
-org.mozilla.jss.pkcs11.CipherContextProxy 
-org.mozilla.jss.pkcs11.PK11Module 
-org.mozilla.jss.pkcs11.ModuleProxy 
-org.mozilla.jss.pkcs11.PK11Cert     
-org.mozilla.jss.pkcs11.PK11Cipher     
-org.mozilla.jss.pkcs11.PK11KeyWrapper  
-org.mozilla.jss.pkcs11.PK11MessageDigest 
-org.mozilla.jss.pkcs11.PK11PrivKey   
-org.mozilla.jss.pkcs11.PK11PubKey     
-org.mozilla.jss.pkcs11.PK11SymKey      
-org.mozilla.jss.pkcs11.PK11KeyPairGenerator 
+org.mozilla.jss.pkcs11.CertProxy
+org.mozilla.jss.pkcs11.CipherContextProxy
+org.mozilla.jss.pkcs11.PK11Module
+org.mozilla.jss.pkcs11.ModuleProxy
+org.mozilla.jss.pkcs11.PK11Cert
+org.mozilla.jss.pkcs11.PK11Cipher
+org.mozilla.jss.pkcs11.PK11KeyWrapper
+org.mozilla.jss.pkcs11.PK11MessageDigest
+org.mozilla.jss.pkcs11.PK11PrivKey
+org.mozilla.jss.pkcs11.PK11PubKey
+org.mozilla.jss.pkcs11.PK11SymKey
+org.mozilla.jss.pkcs11.PK11KeyPairGenerator
 org.mozilla.jss.pkcs11.PK11SymmetricKeyDeriver
 org.mozilla.jss.pkcs11.PK11KeyGenerator
 org.mozilla.jss.pkcs11.PK11Token
-org.mozilla.jss.pkcs11.PrivateKeyProxy  
-org.mozilla.jss.pkcs11.PublicKeyProxy    
+org.mozilla.jss.pkcs11.PrivateKeyProxy
+org.mozilla.jss.pkcs11.PublicKeyProxy
 org.mozilla.jss.pkcs11.SymKeyProxy
-org.mozilla.jss.pkcs11.KeyProxy    
-org.mozilla.jss.pkcs11.PK11Token    
-org.mozilla.jss.pkcs11.TokenProxy    
-org.mozilla.jss.pkcs11.PK11Signature  
-org.mozilla.jss.pkcs11.PK11Store       
-org.mozilla.jss.pkcs11.PK11KeyPairGenerator 
+org.mozilla.jss.pkcs11.KeyProxy
+org.mozilla.jss.pkcs11.PK11Token
+org.mozilla.jss.pkcs11.TokenProxy
+org.mozilla.jss.pkcs11.PK11Signature
+org.mozilla.jss.pkcs11.PK11Store
+org.mozilla.jss.pkcs11.PK11KeyPairGenerator
 org.mozilla.jss.pkcs11.SigContextProxy
 org.mozilla.jss.pkcs11.PK11RSAPublicKey
 org.mozilla.jss.pkcs11.PK11DSAPublicKey
 org.mozilla.jss.pkcs11.PK11ECPublicKey
-org.mozilla.jss.pkcs11.PK11SecureRandom 
+org.mozilla.jss.pkcs11.PK11SecureRandom
 org.mozilla.jss.provider.java.security.JSSKeyStoreSpi
 org.mozilla.jss.SecretDecoderRing.KeyManager
-org.mozilla.jss.ssl.SSLSocket 
-org.mozilla.jss.ssl.SSLServerSocket 
-org.mozilla.jss.ssl.SocketBase 
-org.mozilla.jss.util.Password       
+org.mozilla.jss.ssl.SSLSocket
+org.mozilla.jss.ssl.SSLServerSocket
+org.mozilla.jss.ssl.SocketBase
+org.mozilla.jss.util.Password
 );
 
 my @packages = qw(
@@ -219,10 +219,10 @@ sub setup_vars {
                          . "    hg clone https://hg.mozilla.org/projects/nss\n"
                          . "    hg clone https://hg.mozilla.org/projects/jss\n"
                          . "    cd ..\n\n";
-            
+
             die "$workarea";
         }
-        
+
         # Build NSS if not already built
         my $nss_latest_objdir = "$dist_dir/latest";
 
@@ -297,7 +297,7 @@ sub build {
     #*** Print freeform text, semicolon required ***
 print MYOUTFILE <<"MyLabel";
 Manifest-Version: 1.0
-    
+
 Name: org/mozilla/jss/
 Specification-Title: Network Security Services for Java (JSS)
 Specification-Version: $jss_revision
@@ -316,7 +316,7 @@ MyLabel
     my %source_list;
     find sub {
         my $name = $File::Find::name;
-        if( $name =~ /\.java$/) { 
+        if( $name =~ /\.java$/) {
             $source_list{$File::Find::name} = 1;
         }
     }, ".";

--- a/lib/Common.pm
+++ b/lib/Common.pm
@@ -1,0 +1,33 @@
+package Common;
+
+use strict;
+use warnings;
+
+use Exporter qw(import);
+
+# The below methods are used by build_java.pl and tests/all.pl; if the
+# location of Common.pm ever changes, update the includes in those files
+# to point to the new location.
+our @EXPORT_OK = qw(get_jar_files);
+
+sub get_jar_files {
+    # Return a list of JAR files of the dependencies of JSS; in particular,
+    # handle Debian vs OpenSUSE vs Fedora builds and the locations of relevant
+    # jars on those platforms.
+    our $jarFiles = "";
+
+    if( $ENV{DEBIAN_BUILD} ) {
+        $jarFiles = "/usr/share/java/slf4j-api.jar:/usr/share/java/commons-codec.jar:/usr/share/java/jaxb-api.jar";
+        $jarFiles = "$jarFiles:/usr/share/java/commons-lang.jar"
+    } elsif( $ENV{OPENSUSE_BUILD} ) {
+        $jarFiles = "/usr/share/java/slf4j/api.jar:/usr/share/java/apache-commons-codec.jar:/usr/share/java/apache-commons-lang.jar";
+        $jarFiles = "$jarFiles:/usr/share/java/jaxb-api.jar:/usr/share/java/apache-commons-lang.jar"
+        # If some distro doesn't match the cases that we have identified
+        # then add another elfsif section to handle it.
+    } else {
+        $jarFiles = "/usr/share/java/slf4j/api.jar:/usr/share/java/commons-codec.jar:/usr/share/java/jaxb-api.jar";
+        $jarFiles = "$jarFiles:/usr/share/java/commons-lang.jar";
+    }
+
+    return $jarFiles;
+}

--- a/org/mozilla/jss/crypto/Algorithm.c
+++ b/org/mozilla/jss/crypto/Algorithm.c
@@ -13,7 +13,6 @@
 
 #include <jssutil.h>
 
-#include "_jni/org_mozilla_jss_crypto_Algorithm.h"
 #include "Algorithm.h"
 
 static PRStatus

--- a/org/mozilla/jss/tests/all.pl
+++ b/org/mozilla/jss/tests/all.pl
@@ -3,12 +3,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use strict;
+use warnings;
+
 use Socket;
 use File::Basename;
-use Cwd;
-use Cwd 'abs_path';
+use Cwd qw(abs_path);
 use POSIX 'uname';
 
+# change the line below if we reorganize the code; must
+# point to the location with Common.pm
+use lib dirname(dirname abs_path $0) . '/../../../lib';
+
+use Common qw(get_jar_files);
 
 # dist <dist_dir> <NSS bin dir> <NSS lib dir> <JSS lib dir>
 # release <java release dir> <nss release dir> <nspr release dir>
@@ -207,7 +214,7 @@ sub setup_vars {
     if ($osname =~ /Darwin/) {
         $java = "$ENV{JAVA_HOME}/bin/java";
     } else {
-        $java = "$ENV{JAVA_HOME}/jre/bin/java$exe_suffix";
+        $java = "$ENV{JAVA_HOME}/bin/java$exe_suffix";
     }
 
     #
@@ -232,10 +239,6 @@ sub setup_vars {
 
     (-f $java) or die "'$java' does not exist\n";
     $java = $java . $ENV{NATIVE_FLAG};
-
-    if ($ENV{USE_64} && !$java_64bit) {
-        $java = $java . " -d64";
-    }
 
     #MAC OS X have the -Djava.library.path for the JSS JNI library
     if ($osname =~ /Darwin/ || $osname =~ /Linux/) {
@@ -455,14 +458,9 @@ createpkcs11_cfg;
 
 my $serverCommand;
 
-$jarFiles = "";
-
-if( $ENV{DEBIAN_BUILD} ) {
-    $jarFiles = "/usr/share/java/slf4j-api.jar:/usr/share/java/slf4j-jdk14.jar:/usr/share/java/commons-lang.jar";
-} else {
-    $jarFiles = "/usr/share/java/slf4j/slf4j-api.jar:/usr/share/java/slf4j/slf4j-jdk14.jar:/usr/share/java/commons-lang.jar";
-}
-
+$jarFiles = Common::get_jar_files;
+$jarFiles = "$jarFiles:/usr/share/java/slf4j/jdk14.jar";
+# Note: jdk14.jar required for testing though not for building
 my $classpath = "$jarFiles:$jss_classpath";
 
 my $pk12util = "pk12util$exe_suffix";

--- a/org/mozilla/jss/tests/all.pl
+++ b/org/mozilla/jss/tests/all.pl
@@ -9,7 +9,7 @@ use Cwd;
 use Cwd 'abs_path';
 use POSIX 'uname';
 
-                                                                                                  
+
 # dist <dist_dir> <NSS bin dir> <NSS lib dir> <JSS lib dir>
 # release <java release dir> <nss release dir> <nspr release dir>
 # auto   (test the current build directory)
@@ -55,15 +55,15 @@ my $release        = "";
 ($osname,$host,$release)    = uname;
 
 # checkPort will return a free Port number
-# otherwise it will die after trying 10 times. 
+# otherwise it will die after trying 10 times.
 sub checkPort {
-   my ($p) = @_; 
+   my ($p) = @_;
    my $localhost = inet_aton("localhost");
    my $max = $p + 20; # try to find a port 10 times
    my $port = sockaddr_in($p, $localhost);
 
-   #create a socket 
-   socket(SOCKET, PF_INET, SOCK_STREAM, getprotobyname('tcp')) 
+   #create a socket
+   socket(SOCKET, PF_INET, SOCK_STREAM, getprotobyname('tcp'))
    || die "Unable to create socket: $!\n";
 
    #loop until you find a free port
@@ -73,7 +73,7 @@ sub checkPort {
          $port = sockaddr_in($p, $localhost);
    }
    close SOCKET || die "Unable to close socket: $!\n";
-   if ($p == $max) { 
+   if ($p == $max) {
       die "Unable to find a free port..\n";
    }
 
@@ -101,7 +101,7 @@ sub setup_vars {
     } elsif( $osname =~ /Darwin/) {
         $ld_lib_path = "DYLD_LIBRARY_PATH";
         $lib_suffix = ".jnilib";
-    } elsif( $osname =~ /mingw/i ) { 
+    } elsif( $osname =~ /mingw/i ) {
     	print "We are mingw\n";
         $ld_lib_path = "PATH";
         $truncate_lib_path = 0;
@@ -111,7 +111,7 @@ sub setup_vars {
         $lib_jss    = "jss";
         $scriptext = "sh";
         $run_shell = "sh.exe";
-    } elsif( $osname =~ /win/i ) { 
+    } elsif( $osname =~ /win/i ) {
         $ld_lib_path = "PATH";
         $truncate_lib_path = 0;
         $pathsep = ";";
@@ -195,7 +195,7 @@ sub setup_vars {
        $serverPort = $ENV{PORT_JSSE_SERVER};
     }
 
-    if ($ENV{PORT_JSS_SERVER}) { 
+    if ($ENV{PORT_JSS_SERVER}) {
        $serverPort = $ENV{PORT_JSS_SERVER};
     }
 
@@ -240,7 +240,7 @@ sub setup_vars {
     #MAC OS X have the -Djava.library.path for the JSS JNI library
     if ($osname =~ /Darwin/ || $osname =~ /Linux/) {
         $java = $java . " -Djava.library.path=$jss_lib_dir";
-    } 
+    }
 
     $pwfile = "passwords";
 
@@ -281,9 +281,9 @@ sub setup_vars {
     # Finally, set $testdir
     $testdir = $result_dir . "/" . $host . "." . $version;
 
-    #in case multiple tests are being run on the same machine increase  
+    #in case multiple tests are being run on the same machine increase
     #the port numbers with version number * 10
-    
+
     $serverPort = $serverPort + ($version * 10);
 
     outputEnv();
@@ -322,7 +322,7 @@ sub outputEnv {
    print "testdir=$testdir\n";
    print "serverPort=$serverPort\n";
    print "LIB_SUFFIX=$lib_suffix\n";
-   print "osname=$osname\n";  
+   print "osname=$osname\n";
    print "release=$release\n";
    print "which perl=";
    system ("which perl");
@@ -331,17 +331,17 @@ sub outputEnv {
 }
 
 sub createpkcs11_cfg {
-   
+
     $configfile = $testdir . "/" . "nsspkcs11.cfg";
     $keystore = $testdir . "/" . "keystore";
     if ( -f $configfile ) {
         print "configfile all ready exists";
        return;
-    } 
- 
+    }
+
     my $nsslibdir = $nss_lib_dir;
     my $tdir = $testdir;
-    
+
     #On windows make sure the path starts with c:
     if ($osname =~ /_NT/i) {
        substr($nsslibdir, 0, 2) = 'c:';
@@ -361,7 +361,7 @@ sub createpkcs11_cfg {
        print CONFIG "nssModule=keystore\n";
        close (CONFIG);
 
-    } else { # default 
+    } else { # default
 
        # java 5
        #http://java.sun.com/j2se/1.5.0/docs/guide/security/p11guide.html
@@ -393,7 +393,7 @@ sub run_ssl_test {
         print "launching server FAILED with return value $result\n";
         return;
     }
-    sleep 5;                                    
+    sleep 5;
     print "\nSSL Server is invoked using port $serverPort \n" ;
     print "$clientCommand \n";
     $result = system("$clientCommand");
@@ -442,7 +442,7 @@ if( ! -d $testdir ) {
     mkdir( $testdir, 0755 ) or die;
 }
 {
-    my @dbfiles = 
+    my @dbfiles =
         ("$testdir/cert8.db", "$testdir/key3.db", "$testdir/secmod.db", "$testdir/rsa.pfx");
     (grep{ -f } @dbfiles)  and die "There is already an old database in $testdir";
     my $result = system("cp $nss_lib_dir/*nssckbi* $testdir");
@@ -614,7 +614,7 @@ $command = "$java -cp $classpath org.mozilla.jss.tests.JSS_SelfServClient 2 -1 $
 if ($java =~ /1.4/i || $osname =~ /HP/ || ( ($osname =~ /Linux/)  && $java =~ /1.5/i && ($ENV{USE_64}) )) {
     print "don't run the SunJSSE with Mozilla-JSS provider with Java4 need java5 or higher";
     print "don't run the JSSE Server tests on HP or Linux  64 bit with java5.\n";
-    print "Java 5 on HP does not have SunPKCS11 class\n"; 
+    print "Java 5 on HP does not have SunPKCS11 class\n";
 } else {
 #with JSS is being build with JDK 1.5 add the Sunpkcs11-NSS support back in!
 #$serverPort = checkPort($serverPort);

--- a/org/mozilla/jss/util/jssutil.c
+++ b/org/mozilla/jss/util/jssutil.c
@@ -12,7 +12,6 @@
 #include "jss_exceptions.h"
 #include "java_ids.h"
 
-#include "_jni/org_mozilla_jss_util_Password.h"
 
 /***********************************************************************
 **


### PR DESCRIPTION
This PR contains work by @emaldona that he has agreed to let me separate out from his JDK11-related work.

This introduces a `lib/Common.pm` Perl module for use by both `build_java.pl` and `tests/all.pl`, along with various small refactoring. This removes the call to `javah`, which has been removed in JDK9+, and replaces it to a single call to `javac` with the `-h` flag.

I'll be reviewing and cleaning up these two commits in this PR.