### PR TITLE
Add additional Fedora testing images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,12 @@ matrix:
       env: BASE_IMAGE="debian_jdk11"
     - stage: extra
       env: BASE_IMAGE="ubuntu_jdk8"
+    - stage: extra
+      env: BASE_IMAGE="fedora_29"
+    - stage: extra
+      env: BASE_IMAGE="fedora_29_jdk11"
+    - stage: extra
+      env: BASE_IMAGE="fedora_rawhide"
   allow_failures:
     - stage: extra
       env: BASE_IMAGE="pkcs11check"
@@ -38,3 +44,9 @@ matrix:
       env: BASE_IMAGE="debian_jdk11"
     - stage: extra
       env: BASE_IMAGE="ubuntu_jdk8"
+    - stage: extra
+      env: BASE_IMAGE="fedora_29"
+    - stage: extra
+      env: BASE_IMAGE="fedora_29_jdk11"
+    - stage: extra
+      env: BASE_IMAGE="fedora_rawhide"

--- a/tools/Dockerfiles/fedora_29
+++ b/tools/Dockerfiles/fedora_29
@@ -1,0 +1,30 @@
+FROM fedora:29
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+        && dnf copr -y enable ${JSS_4_5_REPO:-@pki/10.6} \
+        && dnf build-dep -y jss \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Install dependencies from the spec file in case they've changed
+# since the last release on this platform.
+RUN true \
+        && dnf build-dep -y --spec /home/sandbox/jss/jss.spec \
+        && true
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && bash ./build.sh --with-timestamp --with-commit-id rpm \
+        && dnf install -y /root/build/jss/RPMS/*.rpm \
+        && true

--- a/tools/Dockerfiles/fedora_29_jdk11
+++ b/tools/Dockerfiles/fedora_29_jdk11
@@ -1,0 +1,26 @@
+FROM fedora:29
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+                          glassfish-jaxb-api java-11-openjdk nss-tools \
+                          apache-commons-codec apache-commons-lang gcc-c++ \
+                          java-11-openjdk-devel jpackage-utils slf4j nss \
+                          zlib-devel nss-devel nspr-devel perl slf4j-jdk14 \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && . tools/autoenv.sh \
+        && make clean all check \
+        && true

--- a/tools/Dockerfiles/fedora_rawhide
+++ b/tools/Dockerfiles/fedora_rawhide
@@ -1,0 +1,26 @@
+FROM fedora:rawhide
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+                          glassfish-jaxb-api java-11-openjdk nss-tools \
+                          apache-commons-codec apache-commons-lang gcc-c++ \
+                          java-11-openjdk-devel jpackage-utils slf4j nss \
+                          zlib-devel nss-devel nspr-devel perl slf4j-jdk14 \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && . tools/autoenv.sh \
+        && make clean all check \
+        && true


### PR DESCRIPTION
These images help ensure support for later Fedora releases and ensure
that we maintain JDK8+ support across various Fedora releases. They've
been added to the Extras section such that they don't fail the build and
aren't required to pass for the build to succeed, but so that we can
keep an eye on their status.

The `fedora_29` image can be moved to the main section when 29 ships and
27 can then be removed.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`