### PR TITLE
Small script fixes

### DIFF
--- a/tools/autoenv.sh
+++ b/tools/autoenv.sh
@@ -29,7 +29,7 @@ fi
 # Validate that JAVA_HOME was set; otherwise, exit.
 if [ "x$JAVA_HOME" = "x" ]; then
     echo "Unable to detect JAVA_HOME installation automatically!" 1>&2
-    exit 1
+    return 1
 fi
 
 # Check if we're running in 64-bit mode.

--- a/tools/build_pkcs11_constants.py
+++ b/tools/build_pkcs11_constants.py
@@ -293,19 +293,15 @@ class ConstantDefinition(object):
                 comment_info += "     *\n"
                 comment_info += "     * check stdout:\n"
                 for line in self.stdout.split("\n"):
-                    if line.strip():
-                        comment_info += "     * %s\n" % line
-                    else:
-                        comment_info += "     *\n"
+                    comment_line = "     * %s" % line.strip()
+                    comment_info += comment_line.rstrip() + "\n"
 
             if self.stderr:
                 comment_info += "     *\n"
                 comment_info += "     * check stderr:\n"
                 for line in self.stderr.split("\n"):
-                    if line.strip():
-                        comment_info += "     * %s\n" % line
-                    else:
-                        comment_info += "     *\n"
+                    comment_line = "     * %s" % line.strip()
+                    comment_info += comment_line.rstrip() + "\n"
 
         comment_footer = "     */\n"
         comment = comment_header + comment_info + comment_footer


### PR DESCRIPTION
`tools/autoenv.sh` now returns rather than exiting; when sourced and
`JAVA_HOME` could not be determined, the entire shell exited.

`tools/build_pkcs11_constants.py` has been updated to conform to F29
`pylint` standards; this limits the number of branches in a function.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`