### PR TITLE
Fix Travis CI on v4.4.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ services:
   - docker
 
 install:
-  - docker pull registry.fedoraproject.org/fedora:28
+  - docker pull registry.fedoraproject.org/fedora:27
   - docker run
       --name=container
       --detach
       -i
       -v $(pwd):/root/jss
-      registry.fedoraproject.org/fedora:28
+      registry.fedoraproject.org/fedora:27
   - docker exec container dnf install -y dnf-plugins-core gcc make rpm-build
   - docker exec container dnf builddep -y --spec /root/jss/jss.spec.in
   - docker exec container /root/jss/build.sh --with-timestamp --with-commit-id rpm


### PR DESCRIPTION
Note that F27 was the last release that shipped with v4.4.x;
on F28, ldapjdk 4.20 requires jss >= 4.5.0 and hence we can't
build v4.4.x with F28.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`