### PR TITLE
JDK9+ support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,11 @@ services:
 stages:
   - validate
   - test
+  - extra
 
 env:
   - BASE_IMAGE="fedora_27"
   - BASE_IMAGE="fedora_28"
-  - BASE_IMAGE="ubuntu_jdk8"
-  - BASE_IMAGE="pkcs11check"
 
 script:
   - bash tools/run_container.sh "$BASE_IMAGE"
@@ -26,7 +25,16 @@ matrix:
   include:
     - stage: validate
       env: BASE_IMAGE="stylecheck"
+    - stage: extra
+      env: BASE_IMAGE="pkcs11check"
+    - stage: extra
+      env: BASE_IMAGE="debian_jdk11"
+    - stage: extra
+      env: BASE_IMAGE="ubuntu_jdk8"
   allow_failures:
-    - env: BASE_IMAGE="pkcs11check"
-    - env: BASE_IMAGE="ubuntu_jdk8"
-
+    - stage: extra
+      env: BASE_IMAGE="pkcs11check"
+    - stage: extra
+      env: BASE_IMAGE="debian_jdk11"
+    - stage: extra
+      env: BASE_IMAGE="ubuntu_jdk8"

--- a/org/mozilla/jss/tests/SymKeyDeriving.java
+++ b/org/mozilla/jss/tests/SymKeyDeriving.java
@@ -40,7 +40,7 @@ import org.mozilla.jss.crypto.*;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.InitializationValues;
 
-import sun.security.pkcs11.wrapper.PKCS11Constants;
+import org.mozilla.jss.pkcs11.PKCS11Constants;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Enumeration;

--- a/tools/Dockerfiles/debian_jdk11
+++ b/tools/Dockerfiles/debian_jdk11
@@ -1,0 +1,28 @@
+FROM debian:testing
+
+# Install generic dependencies to build jss
+RUN true \
+        && apt-get update \
+        && apt-get dist-upgrade -y \
+        && apt-get install -y debhelper libnss3-dev openjdk-11-jdk pkg-config \
+                              quilt g++ mercurial zlib1g-dev libslf4j-java \
+                              liblog4j2-java libcommons-lang-java libjaxb-api-java \
+                              libnss3-tools \
+        && mkdir -p /home/sandbox \
+        && apt-get autoremove -y \
+        && apt-get clean -y \
+        && apt-get autoclean -y \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Perform the actual build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && . tools/autoenv.sh \
+        && make clean all check \
+        && true


### PR DESCRIPTION
#### Dependencies

- #41: PKCS11Constants -- Those commits are duplicated here for CI / testing efforts. When that is merged, this PR can be rebased.
- #48: Perl improvements -- Those commits are duplicated here for CI / testing efforts. When that is merged, this PR can be rebased. 


#### Description

This PR introduces two new commits:

1. Switching to the new PKCS11 Constants interface exposed in #41.
2. Add a Debian Testing / JDK11 test to the Travis matrix + rework the Travis matrix.

The second commit adds a Dockerfile for `debian_jdk11` which installs the necessary dependencies and runs the test against JDK11. Reworking the Travis matrix at the same time to allow easy view of what's required and what isn't:

![screenshot from 2018-10-17 13-27-55](https://user-images.githubusercontent.com/914030/47104938-9a9b9f80-d210-11e8-9f7c-82ebe1bfe6bd.png)

I've opted to make `debian_jdk11` optional as it _is_ Debian Testing and might be unstable. Also, Debian is the only distribution thus far to ship a real JDK11; `rawhide` only supports JDK 10, but ships it as 11. 
