### PR TITLE
Reintroduce PKCS11 Constants test

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -22,6 +22,12 @@ macro(jss_tests)
         NAME "JSS_Test_Empty_DER_Value"
         COMMAND "org.mozilla.jss.tests.EmptyDerValue"
     )
+    if ((${Java_VERSION_MAJOR} EQUAL 1) AND (${Java_VERSION_MINOR} LESS 9))
+        jss_test_java(
+            NAME "Test_PKCS11Constants.java_for_Sun_compatibility"
+            COMMAND "org.mozilla.jss.tests.TestPKCS11Constants"
+        )
+    endif()
     jss_test_java(
         NAME "Setup_DBs"
         COMMAND "org.mozilla.jss.tests.SetupDBs" "${RESULTS_OUTPUT_DIR}" "${PASSWORD_FILE}"


### PR DESCRIPTION
When switching to CMake in #78, this was one of the tests dropped from the new test system. This PR adds it back in and addresses the AI from @emaldona's #91. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`