### PR TITLE
Implement a NSPR PRFileDesc using buffers - 0:1

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -162,6 +162,11 @@ macro(jss_tests)
         COMMAND "org.mozilla.jss.tests.SSLClientAuth" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}" "${JSS_TEST_PORT_CLIENTAUTH}" "50"
         DEPENDS "List_CA_certs"
     )
+    jss_test_exec(
+        NAME "TestBufferPRFD"
+        COMMAND "${BIN_OUTPUT_DIR}/TestBufferPRFD" "${RESULTS_NSSDB_OUTPUT_DIR}" "${DB_PWD}"
+        DEPENDS "List_CA_certs" "generate_c_TestBufferPRFD"
+    )
     jss_test_java(
         NAME "Key_Generation"
         COMMAND "org.mozilla.jss.tests.TestKeyGen" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
@@ -306,6 +311,7 @@ endmacro()
 macro(jss_tests_compile)
     jss_tests_compile_c("${PROJECT_SOURCE_DIR}/org/mozilla/jss/tests/buffer_size_1.c" "${BIN_OUTPUT_DIR}/buffer_size_1" "buffer_size_1")
     jss_tests_compile_c("${PROJECT_SOURCE_DIR}/org/mozilla/jss/tests/buffer_size_4.c" "${BIN_OUTPUT_DIR}/buffer_size_4" "buffer_size_4")
+    jss_tests_compile_c("${PROJECT_SOURCE_DIR}/org/mozilla/jss/tests/TestBufferPRFD.c" "${BIN_OUTPUT_DIR}/TestBufferPRFD" "TestBufferPRFD")
 endmacro()
 
 macro(jss_tests_compile_c C_FILE C_OUTPUT C_TARGET)

--- a/org/mozilla/jss/ssl/javax/BufferPRFD.c
+++ b/org/mozilla/jss/ssl/javax/BufferPRFD.c
@@ -1,0 +1,326 @@
+#include <nspr.h>
+
+/* Necessary for correctly propagating E_WOULDBLOCK. */
+#include <errno.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+/* Ring buffer implementation to handle read/write calls. */
+#include "buffer.h"
+#include "BufferPRFD.h"
+
+/* This struct stores all the private data we need access to from inside our
+ * PRFileDesc calls. We store the following information:
+ *
+ *      read_bytes -- raw buffer to read from for recv(...) calls
+ *      read_capacity -- size of read_bytes buffer
+ *      read_ptr -- location after the last character in the buffer;
+ *                  i.e., location to place the next character if writing.
+ *
+ *      write_bytes -- raw buffer to write to for send(...) calls
+ *      write_capacity -- size of write_bytes buffer
+ *      write_ptr -- location after the last character in the buffer;
+ *                   i.e., location to place the next character if writing.
+ *
+ *      peer_addr -- peer address info, truncated to 16 bytes
+ *
+ * As the read_* and write_* members should be provided by the creator, and
+ * actors outside our PRFileDesc need access to this information (to add more
+ * bytes to the read buffer when more data arrives for instance), we store
+ * pointers and not the values themselves.
+ *
+ * The creator is responsible for ensuring that all data gets correctly freed
+ * when the program exits; we will not free any of our pointers that were not
+ * created by us.
+ */
+struct PRFilePrivate {
+    j_buffer *read_buffer;
+    j_buffer *write_buffer;
+
+    uint8_t *peer_addr;
+};
+
+// This function is provided as a stub for all unimplemented calls.
+static PRIntn invalidInternalCall(/* anything */)
+{
+    // For debugging; any invalid calls are asserted, so we can get a full
+    // backtrace from the debugger and _hopefully_ we can find out which call
+    // was attempted. To enable asserts, define DEBUG or FORCE_PR_ASSERT
+    // before loading the NSPR headers, e.g., by using the DEBUG release type
+    // during CMake configuration time.
+    PR_ASSERT(!"invalidInternalCall performed!");
+    return 0;
+}
+
+// This function mimics shutting down a buffer.
+static PRStatus PRBufferShutdown(PRFileDesc *fd, PRIntn how)
+{
+    // This method has no functionality; we're a lower level under both
+    // the SSLEngine and NSS's SSL context. When the application issues
+    // a shutdown request, SSLEngine refuses to allow new writes (and only
+    // reads until the remote party acknowledges the shutdown). All data
+    // should be written into the NSS connection buffer and NSS's shutdown
+    // should be called. At this point, there's nothing left for us to do:
+    // there's no TCP socket we need to terminate, and we need to allow
+    // any remaining buffered bytes to be written. So, the only thing we
+    // can do is return success here.
+    return PR_SUCCESS;
+}
+
+// This function mimics closing a buffer and frees our associated data.
+static PRStatus PRBufferClose(PRFileDesc *fd)
+{
+    if (fd->secret != NULL) {
+        // We intentionally don't free read_buffer or write_buffer; we assume
+        // the caller has a copy of these data structures as well, and could
+        // still be reading after the PRFileDesc is closed.
+        fd->secret->read_buffer = NULL;
+        fd->secret->write_buffer = NULL;
+
+        // Free the peer address we allocated during initialiation.
+        free(fd->secret->peer_addr);
+        fd->secret->peer_addr = NULL;
+
+        // Free our internal data structure.
+        free(fd->secret);
+        fd->secret = NULL;
+    }
+
+    fd->secret = NULL;
+    return PR_SUCCESS;
+}
+
+// Fake getting the name of the remote peer
+static PRStatus PRBufferGetPeerName(PRFileDesc *fd, PRNetAddr *addr)
+{
+    /* getPeerName takes a PRFileDesc and modifies the PRNetAddr with the
+     * name of the peer. Because of the specifics of the NSS Implementation,
+     * we return whatever name was passed to us on creation; we lack a real
+     * TCP socket and thus a real TCP name.
+     *
+     * However, we have to provide the peer name as type IPv6, else it either
+     * gets mangled by the IPv4 -> IPv6 translation or a
+     * PR_ADDRESS_NOT_SUPPORTED_ERROR is thrown by ssl_GetPeerInfo(...).
+     */
+
+    /* There are three main places this is called in a normal TLS connection:
+     *
+     *      ssl_ImportFD(...) -- where the result of this function is compared
+     *                           to PR_SUCCESS to see if it is connected
+     *      ssl_BeginClientHandshake(...) -- where this function sets local
+     *                                       values for session resumption on
+     *                                       the client
+     *      ssl3_HandleClientHello(...) -- where this function sets local
+     *                                     values for evaluating session
+     *                                     resumption from the client.
+     *
+     * Because these results have to be consistent for session resumption to
+     * work, we must query the internal structure and return that value.
+     * Note that it isn't a security risk if an incorrect peer_addr is
+     * provided to us: the other party must _also_ know the session keys for
+     * this to matter.
+     */
+
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR/Reference/PRNetAddr
+    if (fd->secret == NULL || addr == NULL) {
+        return PR_FAILURE;
+    }
+
+    PRFilePrivate *internal = fd->secret;
+    addr->ipv6.family = PR_AF_INET6;
+    addr->ipv6.port = 0xFFFF;
+    addr->ipv6.flowinfo = 0x00000000;
+
+    // We validate that strlen(peer_addr) <= 16 on creation by truncating
+    // it to 16 bytes. Thus the memcpy with strlen(...) won't overflow the
+    // size of ipv6.ip.
+    memset(&addr->ipv6.ip, 0, 16);
+    memcpy(&addr->ipv6.ip, internal->peer_addr, 16);
+    return PR_SUCCESS;
+}
+
+// Respond to send requests
+static PRInt32 PRBufferSend(PRFileDesc *fd, const void *buf, PRInt32 amount,
+        PRIntn flags, PRIntervalTime timeout)
+{
+    /* Send takes a PRFileDesc and attempts to send some amount of bytes from
+     * the start of buf to the other party before timeout is reached. Because
+     * we're implementing this as a buffer, copy into the buffer if there is
+     * free space, else return EWOULDBLOCK.  */
+
+    PRFilePrivate *internal = fd->secret;
+
+    if (!jb_can_write(internal->write_buffer)) {
+        /* Under correct Unix non-blocking socket semantics, if we lack data
+         * to read, return a negative length and set EWOULDBLOCK. This is
+         * documented in `man 2 recv`. */
+        PR_SetError(PR_WOULD_BLOCK_ERROR, EWOULDBLOCK);
+        return -1;
+    }
+
+    /* By checking if we can write, we ensure we don't return 0 from
+     * jb_write(...); otherwise, we'd violate non-blocking socket
+     * semantics. */
+    return jb_write(internal->write_buffer, (uint8_t*) buf, amount);
+}
+
+// Respond to recv requests
+static PRInt32 PRBufferRecv(PRFileDesc *fd, void *buf, PRInt32 amount, PRIntn flags, PRIntervalTime timeout)
+{
+    /* Recv takes a PRFileDesc and attempts to read some amount of bytes from
+     * the start of buf to return to the caller before timeout is reached.
+     * Because we're implementing this as a buffer, copy from the buffer when
+     * there is something in it, else return EWOULDBLOCK. */
+    PRFilePrivate *internal = fd->secret;
+
+    if (!jb_can_read(internal->read_buffer)) {
+        /* See comment in PRBufferSend about EWOULDBLOCK. */
+        PR_SetError(PR_WOULD_BLOCK_ERROR, EWOULDBLOCK);
+        return -1;
+    }
+
+    /* By checking if we can read, we ensure we don't return 0 from
+     * jb_read(...); otherwise, we'd violate non-blocking socket
+     * semantics. */
+    return jb_read(internal->read_buffer, (uint8_t*) buf, amount);
+}
+
+// Fake responses to getSocketOption requests
+static PRStatus PRBufferGetSocketOption(PRFileDesc *fd, PRSocketOptionData *data)
+{
+    /* getSocketOption takes a PRFileDesc and modifies the PRSocketOptionData
+     * with the options on this. We set a couple of sane defaults here:
+     *
+     *   non_blocking = true
+     *   reuse_addr = true
+     *   keep_alive = false
+     *   no_delay = true
+     *
+     * However the list above is far fom extensive. Note that responses are
+     * "fake" in that calls to setSocketOption fail to reflect here.
+     */
+
+    if (data) {
+        PRFilePrivate *internal = fd->secret;
+
+        data->value.non_blocking = PR_TRUE;
+        data->value.reuse_addr = PR_TRUE;
+        data->value.keep_alive = PR_FALSE;
+        data->value.mcast_loopback = PR_FALSE;
+        data->value.no_delay = PR_TRUE;
+        data->value.max_segment = jb_capacity(internal->read_buffer);
+        data->value.recv_buffer_size = jb_capacity(internal->read_buffer);
+        data->value.send_buffer_size = jb_capacity(internal->write_buffer);
+
+        return PR_SUCCESS;
+    }
+
+    return PR_FAILURE;
+}
+
+// Fake responses to setSocketOption
+static PRStatus PRBufferSetSocketOption(PRFileDesc *fd, const PRSocketOptionData *data)
+{
+    /* This gives the caller control over setting socket options. It is the
+     * equivalent of fcntl() with F_SETFL. In our case, O_NONBLOCK is the
+     * only thing passed in, which we always return as true anyways, so
+     * ignore the result. */
+    return PR_SUCCESS;
+}
+
+// Create a method table with all our implemented functions
+static const PRIOMethods PRIOBufferMethods = {
+    PR_DESC_SOCKET_TCP,
+    PRBufferClose,
+    (PRReadFN)invalidInternalCall,
+    (PRWriteFN)invalidInternalCall,
+    (PRAvailableFN)invalidInternalCall,
+    (PRAvailable64FN)invalidInternalCall,
+    (PRFsyncFN)invalidInternalCall,
+    (PRSeekFN)invalidInternalCall,
+    (PRSeek64FN)invalidInternalCall,
+    (PRFileInfoFN)invalidInternalCall,
+    (PRFileInfo64FN)invalidInternalCall,
+    (PRWritevFN)invalidInternalCall,
+    (PRConnectFN)invalidInternalCall,
+    (PRAcceptFN)invalidInternalCall,
+    (PRBindFN)invalidInternalCall,
+    (PRListenFN)invalidInternalCall,
+    PRBufferShutdown,
+    PRBufferRecv,
+    PRBufferSend,
+    (PRRecvfromFN)invalidInternalCall,
+    (PRSendtoFN)invalidInternalCall,
+    (PRPollFN)invalidInternalCall,
+    (PRAcceptreadFN)invalidInternalCall,
+    (PRTransmitfileFN)invalidInternalCall,
+    (PRGetsocknameFN)invalidInternalCall,
+    PRBufferGetPeerName,
+    (PRReservedFN)invalidInternalCall,
+    (PRReservedFN)invalidInternalCall,
+    PRBufferGetSocketOption,
+    PRBufferSetSocketOption,
+    (PRSendfileFN)invalidInternalCall,
+    (PRConnectcontinueFN)invalidInternalCall,
+    (PRReservedFN)invalidInternalCall,
+    (PRReservedFN)invalidInternalCall,
+    (PRReservedFN)invalidInternalCall,
+    (PRReservedFN)invalidInternalCall
+};
+
+/* Free a Buffer-backed PRFileDesc. Note that it is usually sufficient to call
+ * PR_Close(...) on the buffer instead. This is provided for completeness and
+ * should not be called in a SSL context as the buffer PRFileDesc is wrapped
+ * by the SSL PRFileDesc. Note that this only removes references to the
+ * underlying j_buffers and does not free them; it is up to the caller to
+ * do so. */
+void freeBufferPRFileDesc(PRFileDesc *fd)
+{
+    /* Leave it to the caller to free the bytes; they should maintain a
+     * reference to it as well. */
+
+    /* If fd->secret is none, close() was called first so we can just exit. */
+    if (fd->secret == NULL) {
+        return;
+    }
+
+    fd->secret->read_buffer = NULL;
+    fd->secret->write_buffer = NULL;
+    fd->secret = NULL;
+}
+
+/* Construct a new PRFileDesc backed by a pair of buffers. Note that these
+ * should be separate buffers, but need not be unique to this PRFileDesc;
+ * that is, a client and server could share (but be swapped) j_buffers.
+ * The caller is expected to provide a peer_info to be used for optional
+ * session resumption; this will be truncated at 16 bytes of data, and
+ * extended with nulls if it is shorter. It is suggested that this be an IPv4
+ * or IPv6 address. Note that this value is not used to validate the hostname
+ * in any way (see SSL_SetURL to validate the peer). */
+PRFileDesc *newBufferPRFileDesc(j_buffer *read_buf, j_buffer *write_buf,
+    uint8_t *peer_info, size_t peer_info_len)
+{
+    PRFileDesc *fd;
+
+    fd = PR_NEW(PRFileDesc);
+    if (fd) {
+        fd->methods = &PRIOBufferMethods;
+        fd->secret = PR_NEW(PRFilePrivate);
+
+        fd->secret->read_buffer = read_buf;
+        fd->secret->write_buffer = write_buf;
+
+        size_t len = peer_info_len;
+        if (len > 16) { len = 16; }
+
+        fd->secret->peer_addr = calloc(16, sizeof(uint8_t));
+        memcpy(fd->secret->peer_addr, peer_info, len);
+
+        fd->lower = NULL;
+        fd->higher = NULL;
+        fd->dtor = freeBufferPRFileDesc;
+    }
+
+    return fd;
+}

--- a/org/mozilla/jss/ssl/javax/BufferPRFD.h
+++ b/org/mozilla/jss/ssl/javax/BufferPRFD.h
@@ -1,0 +1,32 @@
+#include <nspr.h>
+
+/* Necessary for correctly propagating E_WOULDBLOCK. */
+#include <errno.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+/* Ring buffer implementation to handle read/write calls. */
+#include "buffer.h"
+
+/* Use a modern pragma guard... */
+#pragma once
+
+/* Free a Buffer-backed PRFileDesc. Note that it is usually sufficient to call
+ * PR_Close(...) on the buffer instead. This is provided for completeness and
+ * should not be called in a SSL context as the buffer PRFileDesc is wrapped
+ * by the SSL PRFileDesc. Note that this only removes references to the
+ * underlying j_buffers and does not free them; it is up to the caller to
+ * do so. */
+void freeBufferPRFileDesc(PRFileDesc *fd);
+
+/* Construct a new PRFileDesc backed by a pair of buffers. Note that these
+ * should be separate buffers, but need not be unique to this PRFileDesc;
+ * that is, a client and server could share (but be swapped) j_buffers.
+ * The caller is expected to provide a peer_info to be used for optional
+ * session resumption; this will be truncated at 16 bytes of data, and
+ * extended with nulls if it is shorter. It is suggested that this be an IPv4
+ * or IPv6 address. Note that this value is not used to validate the hostname
+ * in any way (see SSL_SetURL to validate the peer). */
+PRFileDesc *newBufferPRFileDesc(j_buffer *read_buf, j_buffer *write_buf,
+    uint8_t *peer_info, size_t peer_info_len);

--- a/org/mozilla/jss/tests/TestBufferPRFD.c
+++ b/org/mozilla/jss/tests/TestBufferPRFD.c
@@ -1,0 +1,418 @@
+/*
+ * Test case for Buffer PRFileDesc implementation located under the
+ * org.mozilla.jss.ssl.javax package. This ensures that we can do a
+ * basic SSL handshake and verify that it works alright.
+ */
+
+/* Optional, for enabling asserts */
+#define DEBUG 1
+
+/* Header file under test */
+#include "BufferPRFD.h"
+
+/* NSPR required includes */
+#include <prio.h>
+#include <prlog.h>
+#include <prmem.h>
+#include <prnetdb.h>
+
+/* NSS includes */
+#include <nss.h>
+#include <ssl.h>
+#include <pk11pub.h>
+#include <cert.h>
+#include <certdb.h>
+#include <certt.h>
+#include <secmod.h>
+#include <sslproto.h>
+
+/* Standard includes */
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+
+static char *return_password(PK11SlotInfo *slot, PRBool retry, void *arg)
+{
+    /* Return the password passed in via arg as the password for the PKCS11
+     * slot. From NSS semantics it appears that this function should allocate
+     * a new copy with strdup as the caller expects to free it. */
+    if (retry == PR_FALSE) {
+        return strdup((char*) arg);
+    } else {
+        /* Since arg is static, exit on an incorrect password; otherwise,
+         * we'd be stuck in an infinite loop as there's no way to change
+         * the value of arg. */
+        fprintf(stderr, "Error: Incorrect password!\n");
+        exit(1);
+    }
+}
+
+static void setup_nss_context(char *database)
+{
+    /* Create NSS Context to reference the given NSS DB and initialize the
+     * NSS context with the database connection. */
+    PR_Init(PR_USER_THREAD, PR_PRIORITY_NORMAL, 0);
+
+    NSSInitContext *const ctx = NSS_InitContext(database, "", "", "", NULL,
+        NSS_INIT_READONLY | NSS_INIT_PK11RELOAD);
+    if (ctx == NULL) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: NSPR error code %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    if (NSS_Init(database) != SECSuccess) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: NSPR error code when doing NSS_Init %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+}
+
+static PRFileDesc *setup_nss_client(PRFileDesc *c_nspr, char *host)
+{
+    /* Configure the client end of the TLS connection. */
+    /* Note that most of this comes from the Fedora guide link: */
+    // https://docs.fedoraproject.org/en-US/Fedora_Security_Team/1/html/Defensive_Coding/sect-Defensive_Coding-TLS-Client-NSS.html
+    PRFileDesc *model = PR_NewTCPSocket();
+    PRFileDesc *newfd = SSL_ImportFD(NULL, model);
+    if (newfd == NULL) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: NSPR error code %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    model = newfd;
+    newfd = SSL_ImportFD(model, c_nspr);
+    if (newfd == NULL) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: SSL_ImportFD error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+    c_nspr = newfd;
+    PR_Close(model);
+
+    // Reset the handshake status after importing.
+    if (SSL_ResetHandshake(c_nspr, PR_FALSE) != SECSuccess) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: SSL_ResetHandshake error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+    if (SSL_SetURL(c_nspr, host) != SECSuccess) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: SSL_SetURL error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    return c_nspr;
+}
+
+static CERTCertificate *get_cert(char *host)
+{
+    /* Find and return the certificate for the given host in the NSS DB;
+     * this is only the public key. */
+
+    /* Code adapted from mod_nss. */
+    CERTCertList *clist;
+    CERTCertListNode *cln;
+
+    /* To do this, we have to iterate over all certs in the "user" NSS
+     * database and see if any has a nickname matching the hostname. */
+    clist = PK11_ListCerts(PK11CertListUser, NULL);
+    for (cln = CERT_LIST_HEAD(clist); !CERT_LIST_END(cln, clist);
+         cln = CERT_LIST_NEXT(cln)) {
+        CERTCertificate *cert = cln->cert;
+        const char *nickname = (const char*)cln->appData;
+
+        if (!nickname) {
+            nickname = cert->nickname;
+        }
+
+        if (strcmp(host, nickname) == 0) {
+            printf("Found cert with nickname: %s\n", nickname);
+            return cert;
+        }
+    }
+
+    return NULL;
+}
+
+static SECKEYPrivateKey *get_privkey(CERTCertificate *cert, char *password)
+{
+    /* For the given certificate, return the matching private key. Uses
+     * password as authentication to the PKCS11 database if necessary. */
+
+    /* Code adapted from mod_nss. */
+    PK11SlotInfo *slot = NULL;
+
+    /* First get the "default" slot -- this is the slot that GenerateTestCert
+     * places its certificates in. */
+    slot = PK11_GetInternalKeySlot();
+    if (slot == NULL) {
+        printf("Error finding internal slot!\n");
+        exit(2);
+    }
+
+    /* Since the JSS test suite uses a password on its database, we need a
+     * shim function that returns the string. Note that this is implemented
+     * in various places in NSS, but not exposed to calling applications. */
+    PK11_SetPasswordFunc(return_password);
+
+    PRInt32 rv = PK11_Authenticate(slot, PR_TRUE, password);
+    if (rv != SECSuccess) {
+        /* This branch won't be reached as our return_password calls exit for
+         * us on an incorrect password. */
+        printf("Invalid password for slot!\n");
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(3);
+    }
+
+    return PK11_FindPrivateKeyFromCert(slot, cert, NULL);
+}
+
+static PRFileDesc *setup_nss_server(PRFileDesc *s_nspr, char *host, char *password)
+{
+    /* Set up the server end of the SSL connection and find certificates. */
+    /* Adapted from aforementioned Fedora developer guide and mod_nss. */
+    CERTCertificate *cert = get_cert("Server_RSA");
+    if (cert == NULL) {
+        printf("Failed to find certificate for host: %s\n", host);
+        exit(1);
+    }
+
+    SECKEYPrivateKey *priv_key = get_privkey(cert, password);
+    if (priv_key == NULL) {
+        printf("Failed to find private key for certificate for host: %s\n", host);
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    PRFileDesc *model = PR_NewTCPSocket();
+    PRFileDesc *newfd = SSL_ImportFD(NULL, model);
+    if (newfd == NULL) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: NSPR error code %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    model = newfd;
+    newfd = SSL_ImportFD(model, s_nspr);
+    if (newfd == NULL) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: SSL_ImportFD error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+    s_nspr = newfd;
+    PR_Close(model);
+
+    /* This part differs from the client side: set the certificate and
+     * private key we're using. */
+    if (SSL_ConfigSecureServer(s_nspr, cert, priv_key, kt_rsa) != SECSuccess) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: SSL_ResetHandshake error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    /* We need to initialize the SessionID cache, else NSS will segfault
+     * because it has zero size when it tries to insert the new
+     * connection into the cache... */
+    SSL_ConfigServerSessionIDCache(1, 100, 100, NULL);
+
+    // Reset the handshake status -- server end
+    if (SSL_ResetHandshake(s_nspr, PR_TRUE) != SECSuccess) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: SSL_ResetHandshake error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    if (SSL_SetURL(s_nspr, host) != SECSuccess) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: SSL_SetURL error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    return s_nspr;
+}
+
+bool is_finished(PRFileDesc *c_nspr, PRFileDesc *s_nspr)
+{
+    /* Check whether or not the SSL Handshake has finished on both sides of
+     * the connection. Since we cannot be guaranteed that the handshake was
+     * successful, check whether SSL isn't off, i.e., is on or failed. */
+    int c_sec_status;
+    int s_sec_status;
+    if (SSL_SecurityStatus(c_nspr, &c_sec_status, NULL, NULL, NULL, NULL, NULL) != SECSuccess) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: SSL_SecurityStatus error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    if (SSL_SecurityStatus(s_nspr, &s_sec_status, NULL, NULL, NULL, NULL, NULL) != SECSuccess) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: SSL_SecurityStatus error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    return c_sec_status != SSL_SECURITY_STATUS_OFF && s_sec_status != SSL_SECURITY_STATUS_OFF;
+}
+
+int main(int argc, char** argv)
+{
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s /path/to/nssdb password\n", argv[0]);
+        exit(1);
+    }
+
+    setup_nss_context(argv[1]);
+
+    /* Initialize Read/Write Buffers */
+    /* In order to maintain complete control over our buffers, we need to
+     * create our buffers, sizes, and pointers here. This means that the
+     * PRFileDesc does nothing except hold pointers to our memory and update
+     * the contents/values as it sees fit (send/recv). If instead the buffer
+     * took access (or created access itself), we'd need to get access to
+     * them befor giving it to NSS, as NSS wraps our PRFileDesc in one of
+     * their PRFileDescs, removing our access to fd->secret. */
+    j_buffer *c_read_buf = jb_alloc(2048);
+    j_buffer *c_write_buf = jb_alloc(2048);
+
+    PRFileDesc *c_nspr = newBufferPRFileDesc(c_read_buf, c_write_buf,
+        (uint8_t*) "localhost", 9);
+
+    /* Initialize Server Buffers */
+    PRFileDesc *s_nspr = newBufferPRFileDesc(c_write_buf, c_read_buf,
+        (uint8_t*) "localhost", 9);
+
+    /* Set up client and server sockets with NSSL */
+    char *host = "localhost";
+    c_nspr = setup_nss_client(c_nspr, host);
+    s_nspr = setup_nss_server(s_nspr, host, argv[2]);
+
+    /* In the handshake step, we blindly try to step both the client and
+     * server ends of the handshake. As NSS stores the contents of what we're
+     * supposed to be sending, as long as our buffers are of "reasonable"
+     * size, we'll be able to step one of the two sides until something useful
+     * happens. */
+    printf("Trying handshake...\n");
+    while (!is_finished(c_nspr, s_nspr)) {
+        printf("Client Handshake:\n");
+        if (SSL_ForceHandshake(c_nspr) != SECSuccess) {
+            const PRErrorCode err = PR_GetError();
+            if (err != PR_WOULD_BLOCK_ERROR) {
+                fprintf(stderr, "error: SSL_ForceHandshake error %d: %s\n",
+                    err, PR_ErrorToName(err));
+                exit(1);
+            }
+        }
+
+        printf("\n\nServer Handshake:\n");
+        if (SSL_ForceHandshake(s_nspr) != SECSuccess) {
+            const PRErrorCode err = PR_GetError();
+            if (err != PR_WOULD_BLOCK_ERROR) {
+                fprintf(stderr, "error: SSL_ForceHandshake error %d: %s\n",
+                    err, PR_ErrorToName(err));
+                exit(1);
+            }
+        }
+
+        printf("\n\n");
+    }
+
+    /* Send a test message from client -> server to ensure that the connection
+     * truly is ready. */
+    /* Note: we don't handle E_WOULDBLOCK here as our messages are small. */
+    printf("Send a message from the client to the server...\n");
+    size_t buf_size = 1025;
+    char *buf = calloc(buf_size, sizeof(char));
+    char *buf2 = calloc(buf_size, sizeof(char));
+    char *client_message = "Cooking MCs";
+    char *server_message = "like a pound of bacon";
+
+    memcpy(buf, client_message, strlen(client_message));
+    PRInt32 ret = PR_Write(c_nspr, buf, strlen(buf));
+    if (ret < 0) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: PR_Write error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    ret = PR_Read(s_nspr, buf2, buf_size - 1);
+    if (ret < 0) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: PR_Read error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    printf("Received message from client: %s [len: %d]\n", buf2, ret);
+    printf("\n\n");
+
+    /* Send a message back to confirm we received it! */
+    printf("Send a message from the server to the client...\n");
+    memcpy(buf, server_message, strlen(server_message));
+    ret = PR_Write(s_nspr, buf, strlen(buf));
+    if (ret < 0) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: PR_Write error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    memset(buf2, 0, buf_size);
+    ret = PR_Read(c_nspr, buf2, buf_size - 1);
+    if (ret < 0) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: PR_Read error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    printf("Received message from client: %s [len: %d]\n", buf2, ret);
+
+    /* Close the client and then the server end of the connection. */
+    ret = PR_Shutdown(c_nspr, PR_SHUTDOWN_BOTH);
+    if (ret < 0) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: PR_Shutdown client error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    ret = PR_Shutdown(s_nspr, PR_SHUTDOWN_BOTH);
+    if (ret < 0) {
+        const PRErrorCode err = PR_GetError();
+        fprintf(stderr, "error: PR_Shutdown server error %d: %s\n",
+            err, PR_ErrorToName(err));
+        exit(1);
+    }
+
+    /* Closes the underlying POSIX file descriptors */
+    PR_Close(c_nspr);
+    PR_Close(s_nspr);
+
+    /* Free the buffers and their contents */
+    jb_free(c_read_buf);
+    jb_free(c_write_buf);
+
+    return 0;
+}


### PR DESCRIPTION
~This PR is blocked on #103 and depends on commits in it.~

In order to support the `javax.net.ssl.SSLEngine` interface, we need to implement SSL-over-buffers instead of SSL over Sockets. This is the first step towards that: implementing a `PRFileDesc` which NSS can wrap with SSL to provide read/write methods. This can then be used in Java and then used to implement SSLEngine.

There are two commits here:

- Add the `PRFileDesc` implementation as a new header
- Use this new header in a test to ensure that it provides the requisite features.

Much of this code was previewed in [`cipherboy/testbed/c-prfd`](https://github.com/cipherboy/testbed/tree/master/c-prfd) before being cleaned up and introduced to JSS. 