### PR TITLE
Add ClientAuth tests to ctest

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -199,4 +199,8 @@ macro(jss_config_java)
     # updated whenever a new package is created.
     set(JSS_WINDOW_TITLE "JSS: Java Security Services")
     set(JSS_PACKAGES "org.mozilla.jss;org.mozilla.jss.asn1;org.mozilla.jss.crypto;org.mozilla.jss.pkcs7;org.mozilla.jss.pkcs10;org.mozilla.jss.pkcs11;org.mozilla.jss.pkcs12;org.mozilla.jss.pkix.primitive;org.mozilla.jss.pkix.cert;org.mozilla.jss.pkix.cmc;org.mozilla.jss.pkix.cmmf;org.mozilla.jss.pkix.cms;org.mozilla.jss.pkix.crmf;org.mozilla.jss.provider.java.security;org.mozilla.jss.provider.javax.crypto;org.mozilla.jss.SecretDecoderRing;org.mozilla.jss.ssl;org.mozilla.jss.tests;org.mozilla.jss.util")
+
+    set(JSS_BASE_PORT 2876)
+    math(EXPR JSS_TEST_PORT_CLIENTAUTH ${JSS_BASE_PORT}+0)
+    math(EXPR JSS_TEST_PORT_CLIENTAUTH_FIPS ${JSS_BASE_PORT}+1)
 endmacro()

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -64,6 +64,11 @@ macro(jss_tests)
         DEPENDS "Generate_known_DSS_cert_pair"
     )
     jss_test_java(
+        NAME "SSLClientAuth"
+        COMMAND "org.mozilla.jss.tests.SSLClientAuth" "${RESULTS_OUTPUT_DIR}" "${PASSWORD_FILE}" "${JSS_TEST_PORT_CLIENTAUTH}" "50"
+        DEPENDS "List_CA_certs"
+    )
+    jss_test_java(
         NAME "Key_Generation"
         COMMAND "org.mozilla.jss.tests.TestKeyGen" "${RESULTS_OUTPUT_DIR}" "${PASSWORD_FILE}"
         DEPENDS "Setup_DBs"
@@ -146,6 +151,11 @@ macro(jss_tests)
         DEPENDS "Enable_FipsMODE"
     )
     jss_test_java(
+        NAME "SSLClientAuth_FIPSMODE"
+        COMMAND "org.mozilla.jss.tests.SSLClientAuth" "${RESULTS_FIPS_OUTPUT_DIR}" "${PASSWORD_FILE}" "${JSS_TEST_PORT_CLIENTAUTH_FIPS}" "60"
+        DEPENDS "Enable_FipsMODE"
+    )
+    jss_test_java(
         NAME "HMAC_FIPSMODE"
         COMMAND "org.mozilla.jss.tests.HMACTest" "${RESULTS_FIPS_OUTPUT_DIR}" "${PASSWORD_FILE}"
         DEPENDS "Enable_FipsMODE"
@@ -172,7 +182,7 @@ macro(jss_tests)
     jss_test_java(
         NAME "Disable_FipsMODE"
         COMMAND "org.mozilla.jss.tests.FipsTest" "${RESULTS_FIPS_OUTPUT_DIR}" "disable"
-        DEPENDS "check_FipsMODE" "HMAC_FIPSMODE" "KeyWrapping_FIPSMODE" "Mozilla_JSS_JCA_Signature_FIPSMODE" "JSS_Signature_test_FipsMODE"
+        DEPENDS "check_FipsMODE" "SSLClientAuth_FIPSMODE" "HMAC_FIPSMODE" "KeyWrapping_FIPSMODE" "Mozilla_JSS_JCA_Signature_FIPSMODE" "JSS_Signature_test_FipsMODE"
     )
 
     # For compliance with several


### PR DESCRIPTION
Note that, per [jss issue#30](https://pagure.io/jss/issue/30), these fail under `FUTURE` crypto policy. 

Adds SSLClientAuth tests to the ctest test suite. These were present in `all.pl` at time of moving to CMake, but weren't yet added. This adds them back in.

Note that this PR is dependent upon #84, and includes commits in that PR.