### PR TITLE
Add dependency on JAXB for JDK9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,21 @@ This project has the following build dependencies:
  - [Perl](https://www.perl.org/)
  - [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/)
  - [Apache Commons Codec](https://commons.apache.org/proper/commons-codec/)
+ - [JavaEE JAXB](https://github.com/eclipse-ee4j/jaxb-ri)
  - [SLF4J](https://www.slf4j.org/)
 
 To install these dependencies on Fedora, execute the following:
 
     sudo dnf install apache-commons-codec apache-commons-lang gcc-c++ \
-                     java-devel jpackage-utils slf4j zlib-devel
+                     java-devel jpackage-utils slf4j zlib-devel \
+                     glassfish-jaxb-api
 
 To install these dependencies on Debian, execute the following:
 
     sudo apt-get install build-essential libcommons-codec-java \
                          libcommons-lang-java libnss3-dev libslf4j-java \
-                         openjdk-8-jdk pkg-config zlib1g-dev
+                         openjdk-8-jdk pkg-config zlib1g-dev \
+                         libjaxb-api-java
 
 Build/Test Instructions
 -----------------------

--- a/jss.spec
+++ b/jss.spec
@@ -41,6 +41,7 @@ BuildRequires:  nss-tools >= 3.28.4-6
 BuildRequires:  java-devel
 BuildRequires:  jpackage-utils
 BuildRequires:  slf4j
+BuildRequires:  glassfish-jaxb-api
 %if 0%{?rhel} && 0%{?rhel} <= 7
 # no slf4j-jdk14
 %else
@@ -57,6 +58,7 @@ Requires:       nss >= 3.28.4-6
 Requires:       java-headless
 Requires:       jpackage-utils
 Requires:       slf4j
+Requires:       glassfish-jaxb-api
 %if 0%{?rhel} && 0%{?rhel} <= 7
 # no slf4j-jdk14
 %else

--- a/lib/Common.pm
+++ b/lib/Common.pm
@@ -37,15 +37,11 @@ sub get_jar_files {
     my $slf4j = detect_jar_file("slf4j-api.jar", "slf4j/api.jar");
     my $codec = detect_jar_file("apache-commons-codec.jar", "commons-codec.jar");
     my $lang = detect_jar_file("apache-commons-lang.jar", "commons-lang.jar");
+    my $jaxb = detect_jar_file("jaxb-api.jar");
     push(@jarFiles, $slf4j);
     push(@jarFiles, $codec);
     push(@jarFiles, $lang);
-
-    if (defined $ENV{JDK9_BUILD} and $ENV{JDK9_BUILD}) {
-        my $jaxb = detect_jar_file("jaxb-api.jar", "jboss-jaxb-2.2-api.jar");
-        push(@jarFiles, $jaxb);
-    }
-
+    push(@jarFiles, $jaxb);
 
     return join(':', @jarFiles);
 }

--- a/tools/Dockerfiles/ubuntu_jdk8
+++ b/tools/Dockerfiles/ubuntu_jdk8
@@ -7,6 +7,7 @@ RUN true \
         && apt-get install -y debhelper libnss3-dev openjdk-8-jdk pkg-config \
                               quilt g++ mercurial zlib1g-dev libslf4j-java \
                               liblog4j2-java libcommons-lang-java \
+                              libjaxb-api-java \
         && mkdir -p /home/sandbox \
         && apt-get autoremove -y \
         && apt-get clean -y \

--- a/tools/autoenv.sh
+++ b/tools/autoenv.sh
@@ -32,12 +32,6 @@ if [ "x$JAVA_HOME" = "x" ]; then
     exit 1
 fi
 
-# Check if the JDK version is 9 or greater...
-java9_check="$(jrunscript -e "print(java.lang.Double.parseDouble(java.lang.System.getProperty('java.specification.version')) >= java.lang.Double.parseDouble('1.9'))" 2>/dev/null)"
-if [ "x$java9_check" = "xtrue" ]; then
-    export JDK9_BUILD=1
-fi
-
 # Check if we're running in 64-bit mode.
 if [ "x$(getconf LONG_BIT)" = "x64" ]; then
     export USE_64=1


### PR DESCRIPTION
Per discussion in #49 and [jss issue#27 / RFC](https://pagure.io/jss/issue/27), add a dependency on JAXB for JDK9+ builds. This is the last major issue preventing a build for JDK8 - JDK11 besides #41.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`