### PR TITLE
Simplify version handling

### DIFF
--- a/lib/jss.def
+++ b/lib/jss.def
@@ -340,3 +340,12 @@ Java_org_mozilla_jss_ssl_SSLSocket_boundSSLVersionRange;
 ;+    local:
 ;+       *;
 ;+};
+;+JSS_4.5.1 {       # JSS 4.5.1 release
+;+    global:
+Java_org_mozilla_jss_CryptoManager_getJSSMajorVersion;
+Java_org_mozilla_jss_CryptoManager_getJSSMinorVersion;
+Java_org_mozilla_jss_CryptoManager_getJSSPatchVersion;
+;+    local:
+;+       *;
+;+};
+

--- a/lib/manifest.mn
+++ b/lib/manifest.mn
@@ -8,9 +8,6 @@
 #/* files everytime a new release of JSS is generated:               */
 #/*                                                                  */
 #/* lib/manifest.mn                                                  */
-#/* org/mozilla/jss/CryptoManager.c                                  */
-#/* org/mozilla/jss/CryptoManager.java                               */
-#/* org/mozilla/jss/JSSProvider.java                                 */
 #/* org/mozilla/jss/util/jssver.h                                    */
 #/*                                                                  */
 #/********************************************************************/

--- a/manifest.mn
+++ b/manifest.mn
@@ -13,9 +13,6 @@ MODULE = jss
 #/* files everytime a new release of JSS is generated:               */
 #/*                                                                  */
 #/* lib/manifest.mn                                                  */
-#/* org/mozilla/jss/CryptoManager.c                                  */
-#/* org/mozilla/jss/CryptoManager.java                               */
-#/* org/mozilla/jss/JSSProvider.java                                 */
 #/* org/mozilla/jss/util/jssver.h                                    */
 #/*                                                                  */
 #/********************************************************************/

--- a/org/mozilla/jss/CryptoManager.c
+++ b/org/mozilla/jss/CryptoManager.c
@@ -50,9 +50,6 @@ const char * jss_sccsid() {
 /* files everytime a new release of JSS is generated:               */
 /*                                                                  */
 /* lib/manifest.mn                                                  */
-/* org/mozilla/jss/CryptoManager.c                                  */
-/* org/mozilla/jss/CryptoManager.java                               */
-/* org/mozilla/jss/JSSProvider.java                                 */
 /* org/mozilla/jss/util/jssver.h                                    */
 /*                                                                  */
 /********************************************************************/
@@ -1059,5 +1056,26 @@ Java_org_mozilla_jss_CryptoManager_setOCSPTimeoutNative(
                      GENERAL_SECURITY_EXCEPTION,
                      "Failed to set OCSP timeout: error "+ PORT_GetError());
     }
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_CryptoManager_getJSSMajorVersion(
+        JNIEnv *env, jobject this)
+{
+    return JSS_VMAJOR;
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_CryptoManager_getJSSMinorVersion(
+        JNIEnv * env, jobject this)
+{
+    return JSS_VMINOR;
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_CryptoManager_getJSSPatchVersion(
+        JNIEnv *env, jobject this)
+{
+    return JSS_VPATCH;
 }
 

--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -975,24 +975,19 @@ public final class CryptoManager implements TokenSupplier
     /* files everytime a new release of JSS is generated:               */
     /*                                                                  */
     /* lib/manifest.mn                                                  */
-    /* org/mozilla/jss/CryptoManager.c                                  */
-    /* org/mozilla/jss/CryptoManager.java                               */
-    /* org/mozilla/jss/JSSProvider.java                                 */
     /* org/mozilla/jss/util/jssver.h                                    */
     /*                                                                  */
     /********************************************************************/
 
 
+    public native static int getJSSMajorVersion();
+    public native static int getJSSMinorVersion();
+    public native static int getJSSPatchVersion();
+
     public static final String
-    JAR_JSS_VERSION     = "JSS_VERSION = JSS_4_5";
-    public static final String
-    JAR_JDK_VERSION     = "JDK_VERSION = N/A";
-    public static final String
-    JAR_NSS_VERSION     = "NSS_VERSION = N/A";
-    public static final String
-    JAR_DBM_VERSION     = "DBM_VERSION = N/A";
-    public static final String
-    JAR_NSPR_VERSION    = "NSPR_VERSION = N/A";
+    JAR_JSS_VERSION     = "JSS_VERSION = JSS_" + getJSSMajorVersion() +
+                          "_" + getJSSMinorVersion() +
+                          "_" + getJSSPatchVersion();
 
     // Hashtable is synchronized.
     private Hashtable<Thread, CryptoToken> perThreadTokenTable = new Hashtable<>();

--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -11,16 +11,12 @@ public final class JSSProvider extends java.security.Provider {
     /* files everytime a new release of JSS is generated:               */
     /*                                                                  */
     /* lib/manifest.mn                                                  */
-    /* org/mozilla/jss/CryptoManager.c                                  */
-    /* org/mozilla/jss/CryptoManager.java                               */
-    /* org/mozilla/jss/JSSProvider.java                                 */
     /* org/mozilla/jss/util/jssver.h                                    */
     /*                                                                  */
     /********************************************************************/
-    /* QUESTION: When do we change MINOR and PATCH to 4 and 0? */
-    private static int JSS_MAJOR_VERSION  = 4;
-    private static int JSS_MINOR_VERSION  = 5;
-    private static int JSS_PATCH_VERSION  = 0;
+    private static int JSS_MAJOR_VERSION  = CryptoManager.getJSSMajorVersion();
+    private static int JSS_MINOR_VERSION  = CryptoManager.getJSSMinorVersion();
+    private static int JSS_PATCH_VERSION  = CryptoManager.getJSSPatchVersion();
     private static double JSS_VERSION     = JSS_MAJOR_VERSION +
                                            (JSS_MINOR_VERSION * 100 +
                                             JSS_PATCH_VERSION)/10000.0;

--- a/org/mozilla/jss/tests/JSSPackageTest.java
+++ b/org/mozilla/jss/tests/JSSPackageTest.java
@@ -27,14 +27,10 @@ public class JSSPackageTest {
             System.out.println("\n\tFetching version information " +
                                "from CryptoManager");
             System.out.println("\n\t" + org.mozilla.jss.CryptoManager.JAR_JSS_VERSION);
-            System.out.println("\n\tSuggested NSS/NSPR version to use " +
-                               "with this JSS:");
-            System.out.println("\n\t" + org.mozilla.jss.CryptoManager.JAR_NSS_VERSION);
-            System.out.println("\t" + org.mozilla.jss.CryptoManager.JAR_NSPR_VERSION);
 
-            System.out.println("\n\tTo check the JNI version in libjss4.so:"); 
-            System.out.println("\n\ttry: strings libjss4.so | grep -i header"); 
-            System.out.println("\n\tor : ident libjss4.so");         
+            System.out.println("\n\tTo check the JNI version in libjss4.so:");
+            System.out.println("\n\ttry: strings libjss4.so | grep -i header");
+            System.out.println("\n\tor : ident libjss4.so");
             System.exit(0);
 
         } catch (Exception e) {

--- a/org/mozilla/jss/util/jssver.h
+++ b/org/mozilla/jss/util/jssver.h
@@ -18,9 +18,6 @@
 /* files everytime a new release of JSS is generated:               */
 /*                                                                  */
 /* lib/manifest.mn                                                  */
-/* org/mozilla/jss/CryptoManager.c                                  */
-/* org/mozilla/jss/CryptoManager.java                               */
-/* org/mozilla/jss/JSSProvider.java                                 */
 /* org/mozilla/jss/util/jssver.h                                    */
 /*                                                                  */
 /********************************************************************/


### PR DESCRIPTION
We define the JSS version in three places:

    lib/manifest.mn
    manifest.mn
    org/mozilla/jss/util/jssver.h

By using JNI, we can extract the JSS version from `org/mozilla/jss/util/jssver.h`, reducing the number of places we have to define the version manually.

Note that I've not fully updated the docstring to reflect the second location (`jss/manifest.mn`) -- we're removing both it and `jss/lib/manifest.mn` anyways in #78.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`