### PR TITLE
Update run_container.sh to use command -v

### DIFF
--- a/tools/run_container.sh
+++ b/tools/run_container.sh
@@ -4,14 +4,14 @@
 # images. If present, it'll use them to run the specified container image.
 
 function rc_buildah() {
-    buildah_path="$(which buildah)"
-    podman_path="$(which podman)"
+    buildah_path="$(command -v buildah)"
+    podman_path="$(command -v podman)"
 
     [ "x$buildah_path" != "x" ] && [ "x$podman_path" != "x" ]
 }
 
 function rc_docker() {
-    docker_path="$(which docker)"
+    docker_path="$(command -v docker)"
 
     [ "x$docker_path" != "x" ]
 }


### PR DESCRIPTION
According to ShellCheck, `which` is non-standard, so replace it with
`command -v` instead.

This should fix CI.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`