### PR TITLE
Various Perl improvements

### DIFF
--- a/build_java.pl
+++ b/build_java.pl
@@ -249,10 +249,11 @@ sub setup_vars {
                     . "cd $jss_dir";
             print_do($cmd);
         }
-    }
 
-    print "nss_bin_dir=$nss_bin_dir\n";
+        print "nss_bin_dir=$nss_bin_dir\n";
+    }
     print "nss_lib_dir=$nss_lib_dir\n";
+
 
     our $jss_lib_dir = "$jss_objdir/lib";
     print "jss_lib_dir=$jss_lib_dir\n";

--- a/build_java.pl
+++ b/build_java.pl
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use warnings FATAL => 'all';
 
 use Cwd qw(abs_path cwd);
 use File::Find;
@@ -196,8 +197,8 @@ sub setup_vars {
     print "jss_objdir=$jss_objdir\n";
 
     my $jss_objdir_name;
-    our $nss_bin_dir;
-    our $nss_lib_dir;
+    our $nss_bin_dir = "";
+    our $nss_lib_dir = "";
     if( ( $ENV{USE_INSTALLED_NSPR} ) && ( $ENV{USE_INSTALLED_NSS} ) ) {
         print "Using the NSPR and NSS installed on the system to build JSS.\n";
 
@@ -446,8 +447,8 @@ sub javadoc {
     our $javadoc;
     our $classpath;
 
-    my $html_header_opt;
-    if( $ENV{HTML_HEADER} ) {
+    my $html_header_opt = "";
+    if( defined $ENV{HTML_HEADER} && $ENV{HTML_HEADER} ) {
         $html_header_opt = "-header '$ENV{HTML_HEADER}'";
     }
 
@@ -477,6 +478,10 @@ sub test {
     # Ensure that JSS is built prior to tests.
     if (( ! -d $dist_dir )  && ( ! -d $jss_objdir && ! -l $jss_objdir )) {
         die "JSS builds are not available at $jss_objdir.";
+    }
+
+    if (!defined $nss_bin_dir) {
+        $nss_bin_dir = "";
     }
 
     my $cmd = "cd $jss_dir/org/mozilla/jss/tests; "

--- a/lib/Common.pm
+++ b/lib/Common.pm
@@ -2,32 +2,50 @@ package Common;
 
 use strict;
 use warnings;
+use warnings FATAL => 'all';
 
 use Exporter qw(import);
 
 # The below methods are used by build_java.pl and tests/all.pl; if the
 # location of Common.pm ever changes, update the includes in those files
 # to point to the new location.
-our @EXPORT_OK = qw(get_jar_files);
+our @EXPORT_OK = qw(get_jar_files detect_jar_file);
+
+sub detect_jar_file {
+    # Detect the correct path to a jar file.
+    # Die if the jar is missing.
+
+    my @locations = qw(/usr/share/java /usr/lib/java);
+    for my $location (@locations) {
+        for my $candidate (@_) {
+            my $path="$location/$candidate";
+            if (-e $path) {
+                return $path;
+            }
+        }
+    }
+
+    die "Can't find any jars for $_[1]";
+}
 
 sub get_jar_files {
     # Return a list of JAR files of the dependencies of JSS; in particular,
     # handle Debian vs OpenSUSE vs Fedora builds and the locations of relevant
     # jars on those platforms.
-    our $jarFiles = "";
 
-    if( $ENV{DEBIAN_BUILD} ) {
-        $jarFiles = "/usr/share/java/slf4j-api.jar:/usr/share/java/commons-codec.jar:/usr/share/java/jaxb-api.jar";
-        $jarFiles = "$jarFiles:/usr/share/java/commons-lang.jar"
-    } elsif( $ENV{OPENSUSE_BUILD} ) {
-        $jarFiles = "/usr/share/java/slf4j/api.jar:/usr/share/java/apache-commons-codec.jar:/usr/share/java/apache-commons-lang.jar";
-        $jarFiles = "$jarFiles:/usr/share/java/jaxb-api.jar:/usr/share/java/apache-commons-lang.jar"
-        # If some distro doesn't match the cases that we have identified
-        # then add another elfsif section to handle it.
-    } else {
-        $jarFiles = "/usr/share/java/slf4j/api.jar:/usr/share/java/commons-codec.jar:/usr/share/java/jaxb-api.jar";
-        $jarFiles = "$jarFiles:/usr/share/java/commons-lang.jar";
+    our @jarFiles = ();
+    my $slf4j = detect_jar_file("slf4j-api.jar", "slf4j/api.jar");
+    my $codec = detect_jar_file("apache-commons-codec.jar", "commons-codec.jar");
+    my $lang = detect_jar_file("apache-commons-lang.jar", "commons-lang.jar");
+    push(@jarFiles, $slf4j);
+    push(@jarFiles, $codec);
+    push(@jarFiles, $lang);
+
+    if (defined $ENV{JDK9_BUILD} and $ENV{JDK9_BUILD}) {
+        my $jaxb = detect_jar_file("jaxb-api.jar", "jboss-jaxb-2.2-api.jar");
+        push(@jarFiles, $jaxb);
     }
 
-    return $jarFiles;
+
+    return join(':', @jarFiles);
 }

--- a/tools/Dockerfiles/ubuntu_jdk8
+++ b/tools/Dockerfiles/ubuntu_jdk8
@@ -30,8 +30,6 @@ RUN true \
 # Perform the actual RPM build
 WORKDIR /home/sandbox/jss
 CMD true \
-        && export DEBIAN_BUILD=1 \
-        && export JAVA_HOME="$(dirname "$(dirname "$(readlink -f /etc/alternatives/javac)")")" \
-        && export USE_64=1 \
+        && . tools/autoenv.sh \
         && make clean all check \
         && true

--- a/tools/test_perl_style.sh
+++ b/tools/test_perl_style.sh
@@ -27,4 +27,5 @@ perl_check() {
 
 
 perl_check "build_java.pl"
+perl_check "lib/Common.pm"
 perl_check "org/mozilla/jss/tests/all.pl"


### PR DESCRIPTION
This PR includes several Perl improvements split off from #47. In particular:

 - Do jar detection versus using ENV vars to set the location of jars in `lib/Common.pm`
 - Use fatal warnings in `build_java.pl` and `tests/all.pl` -- this found a number of bugs and more importantly, stops the script in the event of failure
 - Uses the revised autoenv.sh in the Ubuntu build; this should allow us to test it more frequently.

Of particular note in the `tests/all.pl` revisions are the following:

 - An error in the tests now results in an error in the build. Previously the exit status was still zero in the event of one or more test failures.
 - `NATIVE_FLAG` has been removed. There appears to have been a [discussion with wtc](https://bugzilla.mozilla.org/show_bug.cgi?id=302550) in which nobody stated its purpose.
 - Various cleanup in the handling of the classpath and detecting libraries. 

