### PR TITLE
Reproducible JAR builds

### DIFF
--- a/build_java.pl
+++ b/build_java.pl
@@ -346,6 +346,8 @@ MyLabel
     our $javac_deprecation_flag;
     our $classpath;
     our $jar;
+    our $class_jar;
+
     if( scalar(@source_list) > 0 ) {
         ensure_dir_exists($class_dir);
         print_do("$javac $javac_opt_flag $javac_deprecation_flag -sourcepath . -d $class_dir " .
@@ -361,7 +363,7 @@ MyLabel
         print_do("$javac $javac_opt_flag $javac_deprecation_flag -sourcepath . -d $class_dir -h $jni_header_dir " .
             "$classpath " . join(" ", @jni_sources) );
 
-        print_do("sh -c 'cd $dist_dir/classes && $jar cvmf $dist_dir/MANIFEST.MF $dist_dir/xpclass.jar *'");
+        print_do("sh -c 'cd $dist_dir/classes && $jar cvmf $dist_dir/MANIFEST.MF $class_jar *'");
         print "Exit status was " . ($?>>8) . "\n";
     }
 }
@@ -461,6 +463,7 @@ sub javadoc {
 sub test {
     our $os;
     our $dist_dir;
+    our $class_jar;
 
     our $jss_dir;
     our $jss_lib_dir;
@@ -483,7 +486,7 @@ sub test {
     }
 
     my $cmd = "cd $jss_dir/org/mozilla/jss/tests; "
-            . "perl all.pl dist \"$dist_dir\" \"$nss_bin_dir\" \"$nss_lib_dir\" \"$jss_lib_dir\"";
+            . "perl all.pl dist \"$dist_dir\" \"$nss_bin_dir\" \"$nss_lib_dir\" \"$jss_lib_dir\" \"$class_jar\"";
 
     print("#######################\n" .
           "# BEGIN:  Testing JSS #\n" .

--- a/jss.spec
+++ b/jss.spec
@@ -135,7 +135,8 @@ export USE_64
 make -C coreconf
 make
 make javadoc
-make test_jss
+make reproducible
+make reproducibleCheck
 
 ################################################################################
 %install
@@ -144,7 +145,7 @@ make test_jss
 
 # jars
 install -d -m 0755 $RPM_BUILD_ROOT%{_jnidir}
-install -m 644 ../dist/xpclass.jar ${RPM_BUILD_ROOT}%{_jnidir}/jss4.jar
+install -m 644 ../dist/reproducible-xpclass.jar ${RPM_BUILD_ROOT}%{_jnidir}/jss4.jar
 
 # We have to use the name libjss4.so because this is dynamically
 # loaded by the jar file.

--- a/org/mozilla/jss/tests/all.pl
+++ b/org/mozilla/jss/tests/all.pl
@@ -24,9 +24,9 @@ use Common qw(get_jar_files);
 
 sub usage {
     print "Usage:\n";
-    print "$0 dist <dist_dir> <NSS bin_dir> <NSS lib dir> <JSS lib dir>\n";
+    print "$0 dist <dist_dir> <NSS bin_dir> <NSS lib dir> <JSS lib dir> <jss jar>\n";
     print "$0 release <jss release dir> <nss release dir> "
-        . "<nspr release dir>\n";
+        . "<nspr release dir> <jss jar>\n";
     print "$0 auto\n";
     exit(1);
 }
@@ -138,7 +138,7 @@ sub setup_vars {
     if( $$argv[0] eq "dist" ) {
         shift @$argv;
 
-        if (scalar @$argv != 4) {
+        if (scalar @$argv != 5) {
             usage("incorrect dist parameters");
         }
 
@@ -146,9 +146,9 @@ sub setup_vars {
         $nss_bin_dir = shift @$argv;
         $nss_lib_dir = shift @$argv;
         $jss_lib_dir = shift @$argv;
+        $jss_classpath = shift @$argv;
 
         $jss_rel_dir   = "$dist_dir/classes/org";
-        $jss_classpath = "$dist_dir/xpclass.jar";
 
         ( -f $jss_classpath ) or die "$jss_classpath does not exist";
 
@@ -179,12 +179,12 @@ sub setup_vars {
         $jss_rel_dir     = shift @$argv or usage();
         my $nss_rel_dir  = shift @$argv or usage();
         my $nspr_rel_dir = shift @$argv or usage();
+        $jss_classpath   = shift @$argv or usage();
 
         $nspr_lib_dir = "$nspr_rel_dir/lib";
         $nss_bin_dir = "$nss_rel_dir/bin";
         $nss_lib_dir = "$nss_rel_dir/lib";
         $jss_lib_dir = "$jss_rel_dir/lib";
-        $jss_classpath = "$jss_rel_dir/../xpclass.jar";
 
         $ENV{$ld_lib_path} =
                 "$jss_lib_dir" . $pathsep .

--- a/rules.mk
+++ b/rules.mk
@@ -17,12 +17,19 @@ html:: javadoc
 # always do a private_export
 export:: private_export
 
-PERL_VARIABLES=     \
+CORE_VARIABLES=     \
     "JSS_OBJDIR_NAME=$(OBJDIR_NAME)" \
     "SOURCE_PREFIX=$(SOURCE_PREFIX)" \
     "SOURCE_RELEASE_PREFIX=$(SOURCE_RELEASE_PREFIX)" \
     "SOURCE_RELEASE_CLASSES_DIR=$(SOURCE_RELEASE_CLASSES_DIR)" \
+
+PERL_VARIABLES= \
+    $(CORE_VARIABLES) \
     "XPCLASS_JAR=$(XPCLASS_JAR)"
+
+REPRODUCIBLE_VARIABLES= \
+    $(CORE_VARIABLES) \
+    "XPCLASS_JAR=reproducible-$(XPCLASS_JAR)"
 
 buildJava:
 	perl build_java.pl $(PERL_VARIABLES) build
@@ -38,3 +45,9 @@ releaseJava:
 
 javadoc:
 	perl build_java.pl $(PERL_VARIABLES) javadoc
+
+reproducible:
+	bash tools/reproducible_jar.sh "$(SOURCE_PREFIX)/$(XPCLASS_JAR)" "$(SOURCE_PREFIX)/reproducible" "$(SOURCE_PREFIX)/reproducible-$(XPCLASS_JAR)"
+
+reproducibleCheck:
+	perl build_java.pl $(REPRODUCIBLE_VARIABLES) test

--- a/tools/reproducible_jar.sh
+++ b/tools/reproducible_jar.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# A shell script to create a reproducible jar distirbution for JSS.
+#
+# This will extract the created JSS build and normalize timestamp and file
+# insertion order. This will help to ensure that anyone building in the same
+# environment will receive the same jar file assuming the contents of Java
+# haven't changed.
+
+set -e
+
+function extract() {
+    local jar="$1"
+    local path="$2"
+
+    if [ -d "$path" ]; then
+        rm -rf "$path"
+    fi
+
+    mkdir -p "$path"
+    unzip "$jar" -d "$path"
+}
+
+function normalize_timestamps() {
+    local path="$1"
+    find "$path" -exec touch -t 201801010000 {} +
+}
+
+function add_manifest() {
+    local path="$1"
+    local output="$2"
+
+    pushd "$path"
+        zip -X "$output" "META-INF"
+        zip -X "$output" "META-INF/MANIFEST.MF"
+    popd
+}
+
+function add_classes() {
+    local path="$1"
+    local output="$2"
+
+    pushd "$path"
+        for file in $(find "org" | sort); do
+            zip -X "$output" "$file"
+        done
+    popd
+}
+
+abs_jar="$(realpath "$1")"
+abs_path="$(realpath "$2")"
+abs_output="$(realpath "$3")"
+
+extract "$abs_jar" "$abs_path"
+normalize_timestamps "$abs_path"
+add_manifest "$abs_path" "$abs_output"
+add_classes "$abs_path" "$abs_output"

--- a/tools/test_shell_style.sh
+++ b/tools/test_shell_style.sh
@@ -33,6 +33,7 @@ shell_check() {
 
 shell_check "build.sh"
 shell_check "tools/autoenv.sh"
+shell_check "tools/reproducible_jar.sh"
 shell_check "tools/run_container.sh"
 shell_check "tools/test_perl_style.sh"
 shell_check "tools/test_python_style.sh"


### PR DESCRIPTION
This PR adds support for reproducible builds in two parts:

- In `build_java.pl` and `tests/all.pl`, inconsistent use was made for using `xpclass.jar` directly as a literal or as a variable. I've updated this such that the variables set in `rules.mk` (which are passed to the `build_java.pl` script) control the jar name throughout building and testing. This allows us to change the `xpclass.jar` name at a later point if we desire.
- Implement reproducible JAR builds via a shell script, `tools/reproducible_jar.sh`. This is added as a make target, `reproducible`, a test target of `reproducibleCheck`, and then added to the `jss.spec` for use in Fedora.

To validate that this build really is reproducible:

```bash
cd sandbox/jss
rm ../dist -rf
make clean all reproducible
md5sum ../dist/*.jar
sha256sum ../dist/*.jar
```

and note the values / save them to a file. Then repeat all steps (including removing `dist`) and compare the new values.