### PR TITLE
Refactor CMake to support building other C targets

### DIFF
--- a/cmake/JSSCommon.cmake
+++ b/cmake/JSSCommon.cmake
@@ -79,7 +79,7 @@ macro(jss_build_c_file C_FILE C_OUTPUT C_TARGET C_DIR)
     # finished, else many headers wouldn't exist.
     add_custom_command(
         OUTPUT "${C_OUTPUT}"
-        COMMAND ${CMAKE_C_COMPILER} ${JSS_C_FLAGS} -o ${C_OUTPUT} ${C_FILE}
+        COMMAND ${CMAKE_C_COMPILER} -fPIC ${JSS_C_FLAGS} -o ${C_OUTPUT} -c ${C_FILE}
         WORKING_DIRECTORY ${C_DIR}
         DEPENDS ${C_FILE}
         DEPENDS generate_java
@@ -118,7 +118,7 @@ macro(jss_build_c)
 
     add_custom_command(
         OUTPUT "${JSS_SO_PATH}"
-        COMMAND ${CMAKE_C_COMPILER} -o ${JSS_SO_PATH} ${LIB_OUTPUT_DIR}/*.o ${JSS_LD_FLAGS}
+        COMMAND ${CMAKE_C_COMPILER} -o ${JSS_SO_PATH} ${LIB_OUTPUT_DIR}/*.o ${JSS_LD_FLAGS} ${JSS_LIBRARY_FLAGS}
         DEPENDS generate_c
     )
 

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -93,13 +93,10 @@ macro(jss_config_cflags)
 
     # This list of C flags was taken from the original build scripts for
     # debug and release builds.
-    list(APPEND JSS_RAW_C_FLAGS "-c")
     list(APPEND JSS_RAW_C_FLAGS "-g")
-    list(APPEND JSS_RAW_C_FLAGS "-fPIC")
     list(APPEND JSS_RAW_C_FLAGS "-Wall")
     list(APPEND JSS_RAW_C_FLAGS "-Werror-implicit-function-declaration")
     list(APPEND JSS_RAW_C_FLAGS "-Wno-switch")
-    list(APPEND JSS_RAW_C_FLAGS "-pipe")
     list(APPEND JSS_RAW_C_FLAGS "-I${NSPR_INCLUDE_DIR}")
     list(APPEND JSS_RAW_C_FLAGS "-I${NSS_INCLUDE_DIR}")
     list(APPEND JSS_RAW_C_FLAGS "-I${INCLUDE_OUTPUT_DIR}")
@@ -131,11 +128,6 @@ macro(jss_config_ldflags)
     # This list of C linker flags was taken from the original build scripts
     # for debug and release builds. We lack a "check_c_linker_flag" macro,
     # so no effort is made to validate these flags.
-    list(APPEND JSS_LD_FLAGS "-shared")
-    list(APPEND JSS_LD_FLAGS "-Wl,-z,defs")
-    list(APPEND JSS_LD_FLAGS "-Wl,-soname")
-    list(APPEND JSS_LD_FLAGS "-Wl,${JSS_SO}")
-    list(APPEND JSS_LD_FLAGS "-Wl,--version-script,${PROJECT_SOURCE_DIR}/lib/jss.map")
     list(APPEND JSS_LD_FLAGS "-lsmime3")
     list(APPEND JSS_LD_FLAGS "-lssl3")
     list(APPEND JSS_LD_FLAGS "-lnss3")
@@ -145,6 +137,13 @@ macro(jss_config_ldflags)
     list(APPEND JSS_LD_FLAGS "-lnspr4")
     list(APPEND JSS_LD_FLAGS "-lpthread")
     list(APPEND JSS_LD_FLAGS "-ldl")
+
+    # This set of flags is specific to building the libjss library.
+    list(APPEND JSS_LIBRARY_FLAGS "-shared")
+    list(APPEND JSS_LIBRARY_FLAGS "-Wl,-z,defs")
+    list(APPEND JSS_LIBRARY_FLAGS "-Wl,-soname")
+    list(APPEND JSS_LIBRARY_FLAGS "-Wl,${JSS_SO}")
+    list(APPEND JSS_LIBRARY_FLAGS "-Wl,--version-script,${PROJECT_SOURCE_DIR}/lib/jss.map")
 endmacro()
 
 macro(jss_config_java)


### PR DESCRIPTION
In preparation for a C language test, this refactors CMake so that it
can support building other C targets besides the `libjss4.so` library.
This will allow us to build stand-alone executables which don't depend
on `libjss4.so` but could depend on the NSS/NSPR libraries.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`