### PR TITLE
CMake reproducible JARs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To install these dependencies on Debian, execute the following:
     sudo apt-get install build-essential libcommons-codec-java \
                          libcommons-lang-java libnss3-dev libslf4j-java \
                          openjdk-8-jdk pkg-config zlib1g-dev \
-                         libjaxb-api-java libnss3-tools cmake
+                         libjaxb-api-java libnss3-tools cmake zip unzip
 
 
 Building

--- a/cmake/JSSCommon.cmake
+++ b/cmake/JSSCommon.cmake
@@ -135,10 +135,21 @@ macro(jss_build_jar)
     # jss_config_version macro. Further, this doesn't yet build a reproducible
     # JAR.
     add_custom_command(
-        OUTPUT "${JSS_JAR_PATH}"
-        COMMAND "${Java_JAR_EXECUTABLE}" cmf "${CMAKE_BINARY_DIR}/MANIFEST.MF" ${JSS_JAR_PATH} org/*
+        OUTPUT "${JSS_BUILD_JAR_PATH}"
+        COMMAND "${Java_JAR_EXECUTABLE}" cmf "${CMAKE_BINARY_DIR}/MANIFEST.MF" ${JSS_BUILD_JAR_PATH} org/*
         WORKING_DIRECTORY "${CLASSES_OUTPUT_DIR}"
         DEPENDS generate_java
+    )
+
+    add_custom_target(
+        generate_build_jar
+        DEPENDS "${JSS_BUILD_JAR_PATH}"
+    )
+
+    add_custom_command(
+        OUTPUT "${JSS_JAR_PATH}"
+        COMMAND "${PROJECT_SOURCE_DIR}/tools/reproducible_jar.sh" "${JSS_BUILD_JAR_PATH}" "${REPRODUCIBLE_TEMP_DIR}" "${JSS_JAR_PATH}"
+        DEPENDS generate_build_jar
     )
 
     add_custom_target(

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -73,8 +73,13 @@ macro(jss_config_outputs)
     set(RESULTS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/results/tests")
     set(RESULTS_FIPS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/results/fips")
 
+    # This is a temporary location for building the reproducible jar
+    set(REPRODUCIBLE_TEMP_DIR "${CMAKE_BINARY_DIR}/reproducible")
+
+    set(JSS_BUILD_JAR "staging.jar")
     set(JSS_JAR "jss${JSS_VERSION_MAJOR}.jar")
     set(JSS_SO "libjss${JSS_VERSION_MAJOR}.so")
+    set(JSS_BUILD_JAR_PATH "${CMAKE_BINARY_DIR}/${JSS_BUILD_JAR}")
     set(JSS_JAR_PATH "${CMAKE_BINARY_DIR}/${JSS_JAR}")
     set(JSS_SO_PATH "${CMAKE_BINARY_DIR}/${JSS_SO}")
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -15,6 +15,9 @@ This project has the following dependencies:
  - [JavaEE JAXB](https://github.com/eclipse-ee4j/jaxb-ri)
  - [SLF4J](https://www.slf4j.org/)
 
+Additionally, a zipping and unzipping program is required to create
+reproducible builds.
+
 To install these dependencies on Fedora, execute the following:
 
     sudo dnf install apache-commons-codec apache-commons-lang gcc-c++ \
@@ -26,7 +29,7 @@ To install these dependencies on Debian, execute the following:
     sudo apt-get install build-essential libcommons-codec-java \
                          libcommons-lang-java libnss3-dev libslf4j-java \
                          openjdk-8-jdk pkg-config zlib1g-dev \
-                         libjaxb-api-java cmake
+                         libjaxb-api-java cmake zip unzip
 
 ## Test Suite Dependencies:
 

--- a/tools/Dockerfiles/debian_jdk11
+++ b/tools/Dockerfiles/debian_jdk11
@@ -8,6 +8,7 @@ RUN true \
                               openjdk-11-jdk pkg-config quilt g++ mercurial \
                               zlib1g-dev libslf4j-java liblog4j2-java \
                               libcommons-lang-java libjaxb-api-java cmake \
+                              zip unzip \
         && mkdir -p /home/sandbox \
         && apt-get autoremove -y \
         && apt-get clean -y \

--- a/tools/Dockerfiles/ubuntu_jdk8
+++ b/tools/Dockerfiles/ubuntu_jdk8
@@ -8,6 +8,7 @@ RUN true \
                               openjdk-8-jdk pkg-config quilt g++ mercurial \
                               zlib1g-dev libslf4j-java liblog4j2-java \
                               libcommons-lang-java libjaxb-api-java cmake \
+                              zip unzip \
         && mkdir -p /home/sandbox \
         && apt-get autoremove -y \
         && apt-get clean -y \

--- a/tools/reproducible_jar.sh
+++ b/tools/reproducible_jar.sh
@@ -6,6 +6,9 @@
 # insertion order. This will help to ensure that anyone building in the same
 # environment will receive the same jar file assuming the contents of Java
 # haven't changed.
+#
+# Usage:
+#   reproducible_jar.sh /path/to/input.jar /path/to/tmp/dir /path/to/output.jar
 
 set -e
 

--- a/tools/reproducible_jar.sh
+++ b/tools/reproducible_jar.sh
@@ -21,7 +21,7 @@ function extract() {
     fi
 
     mkdir -p "$path"
-    unzip "$jar" -d "$path"
+    unzip -q "$jar" -d "$path"
 }
 
 function normalize_timestamps() {
@@ -33,21 +33,21 @@ function add_manifest() {
     local path="$1"
     local output="$2"
 
-    pushd "$path"
-        zip -X "$output" "META-INF"
-        zip -X "$output" "META-INF/MANIFEST.MF"
-    popd
+    pushd "$path" >/dev/null
+        zip -X -q "$output" "META-INF"
+        zip -X -q "$output" "META-INF/MANIFEST.MF"
+    popd >/dev/null
 }
 
 function add_classes() {
     local path="$1"
     local output="$2"
 
-    pushd "$path"
+    pushd "$path" >/dev/null
         for file in $(find "org" | sort); do
-            zip -X "$output" "$file"
+            zip -X -q "$output" "$file"
         done
-    popd
+    popd >/dev/null
 }
 
 abs_jar="$(realpath "$1")"


### PR DESCRIPTION
When CMake was introduced, reproducible JAR builds were not part of the pull request. 

This reintroduces reproducible JAR builds in three commits:

 - Document the usage of `tools/reproducible_jar.sh`
 - Add reproducible JAR build back to CMake
 - Make `tools/reproducible_jar.sh` silent except on errors.

