### PR TITLE
Remove unused variables from ssl/callbacks.c

### DIFF
--- a/org/mozilla/jss/ssl/callbacks.c
+++ b/org/mozilla/jss/ssl/callbacks.c
@@ -276,7 +276,6 @@ JSSL_AlertReceivedCallback(const PRFileDesc *fd, void *arg, const SSLAlert *aler
 {
     JSSL_SocketData *socket = (JSSL_SocketData*) arg;
 
-    jint rc;
     JNIEnv *env;
     jclass socketClass, eventClass;
     jmethodID eventConstructor, eventSetLevel, eventSetDescription;
@@ -336,7 +335,6 @@ JSSL_AlertSentCallback(const PRFileDesc *fd, void *arg, const SSLAlert *alert)
 {
     JSSL_SocketData *socket = (JSSL_SocketData*) arg;
 
-    jint rc;
     JNIEnv *env;
     jclass socketClass, eventClass;
     jmethodID eventConstructor, eventSetLevel, eventSetDescription;


### PR DESCRIPTION
Note that `rc` is unused in both of these functions. This removes two compile warnings discovered while porting to CMake that were otherwise being lost in the build output.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`