### PR TITLE
Replace instances of loser label with finish

### DIFF
--- a/org/mozilla/jss/CryptoManager.c
+++ b/org/mozilla/jss/CryptoManager.c
@@ -133,7 +133,7 @@ int ConfigureOCSP(
             JSS_throwMsg(env, GENERAL_SECURITY_EXCEPTION,
                     "OCSP invalid URL");
             result = SECFailure;
-            goto loser;
+            goto finish;
         }
     }
 
@@ -144,7 +144,7 @@ int ConfigureOCSP(
             JSS_throwMsg(env, GENERAL_SECURITY_EXCEPTION,
                     "OCSP invalid nickname");
             result = SECFailure;
-            goto loser;
+            goto finish;
         }
     }
 
@@ -162,7 +162,7 @@ int ConfigureOCSP(
                 JSS_throwMsg(env, GENERAL_SECURITY_EXCEPTION,
                 "if OCSP responderURL is set, the Responder Cert nickname must be set");
                         result = SECFailure;
-                        goto loser;
+                        goto finish;
                 } else {
                         CERTCertificate *cert;
                         /* if the nickname is set */
@@ -177,7 +177,7 @@ int ConfigureOCSP(
                                 JSS_throwMsg(env, GENERAL_SECURITY_EXCEPTION,
                     "Unable to find the OCSP Responder Certificate nickname.");
                         result = SECFailure;
-                        goto loser;
+                        goto finish;
 	               }
                         CERT_DestroyCertificate(cert);
 	}
@@ -191,7 +191,7 @@ int ConfigureOCSP(
             JSS_throwMsg(env, GENERAL_SECURITY_EXCEPTION,
                     "OCSP Could not set responder");
             result = SECFailure;
-            goto loser;
+            goto finish;
         }
         CERT_EnableOCSPDefaultResponder(certdb);
     }
@@ -207,7 +207,7 @@ int ConfigureOCSP(
         CERT_EnableOCSPChecking(certdb);
     }
     
-loser:
+finish:
         
     if (ocspResponderURL_string)  {
         (*env)->ReleaseStringUTFChars(env,

--- a/org/mozilla/jss/PK11Finder.c
+++ b/org/mozilla/jss/PK11Finder.c
@@ -507,14 +507,14 @@ collect_der_certs(void *arg, SECItem **certs, int numcerts)
     for(itemsCopied=0; itemsCopied < numcerts; itemsCopied++) {
         rv=SECITEM_CopyItem(NULL, &certCopies[itemsCopied], certs[itemsCopied]);
         if( rv == SECFailure ) {
-            goto loser;
+            goto finish;
         }
     }
     PR_ASSERT(itemsCopied == numcerts);
 
     return SECSuccess;
 
-loser:
+finish:
     for(; itemsCopied >= 0; itemsCopied--) {
         SECITEM_FreeItem( &certCopies[itemsCopied], PR_FALSE /*freeit*/);
     }

--- a/org/mozilla/jss/pkcs11/PK11SecureRandom.c
+++ b/org/mozilla/jss/pkcs11/PK11SecureRandom.c
@@ -107,7 +107,7 @@ Java_org_mozilla_jss_pkcs11_PK11SecureRandom_setSeed
     slot = PK11_GetBestSlot( CKM_FAKE_RANDOM, NULL );
     if( slot == NULL ) {
         PR_ASSERT( PR_FALSE );
-        goto loser;
+        goto finish;
     }
 
 
@@ -135,11 +135,11 @@ Java_org_mozilla_jss_pkcs11_PK11SecureRandom_setSeed
     status = PK11_SeedRandom( slot, ( unsigned char* ) jdata, ( int ) jlen );
     if( status != SECSuccess ) {
         PR_ASSERT( PR_FALSE );
-        goto loser;
+        goto finish;
     }
 
 
-loser:
+finish:
 
     /*
      * Copy back the contents of the "JNI jbyte*" and
@@ -272,11 +272,11 @@ Java_org_mozilla_jss_pkcs11_PK11SecureRandom_nextBytes
 
     status = PK11_GenerateRandom( ( unsigned char* ) jdata, ( int ) jlen );
     if( status != SECSuccess ) {
-        goto loser;
+        goto finish;
     }
 
 
-loser:
+finish:
 
     /*
      * Copy back the contents of the "JNI jbyte*" and

--- a/org/mozilla/jss/ssl/callbacks.c
+++ b/org/mozilla/jss/ssl/callbacks.c
@@ -124,7 +124,7 @@ JSSL_CallCertSelectionCallback(    void * arg,
 
     if((*JSS_javaVM)->AttachCurrentThread(JSS_javaVM, (void**)&env, NULL) != 0){
         PR_ASSERT(PR_FALSE);
-        goto loser;
+        return SECFailure;
     }
     PR_ASSERT(env != NULL);
     
@@ -227,8 +227,7 @@ JSSL_CallCertSelectionCallback(    void * arg,
             );
 
     if (chosen_nickname == NULL) {
-        rv = SECFailure;
-        goto loser;
+        return SECFailure;
     }
 
     chosen_nickname_for_c = (char*)(*env)->GetStringUTFChars(env,
@@ -250,16 +249,14 @@ JSSL_CallCertSelectionCallback(    void * arg,
             
 
     if (cert == NULL) {
-        rv = SECFailure;
-        goto loser;
+        return SECFailure;
     }
 
         privkey = PK11_FindPrivateKeyFromCert(slot, cert, NULL /*pinarg*/);
         PK11_FreeSlot(slot);
         if ( privkey == NULL )  {
         CERT_DestroyCertificate(cert);
-        rv = SECFailure;
-        goto loser;
+        return SECFailure;
     }
     if (debug_cc) { PR_fprintf(PR_STDOUT,"  found privkey. returning\n"); }
 
@@ -267,7 +264,6 @@ JSSL_CallCertSelectionCallback(    void * arg,
     *pRetKey  = privkey;
     rv = SECSuccess;
 
-loser:
     return rv;
 }
 


### PR DESCRIPTION
I'm not a fan of the `loser` label, so I'm opting to replace it with `finish` instead as it is more clear.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`