### PR TITLE
Fix truncation warning

### DIFF
--- a/coreconf/nsinstall/pathsub.c
+++ b/coreconf/nsinstall/pathsub.c
@@ -214,7 +214,7 @@ reversepath(char *inpath, char *name, int len, char *outpath)
 	    xchdir("..");
 	} else {
 	    cp -= 3;
-	    strncpy(cp, "../", 3);
+	    memcpy(cp, "../", 3);
 	    xchdir(buf);
 	}
     }


### PR DESCRIPTION
https://pagure.io/jss/issue/21
‘strncpy’ output truncated before terminating nul copying 3 bytes from a string of the same length
Using memcpy gets rid of the warning, same way NSS folks dealt with it.

Backport of #24 to v4.4.x