### PR TITLE
Add FindNSS and FindNSPR from PKI

### DIFF
--- a/cmake/FindNSPR.cmake
+++ b/cmake/FindNSPR.cmake
@@ -1,0 +1,104 @@
+# - Try to find NSPR
+# Once done this will define
+#
+#  NSPR_FOUND - system has NSPR
+#  NSPR_INCLUDE_DIRS - the NSPR include directory
+#  NSPR_LIBRARIES - Link these to use NSPR
+#  NSPR_DEFINITIONS - Compiler switches required for using NSPR
+#
+#  Copyright (c) 2010 Andreas Schneider <asn@redhat.com>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+
+if (NSPR_LIBRARIES AND NSPR_INCLUDE_DIRS)
+  # in cache already
+  set(NSPR_FOUND TRUE)
+else (NSPR_LIBRARIES AND NSPR_INCLUDE_DIRS)
+  find_package(PkgConfig)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(_NSPR nspr)
+  endif (PKG_CONFIG_FOUND)
+
+  find_path(NSPR_INCLUDE_DIR
+    NAMES
+      nspr.h
+    PATHS
+      ${_NSPR_INCLUDEDIR}
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+    PATH_SUFFIXES
+      nspr4
+      nspr
+  )
+
+  find_library(PLDS4_LIBRARY
+    NAMES
+      plds4
+    PATHS
+      ${_NSPR_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  find_library(PLC4_LIBRARY
+    NAMES
+      plc4
+    PATHS
+      ${_NSPR_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  find_library(NSPR4_LIBRARY
+    NAMES
+      nspr4
+    PATHS
+      ${_NSPR_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  set(NSPR_INCLUDE_DIRS
+    ${NSPR_INCLUDE_DIR}
+  )
+
+  if (PLDS4_LIBRARY)
+    set(NSPR_LIBRARIES
+        ${NSPR_LIBRARIES}
+        ${PLDS4_LIBRARY}
+    )
+  endif (PLDS4_LIBRARY)
+
+  if (PLC4_LIBRARY)
+    set(NSPR_LIBRARIES
+        ${NSPR_LIBRARIES}
+        ${PLC4_LIBRARY}
+    )
+  endif (PLC4_LIBRARY)
+
+  if (NSPR4_LIBRARY)
+    set(NSPR_LIBRARIES
+        ${NSPR_LIBRARIES}
+        ${NSPR4_LIBRARY}
+    )
+  endif (NSPR4_LIBRARY)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(NSPR DEFAULT_MSG NSPR_LIBRARIES NSPR_INCLUDE_DIRS)
+
+  # show the NSPR_INCLUDE_DIRS and NSPR_LIBRARIES variables only in the advanced view
+  mark_as_advanced(NSPR_INCLUDE_DIRS NSPR_LIBRARIES)
+
+endif (NSPR_LIBRARIES AND NSPR_INCLUDE_DIRS)

--- a/cmake/FindNSS.cmake
+++ b/cmake/FindNSS.cmake
@@ -1,0 +1,122 @@
+# - Try to find NSS
+# Once done this will define
+#
+#  NSS_FOUND - system has NSS
+#  NSS_INCLUDE_DIRS - the NSS include directory
+#  NSS_LIBRARIES - Link these to use NSS
+#  NSS_DEFINITIONS - Compiler switches required for using NSS
+#
+#  Copyright (c) 2010 Andreas Schneider <asn@redhat.com>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+
+if (NSS_LIBRARIES AND NSS_INCLUDE_DIRS)
+  # in cache already
+  set(NSS_FOUND TRUE)
+else (NSS_LIBRARIES AND NSS_INCLUDE_DIRS)
+  find_package(PkgConfig)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(_NSS nss)
+  endif (PKG_CONFIG_FOUND)
+
+  find_path(NSS_INCLUDE_DIR
+    NAMES
+      nss.h
+    PATHS
+      ${_NSS_INCLUDEDIR}
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+    PATH_SUFFIXES
+      nss3
+      nss
+  )
+
+  find_library(SSL3_LIBRARY
+    NAMES
+      ssl3
+    PATHS
+      ${_NSS_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  find_library(SMIME3_LIBRARY
+    NAMES
+      smime3
+    PATHS
+      ${_NSS_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  find_library(NSS3_LIBRARY
+    NAMES
+      nss3
+    PATHS
+      ${_NSS_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  find_library(NSSUTIL3_LIBRARY
+    NAMES
+      nssutil3
+    PATHS
+      ${_NSS_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  set(NSS_INCLUDE_DIRS
+    ${NSS_INCLUDE_DIR}
+  )
+
+  if (SSL3_LIBRARY)
+    set(NSS_LIBRARIES
+        ${NSS_LIBRARIES}
+        ${SSL3_LIBRARY}
+    )
+  endif (SSL3_LIBRARY)
+
+  if (SMIME3_LIBRARY)
+    set(NSS_LIBRARIES
+        ${NSS_LIBRARIES}
+        ${SMIME3_LIBRARY}
+    )
+  endif (SMIME3_LIBRARY)
+
+  if (NSS3_LIBRARY)
+    set(NSS_LIBRARIES
+        ${NSS_LIBRARIES}
+        ${NSS3_LIBRARY}
+    )
+  endif (NSS3_LIBRARY)
+
+  if (NSSUTIL3_LIBRARY)
+    set(NSS_LIBRARIES
+        ${NSS_LIBRARIES}
+        ${NSSUTIL3_LIBRARY}
+    )
+  endif (NSSUTIL3_LIBRARY)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(NSS DEFAULT_MSG NSS_LIBRARIES NSS_INCLUDE_DIRS)
+
+  # show the NSS_INCLUDE_DIRS and NSS_LIBRARIES variables only in the advanced view
+  mark_as_advanced(NSS_INCLUDE_DIRS NSS_LIBRARIES)
+
+endif (NSS_LIBRARIES AND NSS_INCLUDE_DIRS)


### PR DESCRIPTION
These are imported from dogtagpki/pki, with minor improvements to make
them work on Debian and Ubuntu.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`