### PR TITLE
Library testing

### DIFF
--- a/cmake/JSSCommon.cmake
+++ b/cmake/JSSCommon.cmake
@@ -153,16 +153,23 @@ macro(jss_build_c)
         DEPENDS ${C_OUTPUTS}
     )
 
+    # We generate two libraries: build/lib/libjss.so and build/libjss.so:
+    # the former is for testing and is unversioned, so all symbols are public
+    # and can thus be tested; the latter is for releases and is versioned,
+    # limiting which symbols are made public. We only need to make the JNI
+    # symbols public as libjss.so should only be used from Java in conjunction
+    # with jss.jar.
     add_custom_command(
-        OUTPUT "${JSS_SO_PATH}"
-        COMMAND ${CMAKE_C_COMPILER} -o ${JSS_SO_PATH} ${LIB_OUTPUT_DIR}/*.o ${JSS_LD_FLAGS} ${JSS_LIBRARY_FLAGS}
+        OUTPUT "${JSS_SO_PATH}" "${JSS_TESTS_SO_PATH}"
+        COMMAND ${CMAKE_C_COMPILER} -o ${JSS_TESTS_SO_PATH} ${LIB_OUTPUT_DIR}/*.o ${JSS_LD_FLAGS} ${JSS_LIBRARY_FLAGS}
+        COMMAND ${CMAKE_C_COMPILER} -o ${JSS_SO_PATH} ${LIB_OUTPUT_DIR}/*.o ${JSS_LD_FLAGS} ${JSS_VERSION_SCRIPT} ${JSS_LIBRARY_FLAGS}
         DEPENDS generate_c
     )
 
     # Add a target for anything depending on the library existing.
     add_custom_target(
         generate_so ALL
-        DEPENDS ${JSS_SO_PATH}
+        DEPENDS ${JSS_SO_PATH} ${JSS_TESTS_SO_PATH}
     )
 endmacro()
 

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -84,12 +84,16 @@ macro(jss_config_outputs)
     set(JSS_SO_PATH "${CMAKE_BINARY_DIR}/${JSS_SO}")
 
     # These options are for the test suite and mirror their non-tests
-    # counterparts
+    # counterparts. Note that JSS_TESTS_SO is the same as JSS_SO, but
+    # JSS_TESTS_SO_PATH differs -- one is "unversioned" and lacks a
+    # version script so we can test internal methods.
     set(TESTS_CLASSES_OUTPUT_DIR "${CMAKE_BINARY_DIR}/classes/tests")
     set(TESTS_INCLUDE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/include/tests")
     set(TESTS_JNI_OUTPUT_DIR "${CMAKE_BINARY_DIR}/include/jss/_jni")
     set(JSS_TESTS_JAR "tests-jss${JSS_VERSION_MAJOR}.jar")
+    set(JSS_TESTS_SO "${JSS_SO}")
     set(JSS_TESTS_JAR_PATH "${CMAKE_BINARY_DIR}/${JSS_TESTS_JAR}")
+    set(JSS_TESTS_SO_PATH "${LIB_OUTPUT_DIR}/${JSS_TESTS_SO}")
 
     # Create the *_OUTPUT_DIR locations.
     file(MAKE_DIRECTORY "${CLASSES_OUTPUT_DIR}")
@@ -160,7 +164,8 @@ macro(jss_config_ldflags)
     list(APPEND JSS_LIBRARY_FLAGS "-Wl,-z,defs")
     list(APPEND JSS_LIBRARY_FLAGS "-Wl,-soname")
     list(APPEND JSS_LIBRARY_FLAGS "-Wl,${JSS_SO}")
-    list(APPEND JSS_LIBRARY_FLAGS "-Wl,--version-script,${PROJECT_SOURCE_DIR}/lib/jss.map")
+
+    set(JSS_VERSION_SCRIPT "-Wl,--version-script,${PROJECT_SOURCE_DIR}/lib/jss.map")
 endmacro()
 
 macro(jss_config_java)

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -241,11 +241,13 @@ function(jss_test_java)
             NAME "${TEST_JAVA_NAME}"
             COMMAND "${EXEC_COMMAND}"
             DEPENDS ${TEST_JAVA_DEPENDS}
+            LIBRARY "java"
         )
     else()
         jss_test_exec(
             NAME "${TEST_JAVA_NAME}"
             COMMAND "${EXEC_COMMAND}"
+            LIBRARY "java"
         )
     endif()
 endfunction()
@@ -262,7 +264,7 @@ macro(jss_test_exec)
     #
     #   jss_test_exec("NAME" "ARG1" "ARG2" "...")
 
-    set(TEST_FLAGS "NAME")
+    set(TEST_FLAGS "NAME" "LIBRARY")
     set(TEST_ARGS  "COMMAND" "DEPENDS")
     cmake_parse_arguments(TEST_EXEC "" "${TEST_FLAGS}" "${TEST_ARGS}" ${ARGN})
 
@@ -270,11 +272,22 @@ macro(jss_test_exec)
         NAME "${TEST_EXEC_NAME}"
         COMMAND ${TEST_EXEC_COMMAND}
     )
-    set_tests_properties(
-        "${TEST_EXEC_NAME}"
-        PROPERTIES ENVIRONMENT
-        "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}"
-    )
+
+    # If we are calling a java program, use the versioned library to ensure
+    # that any new JNI calls are made visible.
+    if(TEST_EXEC_LIBRARY AND (TEST_EXEC_LIBRARY STREQUAL "java"))
+        set_tests_properties(
+            "${TEST_EXEC_NAME}"
+            PROPERTIES ENVIRONMENT
+            "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}"
+        )
+    else()
+        set_tests_properties(
+            "${TEST_EXEC_NAME}"
+            PROPERTIES ENVIRONMENT
+            "LD_LIBRARY_PATH=${LIB_OUTPUT_DIR}"
+        )
+    endif()
     if(TEST_EXEC_DEPENDS)
         set_tests_properties(
             "${TEST_EXEC_NAME}"


### PR DESCRIPTION
This PR is dependent upon #97 and #98 and includes commits from both. Only the last commit is new.

In a future PR to test #93 and the SSLEngine work, we'd like to also be able to test C code which lives in `libjss4.so` but _isn't_ a JNI call. Thus, we require an unversioned `libjss4.so` or directly link to all of the objects we wish to test. If the objects we wish to test are complex and in turn depend on other objects, an unversioned `libjss4.so` is best; if however, these objects are always simple, directly compiling in the objects (from `build/lib/*.o`) would suffice.

In the test suite, we continue using the versioned library for Java calls, but use the unversioned library for directly executed programs: this ensures that any new tests we introduce for new methods will fail if these new methods aren't added to the version script as well. 

Thoughts?

