### PR TITLE
Allow tests to be run repeatedly

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -66,8 +66,10 @@ macro(jss_config_outputs)
     set(LIB_OUTPUT_DIR "${CMAKE_BINARY_DIR}/lib")
     set(INCLUDE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/include")
 
-    # These two are pseudo-locations for CMake targets and the test suite
+    # This folder is for pseudo-locations for CMake targets
     set(TARGETS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/.targets")
+
+    # These folders are for the NSS DBs created during testing
     set(RESULTS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/results/tests")
     set(RESULTS_FIPS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/results/fips")
 
@@ -83,8 +85,6 @@ macro(jss_config_outputs)
     file(MAKE_DIRECTORY "${LIB_OUTPUT_DIR}")
     file(MAKE_DIRECTORY "${INCLUDE_OUTPUT_DIR}")
     file(MAKE_DIRECTORY "${TARGETS_OUTPUT_DIR}")
-    file(MAKE_DIRECTORY "${RESULTS_OUTPUT_DIR}")
-    file(MAKE_DIRECTORY "${RESULTS_FIPS_OUTPUT_DIR}")
 endmacro()
 
 macro(jss_config_cflags)

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -28,15 +28,38 @@ macro(jss_tests)
             COMMAND "org.mozilla.jss.tests.TestPKCS11Constants"
         )
     endif()
+
+    # Rather than creating our results directories earlier in JSSConfig,
+    # create them here so that the test suite can be rerun multiple times.
+    jss_test_exec(
+        NAME "Clean_Setup_DBs"
+        COMMAND "cmake" "-E" "remove_directory" "${RESULTS_OUTPUT_DIR}"
+    )
+    jss_test_exec(
+        NAME "Create_Setup_DBs"
+        COMMAND "cmake" "-E" "make_directory" "${RESULTS_OUTPUT_DIR}"
+        DEPENDS "Clean_Setup_DBs"
+    )
     jss_test_java(
         NAME "Setup_DBs"
         COMMAND "org.mozilla.jss.tests.SetupDBs" "${RESULTS_OUTPUT_DIR}" "${PASSWORD_FILE}"
+        DEPENDS "Create_Setup_DBs"
     )
     # Various FIPS related tests depend on FIPS being enabled; since this
     # affects the entire NSS DB, create a separate database for them.
+    jss_test_exec(
+        NAME "Clean_FIPS_Setup_DBs"
+        COMMAND "cmake" "-E" "remove_directory" "${RESULTS_FIPS_OUTPUT_DIR}"
+    )
+    jss_test_exec(
+        NAME "Create_FIPS_Setup_DBs"
+        COMMAND "cmake" "-E" "make_directory" "${RESULTS_FIPS_OUTPUT_DIR}"
+        DEPENDS "Clean_FIPS_Setup_DBs"
+    )
     jss_test_java(
         NAME "Setup_FIPS_DBs"
         COMMAND "org.mozilla.jss.tests.SetupDBs" "${RESULTS_FIPS_OUTPUT_DIR}" "${PASSWORD_FILE}"
+        DEPENDS "Clean_FIPS_Setup_DBs"
     )
     jss_test_java(
         NAME "Generate_known_RSA_cert_pair"


### PR DESCRIPTION
Remove and recreate the NSS DB folders as part of the test suite to
enable CTests to be executed multiple times without the user having to
manually remove and recreate them.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`