### PR TITLE
[RFC] Increment version number to 4.5.1 post-release

### DIFF
--- a/jss.spec
+++ b/jss.spec
@@ -6,7 +6,7 @@ Summary:        Java Security Services (JSS)
 URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
-Version:        4.5.0
+Version:        4.5.1
 Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
 # global         _phase -a1
 

--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -984,7 +984,7 @@ public final class CryptoManager implements TokenSupplier
 
 
     public static final String
-    JAR_JSS_VERSION     = "JSS_VERSION = JSS_4_5";
+    JAR_JSS_VERSION     = "JSS_VERSION = JSS_4_5_1";
     public static final String
     JAR_JDK_VERSION     = "JDK_VERSION = N/A";
     public static final String

--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -20,7 +20,7 @@ public final class JSSProvider extends java.security.Provider {
     /* QUESTION: When do we change MINOR and PATCH to 4 and 0? */
     private static int JSS_MAJOR_VERSION  = 4;
     private static int JSS_MINOR_VERSION  = 5;
-    private static int JSS_PATCH_VERSION  = 0;
+    private static int JSS_PATCH_VERSION  = 1;
     private static double JSS_VERSION     = JSS_MAJOR_VERSION +
                                            (JSS_MINOR_VERSION * 100 +
                                             JSS_PATCH_VERSION)/10000.0;

--- a/org/mozilla/jss/util/jssver.h
+++ b/org/mozilla/jss/util/jssver.h
@@ -25,10 +25,10 @@
 /*                                                                  */
 /********************************************************************/
 
-#define JSS_VERSION  "4.5.0"
+#define JSS_VERSION  "4.5.1"
 #define JSS_VMAJOR   4
 #define JSS_VMINOR   5
-#define JSS_VPATCH   0
+#define JSS_VPATCH   1
 #define JSS_BETA     PR_FALSE
 
 #endif


### PR DESCRIPTION
Since 4.5.0 was released by @edewata, it'd be nice to bump the version to the next release version, 4.5.1 such that users who build JSS can install it on a system 4.5.0 without needing to do this themselves. In general I'm in favor of "release+increment post release" versus "increment during release" but that's my 2c.

This was based on the commit by @edewata: 3ee3c9d1637a88c5dde5a93521680e42ba0aeefe
Built an unofficial COPR image to begin testing other Dogtag projects with: https://copr.fedorainfracloud.org/coprs/cipherboy/jss/build/814786/ 

Thoughts? /cc @edewata, @SilleBille, @emaldona, @jmagne

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`