### PR TITLE
Fix problem where firefox could not display the INDEX tab as of jdk 11

### DIFF
--- a/build_java.pl
+++ b/build_java.pl
@@ -455,9 +455,7 @@ sub javadoc {
     ensure_dir_exists("$dist_dir/jssdoc");
     my $targets = join(" ", @packages);
     print "$targets\n";
-    print_do("$javadoc -notimestamp -breakiterator $classpath -sourcepath . -d $dist_dir/jssdoc $html_header_opt $targets");
-    print_do("cp $dist_dir/jssdoc/index.html $dist_dir/jssdoc/index.html.bak");
-    print_do("cp $dist_dir/jssdoc/overview-summary.html $dist_dir/jssdoc/index.html");
+    print_do("$javadoc -overview ./overview.html -notimestamp -breakiterator $classpath -sourcepath . -d $dist_dir/jssdoc $html_header_opt $targets");
 }
 
 sub test {

--- a/overview.html
+++ b/overview.html
@@ -1,0 +1,10 @@
+<HTML>
+   <BODY>
+   <b/>JSS: Java Security Services</b><br>
+   <p><br>
+   <b>
+   Java native interface which provides a bridge for java-based<br>
+   applications to use native Network Security Services (NSS).<br>
+   </b>
+   </BODY>
+</HTML>


### PR DESCRIPTION
- address: https://pagure.io/jss/issue/28
- add "-overview ./overview.html" option to the javadoc command invocation
- add overview.html file at the top of the source tree
- overview.html provides a title and a brief description of jss
- no longer need to replace index.html with overview-summary.html