### PR TITLE
Fix javadoc reported errors when switching to jdk11

### DIFF
--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -1003,11 +1003,11 @@ public final class CryptoManager implements TokenSupplier
      * no means of specifying which token to use.
      *
      * <p>If no token is set, the InternalKeyStorageToken will be used. Setting
-     * this thread's token to <tt>null</tt> will also cause the
+     * this thread's token to <code>null</code> will also cause the
      * InternalKeyStorageToken to be used.
      *
      * @param token The token to use for crypto operations. Specifying
-     * <tt>null</tt> will cause the InternalKeyStorageToken to be used.
+     * <code>null</code> will cause the InternalKeyStorageToken to be used.
      */
     public void setThreadToken(CryptoToken token) {
         if( token != null ) {
@@ -1023,7 +1023,7 @@ public final class CryptoManager implements TokenSupplier
      * no means of specifying which token to use.
      *
      * <p>If no token is set, the InternalKeyStorageToken will be used. Setting
-     * this thread's token to <tt>null</tt> will also cause the
+     * this thread's token to <code>null</code> will also cause the
      * InternalKeyStorageToken to be used.
      *
      * @return The default token for this thread. If it has not been specified,

--- a/org/mozilla/jss/InitializationValues.java
+++ b/org/mozilla/jss/InitializationValues.java
@@ -402,13 +402,13 @@ public final class InitializationValues {
     public boolean removeSunProvider = false;
 
     /**
-     * If <tt>true</tt>, none of the underlying NSS components will
+     * If <code>true</code>, none of the underlying NSS components will
      * be initialized. Only the Java portions of JSS will be
      * initialized. This should only be used if NSS has been initialized
      * elsewhere.
      *
      * <p>Specifically, the following components will <b>not</b> be
-     *  configured by <tt>CryptoManager.initialize</tt> if this flag is set:
+     *  configured by <code>CryptoManager.initialize</code> if this flag is set:
      * <ul>
      * <li>The NSS databases.
      * <li>OCSP checking.
@@ -421,7 +421,7 @@ public final class InitializationValues {
      * <li>The cipher strength policy (export/domestic).
      * </ul>
      *
-     * <p>The default is <tt>false</tt>.
+     * <p>The default is <code>false</code>.
      */
     public boolean initializeJavaOnly = false;
 

--- a/org/mozilla/jss/SecretDecoderRing/KeyManager.java
+++ b/org/mozilla/jss/SecretDecoderRing/KeyManager.java
@@ -176,7 +176,7 @@ public class KeyManager {
      * the actual algorithm of the key you are looking for. If you 
      * pass in a different algorithm and try to use the key that is returned,
      * the results are undefined.
-     * @return The key, or <tt>null</tt> if the key is not found.
+     * @return The key, or <code>null</code> if the key is not found.
      */
     public SecretKey lookupKey(EncryptionAlgorithm alg, byte[] keyid)
         throws TokenException
@@ -212,7 +212,7 @@ public class KeyManager {
      * the results are undefined.
      * @param nickname the name of the symmetric key. Duplicate keynames
      *  will be checked for, and are not allowed.
-     * @return The key, or <tt>null</tt> if the key is not found.
+     * @return The key, or <code>null</code> if the key is not found.
      */
     public SecretKey lookupUniqueNamedKey(EncryptionAlgorithm alg,
                                           String nickname)

--- a/org/mozilla/jss/asn1/BIT_STRING.java
+++ b/org/mozilla/jss/asn1/BIT_STRING.java
@@ -79,7 +79,7 @@ public class BIT_STRING implements ASN1Value {
      * its trailing zeroes removed. Generally, DER requires that trailing
      * zeroes be removed when the bitstring is used to hold flags, but
      * not when it is used to hold binary data (such as a public key).
-     * The default is <tt>false</tt>.
+     * The default is <code>false</code>.
      * @return True if trailing zeroes are to be removed.
      */
     public boolean getRemoveTrailingZeroes() {
@@ -91,8 +91,8 @@ public class BIT_STRING implements ASN1Value {
      * its trailing zeroes removed. Generally, DER requires that trailing
      * zeroes be removed when the bitstring is used to hold flags, but
      * not when it is used to hold binary data (such as a public key).
-     * The default is <tt>false</tt>. If this bit string is used to hold
-     * flags, you should set this to <tt>true</tt>.
+     * The default is <code>false</code>. If this bit string is used to hold
+     * flags, you should set this to <code>true</code>.
      * @param removeTrailingZeroes True if trailing zeroes are to be removed.
      */
     public void setRemoveTrailingZeroes(boolean removeTrailingZeroes) {

--- a/org/mozilla/jss/crypto/Algorithm.java
+++ b/org/mozilla/jss/crypto/Algorithm.java
@@ -80,9 +80,9 @@ public class Algorithm {
      *   <code>null</code> if this algorithm does not take any parameters.
      * If the algorithm can accept more than one type of parameter,
      *   this method returns only one of them. It is better to call
-     *   <tt>getParameterClasses()</tt>.
+     *   <code>getParameterClasses()</code>.
      * @return Parameter type.
-     * @deprecated Call <tt>getParameterClasses()</tt> instead.
+     * @deprecated Call <code>getParameterClasses()</code> instead.
      */
     @Deprecated
     public Class<?> getParameterClass() {
@@ -105,11 +105,11 @@ public class Algorithm {
     /**
      * Validates if the given Object can be used as a parameter
      * for this algorithm.
-     * <p>If <tt>null</tt> is passed in, this method will return <tt>true</tt>
-     *      if this algorithm takes no parameters, and <tt>false</tt>
+     * <p>If <code>null</code> is passed in, this method will return true
+     *      if this algorithm takes no parameters, and false
      *      if this algorithm does take parameters.
      * @param o Object.
-     * @return Returns <tt>true</tt> if the given Object can be used as a parameter.
+     * @return Returns <code>true</code> if the given Object can be used as a parameter.
      */
     public boolean isValidParameterObject(Object o) {
         if( o == null ) {

--- a/org/mozilla/jss/crypto/KeyPairGenerator.java
+++ b/org/mozilla/jss/crypto/KeyPairGenerator.java
@@ -58,7 +58,7 @@ public class KeyPairGenerator {
 
     /**
      * Initializes the generator with algorithm-specific parameters.
-     *  The <tt>SecureRandom</tt> parameters is ignored.
+     *  The <code>SecureRandom</code> parameters is ignored.
      *
      * @param params Algorithm-specific parameters for the key pair generation.
      * @param random <b>This parameter is ignored.</b> NSS does not accept
@@ -93,7 +93,7 @@ public class KeyPairGenerator {
 
     /**
      * Initializes the generator with the strength of the keys.
-     *      The <tt>SecureRandom</tt> parameter is ignored.
+     *      The <code>SecureRandom</code> parameter is ignored.
      *
      * @param strength The strength of the keys that will be generated.
      *      Usually this is the length of the key in bits.

--- a/org/mozilla/jss/netscape/security/pkcs/PKCS7.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS7.java
@@ -47,9 +47,9 @@ import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
 /**
  * PKCS7 as defined in RSA Laboratories PKCS7 Technical Note. Profile
- * Supports only <tt>SignedData</tt> ContentInfo
+ * Supports only <code>SignedData</code> ContentInfo
  * type, where to the type of data signed is plain Data.
- * For signedData, <tt>crls</tt>, <tt>attributes</tt> and
+ * For signedData, <code>crls</code>, <code>attributes</code> and
  * PKCS#6 Extended Certificates are not supported.
  *
  * @version 1.33 97/12/10

--- a/org/mozilla/jss/netscape/security/provider/DSA.java
+++ b/org/mozilla/jss/netscape/security/provider/DSA.java
@@ -429,7 +429,7 @@ public final class DSA extends Signature {
      * This implementation recognizes the following parameter:
      * <dl>
      *
-     * <dt><tt>Kseed</tt>
+     * <dt><code>Kseed</code>
      *
      * <dd>a byte array.
      *
@@ -463,7 +463,7 @@ public final class DSA extends Signature {
      *
      * <dl>
      *
-     * <dt><tt>Kseed</tt>
+     * <dt><code>Kseed</code>
      *
      * <dd>a byte array.
      *

--- a/org/mozilla/jss/pkix/cert/CertificateInfo.java
+++ b/org/mozilla/jss/pkix/cert/CertificateInfo.java
@@ -262,8 +262,8 @@ public class CertificateInfo implements ASN1Value {
 
     /**
      * Linearly searches the extension list for an extension with the given
-     * object identifier. If it finds one, returns <tt>true</tt>. Otherwise,
-     * returns <tt>false</tt>.
+     * object identifier. If it finds one, returns <code>true</code>. Otherwise,
+     * returns <code>false</code>.
      */
     public boolean isExtensionPresent(OBJECT_IDENTIFIER oid) {
         return ( getExtension(oid) != null );
@@ -272,7 +272,7 @@ public class CertificateInfo implements ASN1Value {
     /**
      * Linearly searches the extension list for an extension with the given
      * object identifier. It returns the first one it finds. If none are found,
-     * returns <tt>null</tt>.
+     * returns <code>null</code>.
      */
     public Extension getExtension(OBJECT_IDENTIFIER oid) {
         int numExtensions = extensions.size();

--- a/org/mozilla/jss/pkix/cmc/RevokeRequest.java
+++ b/org/mozilla/jss/pkix/cmc/RevokeRequest.java
@@ -175,7 +175,7 @@ public class RevokeRequest implements ASN1Value {
     }
 
     /**
-     * Returns the <tt>invalidityDate</tt> field. Returns <tt>null</tt>
+     * Returns the <code>invalidityDate</code> field. Returns <code>null</code>
      * if the field is not present.
      */
     public GeneralizedTime getInvalidityDate() {
@@ -204,10 +204,10 @@ public class RevokeRequest implements ASN1Value {
 
     /**
      * Constructs a new <code>RevokeRequest</code> from its components,
-     *  omitting the <tt>invalidityDate</tt> field.
+     *  omitting the <code>invalidityDate</code> field.
      *
      * @deprecated This constructor is obsolete now that
-     *      <tt>invalidityDate</tt> has been added to the class.
+     *      <code>invalidityDate</code> has been added to the class.
      *
      * @param issuerName The <code>issuerName</code> field.
      * @param serialNumber The <code>serialNumber</code> field.
@@ -234,7 +234,7 @@ public class RevokeRequest implements ASN1Value {
      * @param reason The <code>reason</code> field.  The constants defined
      *      in this class may be used.
      * @param invalidityDate The suggested value for the Invalidity Date
-     *      CRL extension. This field is optional, so <tt>null</tt> may be
+     *      CRL extension. This field is optional, so <code>null</code> may be
      *      used.
      * @param passphrase The <code>passphrase</code> field.  This field is
      *      optional, so <code>null</code> may be used.

--- a/org/mozilla/jss/pkix/cmmf/RevRequest.java
+++ b/org/mozilla/jss/pkix/cmmf/RevRequest.java
@@ -141,7 +141,7 @@ public class RevRequest implements ASN1Value {
     }
 
     /**
-     * Returns the <tt>invalidityDate</tt> field. Returns <tt>null</tt>
+     * Returns the <code>invalidityDate</code> field. Returns null
      * if the field is not present.
      */
     public GeneralizedTime getInvalidityDate() {
@@ -151,8 +151,8 @@ public class RevRequest implements ASN1Value {
     /**
      * Returns the <code>passphrase</code> field.  Returns
      *  <code>null</code> if the field is not present.
-     * @deprecated The <tt>passphrase</tt> field has been renamed
-     *  <tt>sharedSecret</tt>. Call <tt>getSharedSecret</tt> instead.
+     * @deprecated The <code>passphrase</code> field has been renamed
+     *  <code>sharedSecret</code>. Call <code>getSharedSecret</code> instead.
      */
     @Deprecated
     public OCTET_STRING getPassphrase() {
@@ -181,10 +181,10 @@ public class RevRequest implements ASN1Value {
 
     /**
      * Constructs a new <code>RevRequest</code> from its components,
-     *  omitting the <tt>invalidityDate</tt> field.
+     *  omitting the <code>invalidityDate</code> field.
      *
      * @deprecated This constructor is obsolete now that
-     *      <tt>invalidityDate</tt> has been added to the class.
+     *      <code>invalidityDate</code> has been added to the class.
      *
      * @param issuerName The <code>issuerName</code> field.
      * @param serialNumber The <code>serialNumber</code> field.
@@ -211,7 +211,7 @@ public class RevRequest implements ASN1Value {
      * @param reason The <code>reason</code> field.  The constants defined
      *      in this class may be used.
      * @param invalidityDate The suggested value for the Invalidity Date
-     *      CRL extension. This field is optional, so <tt>null</tt> may be
+     *      CRL extension. This field is optional, so <code>null</code> may be
      *      used.
      * @param sharedSecret The <code>sharedSecret</code> field.  This field is
      *      optional, so <code>null</code> may be used.

--- a/org/mozilla/jss/ssl/SSLServerSocket.java
+++ b/org/mozilla/jss/ssl/SSLServerSocket.java
@@ -91,8 +91,8 @@ public class SSLServerSocket extends java.net.ServerSocket {
      * @param certApprovalCallback Will get called to approve any certificate
      *      presented by the client.
      * @param reuseAddr Reuse the local bind port; this parameter sets
-     *      the <tt>SO_REUSEADDR</tt> option on the socket before calling
-     *      <tt>bind()</tt>. The default is <tt>false</tt> for backward
+     *      the <code>SO_REUSEADDR</code> option on the socket before calling
+     *      <code>bind()</code>. The default is <code>false</code> for backward
      *      compatibility.
      */
     public SSLServerSocket(int port, int backlog, InetAddress bindAddr,

--- a/org/mozilla/jss/ssl/SSLSocket.java
+++ b/org/mozilla/jss/ssl/SSLSocket.java
@@ -1596,7 +1596,7 @@ public class SSLSocket extends java.net.Socket {
      * Returns a list of cipher suites that are implemented by NSS.
      * Each element in the array will be one of the cipher suite constants
      * defined in this class (for example,
-     * <tt>TLS_RSA_WITH_AES_128_CBC_SHA</tt>).
+     * <code>TLS_RSA_WITH_AES_128_CBC_SHA</code>).
      */
     public static native int[] getImplementedCipherSuites();
 }

--- a/org/mozilla/jss/ssl/SSLSocketException.java
+++ b/org/mozilla/jss/ssl/SSLSocketException.java
@@ -8,7 +8,7 @@ package org.mozilla.jss.ssl;
 /**
  * A subclass of java.net.SocketException that contains an error code
  * from the native (NSS/NSPR) code. These error codes are defined in the
- * class <tt>org.mozilla.jss.util.NativeErrcodes</tt>.
+ * class <code>org.mozilla.jss.util.NativeErrcodes</code>.
  * @see org.mozilla.jss.util.NativeErrcodes
  */
 public class SSLSocketException extends java.net.SocketException {
@@ -31,7 +31,7 @@ public class SSLSocketException extends java.net.SocketException {
 
     /**
      * Returns an error code, as defined in class
-     * <tt>org.mozilla.jss.util.NativeErrcodes</tt>.
+     * <code>org.mozilla.jss.util.NativeErrcodes</code>.
      * @see org.mozilla.jss.util.NativeErrcodes
      */
     public int getErrcode() {

--- a/org/mozilla/jss/ssl/SocketBase.java
+++ b/org/mozilla/jss/ssl/SocketBase.java
@@ -300,7 +300,7 @@ class SocketBase {
      * of construction than getByName(), and it is final.
      *
      * @return The InetAddress corresponding to the given integer,
-     *         or <tt>null</tt> if the InetAddress could not be constructed.
+     *         or <code>null</code> if the InetAddress could not be constructed.
      */
     private static InetAddress convertIntToInetAddress(int intAddr) {
         InetAddress in;


### PR DESCRIPTION
- Address: https://github.com/dogtagpki/jss/issues/65
- use of `<tt>/</tt>` tags causes failures with jdk11 tools
- see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt
- not a problem with either jdk8 or jdk10