### PR TITLE
Add html build target

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -12,6 +12,8 @@ release_classes:: releaseJava
 check:: testJava
 test_jss:: testJava
 
+html:: javadoc
+
 # always do a private_export
 export:: private_export
 


### PR DESCRIPTION
html is another standard build target that I missed earlier and is
documented here:

https://www.gnu.org/prep/standards/html_node/Standard-Targets.html

This makes the html target build the javadocs, as they are generated in
HTML format.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`