### PR TITLE
Add lib/MANIFEST.MF.in and lib/jss.map

### DIFF
--- a/lib/MANIFEST.MF.in
+++ b/lib/MANIFEST.MF.in
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+
+Name: org/mozilla/jss/
+Specification-Title: Network Security Services for Java (JSS)
+Specification-Version: ${JSS_VERSION_MANIFEST}
+Specification-Vendor: Mozilla Foundation
+Implementation-Title: org.mozilla.jss
+Implementation-Version: ${JSS_VERSION_MANIFEST}
+Implementation-Vendor: Mozilla Foundation

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -1,0 +1,338 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# OK, this file is meant to support Linux's Version Script. For more
+# information, see:
+# ftp://ftp.gnu.org/pub/old-gnu/Manuals/ld-2.9.1/html_node/ld_25.html
+
+JSS_3.0 {       # JSS 3.0 release
+    global:
+Java_org_mozilla_jss_crypto_EncryptionAlgorithm_getIVLength;
+Java_org_mozilla_jss_crypto_PQGParams_generateNative__I;
+Java_org_mozilla_jss_crypto_PQGParams_generateNative__II;
+Java_org_mozilla_jss_crypto_PQGParams_paramsAreValidNative;
+Java_org_mozilla_jss_DatabaseCloser_closeDatabases;
+Java_org_mozilla_jss_CryptoManager_FIPSEnabled;
+Java_org_mozilla_jss_CryptoManager_buildCertificateChainNative;
+Java_org_mozilla_jss_CryptoManager_enableFIPS;
+Java_org_mozilla_jss_CryptoManager_exportCertsToPKCS7;
+Java_org_mozilla_jss_CryptoManager_findCertByIssuerAndSerialNumberNative;
+Java_org_mozilla_jss_CryptoManager_findCertByNicknameNative;
+Java_org_mozilla_jss_CryptoManager_findCertsByNicknameNative;
+Java_org_mozilla_jss_CryptoManager_findPrivKeyByCertNative;
+Java_org_mozilla_jss_CryptoManager_getCACerts;
+Java_org_mozilla_jss_CryptoManager_getPermCerts;
+Java_org_mozilla_jss_CryptoManager_importCRLNative;
+Java_org_mozilla_jss_CryptoManager_importCertPackageNative;
+Java_org_mozilla_jss_CryptoManager_importCertToPermNative;
+Java_org_mozilla_jss_CryptoManager_initializeAllNative;
+Java_org_mozilla_jss_CryptoManager_putModulesInVector;
+Java_org_mozilla_jss_CryptoManager_setNativePasswordCallback;
+Java_org_mozilla_jss_pkcs11_CertProxy_releaseNativeResources;
+Java_org_mozilla_jss_pkcs11_CipherContextProxy_releaseNativeResources;
+Java_org_mozilla_jss_pkcs11_PK11Module_getLibraryName;
+Java_org_mozilla_jss_pkcs11_PK11Module_getName;
+Java_org_mozilla_jss_pkcs11_PK11Module_putTokensInVector;
+Java_org_mozilla_jss_pkcs11_ModuleProxy_releaseNativeResources;
+Java_org_mozilla_jss_pkcs11_PK11Cert_getEncoded;
+Java_org_mozilla_jss_pkcs11_PK11Cert_getIssuerDNString;
+Java_org_mozilla_jss_pkcs11_PK11Cert_getNickname;
+Java_org_mozilla_jss_pkcs11_PK11Cert_getOwningToken;
+Java_org_mozilla_jss_pkcs11_PK11Cert_getPublicKey;
+Java_org_mozilla_jss_pkcs11_PK11Cert_getSerialNumberByteArray;
+Java_org_mozilla_jss_pkcs11_PK11Cert_getSubjectDNString;
+Java_org_mozilla_jss_pkcs11_PK11Cert_getTrust;
+Java_org_mozilla_jss_pkcs11_PK11Cert_getUniqueID;
+Java_org_mozilla_jss_pkcs11_PK11Cert_getVersion;
+Java_org_mozilla_jss_pkcs11_PK11Cert_setTrust;
+Java_org_mozilla_jss_pkcs11_PK11Cipher_finalizeContext;
+Java_org_mozilla_jss_pkcs11_PK11Cipher_initContext;
+Java_org_mozilla_jss_pkcs11_PK11Cipher_updateContext;
+Java_org_mozilla_jss_pkcs11_PK11KeyWrapper_nativeUnwrapPrivWithSym;
+Java_org_mozilla_jss_pkcs11_PK11KeyWrapper_nativeUnwrapSymWithPriv;
+Java_org_mozilla_jss_pkcs11_PK11KeyWrapper_nativeUnwrapSymWithSym;
+Java_org_mozilla_jss_pkcs11_PK11KeyWrapper_nativeWrapPrivWithSym;
+Java_org_mozilla_jss_pkcs11_PK11KeyWrapper_nativeWrapSymWithPub;
+Java_org_mozilla_jss_pkcs11_PK11KeyWrapper_nativeWrapSymWithSym;
+Java_org_mozilla_jss_pkcs11_PK11MessageDigest_digest;
+Java_org_mozilla_jss_pkcs11_PK11MessageDigest_initDigest;
+Java_org_mozilla_jss_pkcs11_PK11MessageDigest_initHMAC;
+Java_org_mozilla_jss_pkcs11_PK11MessageDigest_update;
+Java_org_mozilla_jss_pkcs11_PK11PrivKey_getKeyType;
+Java_org_mozilla_jss_pkcs11_PK11PrivKey_getOwningToken;
+Java_org_mozilla_jss_pkcs11_PK11PrivKey_getStrength;
+Java_org_mozilla_jss_pkcs11_PK11PrivKey_getUniqueID;
+Java_org_mozilla_jss_pkcs11_PK11PrivKey_verifyKeyIsOnToken;
+Java_org_mozilla_jss_pkcs11_PK11PubKey_DSAFromRaw;
+Java_org_mozilla_jss_pkcs11_PK11PubKey_RSAFromRaw;
+Java_org_mozilla_jss_pkcs11_PK11PubKey_getEncoded;
+Java_org_mozilla_jss_pkcs11_PK11PubKey_getKeyType;
+Java_org_mozilla_jss_pkcs11_PK11PubKey_verifyKeyIsOnToken;
+Java_org_mozilla_jss_pkcs11_PK11SymKey_getKeyData;
+Java_org_mozilla_jss_pkcs11_PK11SymKey_getKeyType;
+Java_org_mozilla_jss_pkcs11_PK11SymKey_getOwningToken;
+Java_org_mozilla_jss_pkcs11_PK11SymKey_getStrength;
+Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateDSAKeyPair;
+Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateRSAKeyPair;
+Java_org_mozilla_jss_pkcs11_PK11KeyGenerator_generateNormal;
+Java_org_mozilla_jss_pkcs11_PK11KeyGenerator_generatePBE;
+Java_org_mozilla_jss_pkcs11_PK11KeyGenerator_generatePBE_1IV;
+Java_org_mozilla_jss_pkcs11_PK11KeyGenerator_nativeClone;
+Java_org_mozilla_jss_pkcs11_PrivateKeyProxy_releaseNativeResources;
+Java_org_mozilla_jss_pkcs11_PublicKeyProxy_releaseNativeResources;
+Java_org_mozilla_jss_pkcs11_SymKeyProxy_releaseNativeResources;
+Java_org_mozilla_jss_pkcs11_PK11Token_PWInitable;
+Java_org_mozilla_jss_pkcs11_PK11Token_SSOPasswordIsCorrect;
+Java_org_mozilla_jss_pkcs11_PK11Token_changePassword;
+Java_org_mozilla_jss_pkcs11_PK11Token_doesAlgorithm;
+Java_org_mozilla_jss_pkcs11_PK11Token_generatePK10;
+Java_org_mozilla_jss_pkcs11_PK11Token_getLoginMode;
+Java_org_mozilla_jss_pkcs11_PK11Token_getLoginTimeoutMinutes;
+Java_org_mozilla_jss_pkcs11_PK11Token_getName;
+Java_org_mozilla_jss_pkcs11_PK11Token_initPassword;
+Java_org_mozilla_jss_pkcs11_PK11Token_isLoggedIn;
+Java_org_mozilla_jss_pkcs11_PK11Token_isPresent;
+Java_org_mozilla_jss_pkcs11_PK11Token_isWritable;
+Java_org_mozilla_jss_pkcs11_PK11Token_logout;
+Java_org_mozilla_jss_pkcs11_PK11Token_nativeLogin;
+Java_org_mozilla_jss_pkcs11_PK11Token_passwordIsInitialized;
+Java_org_mozilla_jss_pkcs11_PK11Token_setLoginMode;
+Java_org_mozilla_jss_pkcs11_PK11Token_setLoginTimeoutMinutes;
+Java_org_mozilla_jss_pkcs11_PK11Token_userPasswordIsCorrect;
+Java_org_mozilla_jss_pkcs11_TokenProxy_releaseNativeResources;
+Java_org_mozilla_jss_pkcs11_PK11Signature_engineRawSignNative;
+Java_org_mozilla_jss_pkcs11_PK11Signature_engineRawVerifyNative;
+Java_org_mozilla_jss_pkcs11_PK11Signature_engineSignNative;
+Java_org_mozilla_jss_pkcs11_PK11Signature_engineUpdateNative;
+Java_org_mozilla_jss_pkcs11_PK11Signature_engineVerifyNative;
+Java_org_mozilla_jss_pkcs11_PK11Signature_initSigContext;
+Java_org_mozilla_jss_pkcs11_PK11Signature_initVfyContext;
+Java_org_mozilla_jss_pkcs11_PK11Store_deleteCert;
+Java_org_mozilla_jss_pkcs11_PK11Store_deletePrivateKey;
+Java_org_mozilla_jss_pkcs11_PK11Store_importPrivateKey;
+Java_org_mozilla_jss_pkcs11_PK11Store_putCertsInVector;
+Java_org_mozilla_jss_pkcs11_PK11Store_putKeysInVector;
+Java_org_mozilla_jss_pkcs11_PK11Store_putSymKeysInVector;
+Java_org_mozilla_jss_pkcs11_PK11Store_putSymKeysInVector;
+Java_org_mozilla_jss_pkcs11_SigContextProxy_releaseNativeResources;
+Java_org_mozilla_jss_pkcs11_PK11RSAPublicKey_getModulusByteArray;
+Java_org_mozilla_jss_pkcs11_PK11RSAPublicKey_getPublicExponentByteArray;
+Java_org_mozilla_jss_pkcs11_PK11DSAPublicKey_getGByteArray;
+Java_org_mozilla_jss_pkcs11_PK11DSAPublicKey_getPByteArray;
+Java_org_mozilla_jss_pkcs11_PK11DSAPublicKey_getQByteArray;
+Java_org_mozilla_jss_pkcs11_PK11DSAPublicKey_getYByteArray;
+Java_org_mozilla_jss_pkcs11_PK11SecureRandom_nextBytes;
+Java_org_mozilla_jss_pkcs11_PK11SecureRandom_setSeed;
+Java_org_mozilla_jss_ssl_SSLServerSocket_clearSessionCache;
+Java_org_mozilla_jss_ssl_SSLServerSocket_configServerSessionIDCache;
+Java_org_mozilla_jss_ssl_SSLServerSocket_setServerCertNickname;
+Java_org_mozilla_jss_ssl_SSLServerSocket_socketAccept;
+Java_org_mozilla_jss_ssl_SSLServerSocket_socketListen;
+Java_org_mozilla_jss_ssl_SSLSocket_forceHandshake;
+Java_org_mozilla_jss_ssl_SSLSocket_getKeepAlive;
+Java_org_mozilla_jss_ssl_SSLSocket_getLocalAddressNative;
+Java_org_mozilla_jss_ssl_SocketBase_getLocalAddressByteArrayNative;
+Java_org_mozilla_jss_ssl_SSLSocket_getPort;
+Java_org_mozilla_jss_ssl_SSLSocket_getReceiveBufferSize;
+Java_org_mozilla_jss_ssl_SSLSocket_getSendBufferSize;
+Java_org_mozilla_jss_ssl_SSLSocket_getSoLinger;
+Java_org_mozilla_jss_ssl_SSLSocket_getStatus;
+Java_org_mozilla_jss_ssl_SSLSocket_getTcpNoDelay;
+Java_org_mozilla_jss_ssl_SSLSocket_invalidateSession;
+Java_org_mozilla_jss_ssl_SSLSocket_redoHandshake;
+Java_org_mozilla_jss_ssl_SSLSocket_resetHandshakeNative;
+Java_org_mozilla_jss_ssl_SSLSocket_setCipherPolicyNative;
+Java_org_mozilla_jss_ssl_SSLSocket_setCipherPreference;
+Java_org_mozilla_jss_ssl_SSLSocket_setKeepAlive;
+Java_org_mozilla_jss_ssl_SSLSocket_setReceiveBufferSize;
+Java_org_mozilla_jss_ssl_SSLSocket_setSSLDefaultOption;
+Java_org_mozilla_jss_ssl_SSLSocket_setSendBufferSize;
+Java_org_mozilla_jss_ssl_SSLSocket_setSoLinger;
+Java_org_mozilla_jss_ssl_SSLSocket_setTcpNoDelay;
+Java_org_mozilla_jss_ssl_SSLSocket_shutdownNative;
+Java_org_mozilla_jss_ssl_SSLSocket_socketAvailable;
+Java_org_mozilla_jss_ssl_SSLSocket_socketConnect;
+Java_org_mozilla_jss_ssl_SSLSocket_socketRead;
+Java_org_mozilla_jss_ssl_SSLSocket_socketWrite;
+Java_org_mozilla_jss_ssl_SocketBase_getLocalPortNative;
+Java_org_mozilla_jss_ssl_SocketBase_getPeerAddressNative;
+Java_org_mozilla_jss_ssl_SocketBase_getPeerAddressByteArrayNative;
+Java_org_mozilla_jss_ssl_SocketBase_setClientCertNicknameNative;
+Java_org_mozilla_jss_ssl_SocketBase_requestClientAuthNoExpiryCheckNative;
+Java_org_mozilla_jss_ssl_SocketBase_setSSLOption;
+Java_org_mozilla_jss_ssl_SocketBase_socketBind;
+Java_org_mozilla_jss_ssl_SocketBase_socketClose;
+Java_org_mozilla_jss_ssl_SocketBase_socketCreate;
+Java_org_mozilla_jss_util_Password_readPasswordFromConsole;
+#
+# Data objects (NONE)
+#
+#
+# commands (NONE)
+#
+#
+    local:
+       *;
+};
+JSS_3.1 {       # JSS 3.1 release
+    global:
+Java_org_mozilla_jss_pkcs11_PK11KeyWrapper_nativeUnwrapSymPlaintext;
+Java_org_mozilla_jss_pkcs11_PK11Store_getEncryptedPrivateKeyInfo;
+    local:
+       *;
+};
+JSS_3.1.1 {       # JSS 3.1.1 release
+    global:
+Java_org_mozilla_jss_ssl_SSLServerSocket_setReuseAddress;
+Java_org_mozilla_jss_ssl_SSLServerSocket_getReuseAddress;
+    local:
+       *;
+};
+JSS_3.2 {       # JSS 3.2 release
+    global:
+Java_org_mozilla_jss_crypto_SecretDecoderRing_encrypt;
+Java_org_mozilla_jss_crypto_SecretDecoderRing_decrypt;
+Java_org_mozilla_jss_pkcs11_PK11PrivKey_fromPrivateKeyInfo;
+Java_org_mozilla_jss_pkcs11_PK11PubKey_fromRawNative;
+Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_getRawAliases;
+Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineDeleteEntry;
+Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_getDERCert;
+Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_getCertNickname;
+Java_org_mozilla_jss_pkcs11_PK11PubKey_fromSPKI;
+Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineGetKey;
+Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineIsCertificateEntry;
+Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineSetKeyEntryNative;
+Java_org_mozilla_jss_CryptoManager_initializeAllNative2;
+Java_org_mozilla_jss_ssl_SocketBase_getLocalAddressNative;
+Java_org_mozilla_jss_pkcs11_PK11PrivKey_getDSAParamsNative;
+Java_org_mozilla_jss_CryptoManager_verifyCertNowNative;
+Java_org_mozilla_jss_ssl_SSLServerSocket_setServerCert;
+Java_org_mozilla_jss_ssl_SocketBase_setClientCert;
+Java_org_mozilla_jss_CryptoManager_verifyCertTempNative;
+Java_org_mozilla_jss_ssl_SocketProxy_releaseNativeResources;
+    local:
+       *;
+};
+JSS_3.3 {       # JSS 3.3 release
+    global:
+Java_org_mozilla_jss_ssl_SSLSocket_getImplementedCipherSuites;
+Java_org_mozilla_jss_ssl_SSLSocket_getCipherPreferenceDefault;
+Java_org_mozilla_jss_ssl_SSLSocket_setCipherPreferenceDefault;
+Java_org_mozilla_jss_ssl_SSLSocket_getCipherPreference;
+Java_org_mozilla_jss_CryptoManager_configureOCSPNative;
+Java_org_mozilla_jss_pkcs11_PK11SymKey_getLength;
+Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_getCertObject;
+Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineGetKeyNative;
+Java_org_mozilla_jss_SecretDecoderRing_KeyManager_generateKeyNative;
+Java_org_mozilla_jss_SecretDecoderRing_KeyManager_lookupKeyNative;
+Java_org_mozilla_jss_SecretDecoderRing_KeyManager_deleteKeyNative;
+    local:
+       *;
+};
+JSS_3.4 {       # JSS 3.4 release
+    global:
+Java_org_mozilla_jss_pkcs11_PK11Cipher_initContextWithKeyBits;
+    local:
+       *;
+};
+JSS_3.5 {       # JSS 3.5 release
+    global:
+Java_org_mozilla_jss_SecretDecoderRing_KeyManager_generateUniqueNamedKeyNative;
+Java_org_mozilla_jss_SecretDecoderRing_KeyManager_lookupUniqueNamedKeyNative;
+    local:
+       *;
+};
+JSS_4.1 {       # JSS 4.1 release
+    global:
+Java_org_mozilla_jss_ssl_SSLSocket_abortReadWrite;
+Java_org_mozilla_jss_ssl_SSLServerSocket_abortAccept;
+    local:
+       *;
+};
+JSS_4.2 {       # JSS 4.2 release
+    global:
+Java_org_mozilla_jss_ssl_SocketBase_getSSLOption;
+Java_org_mozilla_jss_ssl_SSLSocket_getSSLDefaultOption;
+Java_org_mozilla_jss_pkcs11_PK11Store_deleteCertOnly;
+    local:
+       *;
+};
+JSS_4.2.3 {     # JSS 4.2.3 release
+    global:
+Java_org_mozilla_jss_pkcs11_PK11ECPublicKey_getCurveByteArray;
+Java_org_mozilla_jss_pkcs11_PK11ECPublicKey_getWByteArray;
+Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateECKeyPair;
+    local:
+       *;
+};
+JSS_4.2.5 {     # JSS 4.2.5 release
+    global:
+Java_org_mozilla_jss_ssl_SSLSocket_setSSLDefaultOptionMode;
+Java_org_mozilla_jss_ssl_SocketBase_setSSLOptionMode;
+Java_org_mozilla_jss_ssl_SSLSocket_isFipsCipherSuiteNative;
+    local:
+       *;
+};
+JSS_4.3 {     # JSS 4.3 release
+    global:
+Java_org_mozilla_jss_pkcs11_PK11Token_needsLogin;
+    local:
+       *;
+};
+JSS_4.2.6 {     # JSS 4.2.6 release
+    global:
+Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateECKeyPairWithOpFlags;
+Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateRSAKeyPairWithOpFlags;
+Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateDSAKeyPairWithOpFlags;
+Java_org_mozilla_jss_CryptoManager_OCSPCacheSettingsNative;
+Java_org_mozilla_jss_CryptoManager_setOCSPTimeoutNative;
+Java_org_mozilla_jss_CryptoManager_verifyCertificateNowNative;
+Java_org_mozilla_jss_CryptoManager_verifyCertificateNowNative2;
+Java_org_mozilla_jss_CryptoManager_verifyCertificateNowCUNative;
+Java_org_mozilla_jss_asn1_ASN1Util_getTagDescriptionByOid;
+Java_org_mozilla_jss_ssl_SocketBase_setSSLVersionRange;
+Java_org_mozilla_jss_ssl_SSLSocket_setSSLVersionRangeDefault;
+Java_org_mozilla_jss_pkcs11_PK11SymmetricKeyDeriver_nativeDeriveSymKey;
+Java_org_mozilla_jss_pkcs11_PK11SymKey_setNickNameNative;
+    local:
+       *;
+};
+JSS_4.3.1 {     # JSS 4.3.1 release
+    global:
+Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateECKeyPairWithOpFlags;
+Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateRSAKeyPairWithOpFlags;
+Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateDSAKeyPairWithOpFlags;
+Java_org_mozilla_jss_CryptoManager_OCSPCacheSettingsNative;
+Java_org_mozilla_jss_CryptoManager_setOCSPTimeoutNative;
+Java_org_mozilla_jss_pkcs11_PK11SymmetricKeyDeriver_nativeDeriveSymKey;
+Java_org_mozilla_jss_pkcs11_PK11SymKey_setNickNameNative;
+    local:
+       *;
+};
+JSS_4.4.1 {     # JSS 4.4.1 release
+    global:
+Java_org_mozilla_jss_pkcs11_PK11Store_importEncryptedPrivateKeyInfo;
+    local:
+       *;
+};
+JSS_4.5 {       # JSS 4.5 release
+    global:
+Java_org_mozilla_jss_pkcs11_PK11RSAPrivateKey_getModulusByteArray;
+Java_org_mozilla_jss_pkcs11_PK11Token_importPublicKey;
+Java_org_mozilla_jss_pkcs11_PK11Store_loadPrivateKeys;
+Java_org_mozilla_jss_pkcs11_PK11Store_loadPublicKeys;
+Java_org_mozilla_jss_pkcs11_PK11Store_deletePublicKey;
+Java_org_mozilla_jss_ssl_SSLSocket_boundSSLVersionRange;
+    local:
+       *;
+};
+JSS_4.5.1 {
+    global:
+Java_org_mozilla_jss_CryptoManager_getJSSMajorVersion;
+Java_org_mozilla_jss_CryptoManager_getJSSMinorVersion;
+Java_org_mozilla_jss_CryptoManager_getJSSPatchVersion;
+    local:
+       *;
+};


### PR DESCRIPTION
In preparation for the new CMake build system, introduce two new files
to the `lib/` directory. The `MANIFEST.MF.in` is used to generate the
`META-INF/MANIFEST.MF` file in the JSS JAR, and `jss.map` is used as the
linker version script when building the JSS library.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`