### PR TITLE
Enable release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ if (DEFINED CHECK_DEPRECATION)
     set(CMAKE_JAVA_COMPILE_FLAGS "-Xlint:deprecation")
 endif()
 
+# Build a debug build by default when no type is specified on the command line
+if(NOT (DEFINED CMAKE_BUILD_TYPE))
+    set(CMAKE_BUILD_TYPE "Debug")
+endif()
+
 # Find NSPR and NSS Libraries.
 find_package(NSPR REQUIRED)
 find_package(NSS REQUIRED)

--- a/cmake/JSSCommon.cmake
+++ b/cmake/JSSCommon.cmake
@@ -76,14 +76,14 @@ macro(jss_build_java)
     #   https://gitlab.kitware.com/cmake/community/wikis/FAQ#how-can-i-add-a-dependency-to-a-source-file-which-is-generated-in-a-subdirectory
     add_custom_command(
         OUTPUT "${JNI_OUTPUTS}"
-        COMMAND ${Java_JAVAC_EXECUTABLE} -classpath "${JAVAC_CLASSPATH}" -g -d ${CLASSES_OUTPUT_DIR} -sourcepath ${PROJECT_SOURCE_DIR} -h ${JNI_OUTPUT_DIR} ${JAVA_SOURCES}
+        COMMAND ${Java_JAVAC_EXECUTABLE} ${JSS_JAVAC_FLAGS} -d ${CLASSES_OUTPUT_DIR} -h ${JNI_OUTPUT_DIR} ${JAVA_SOURCES}
         COMMAND touch "${JNI_OUTPUTS}"
         DEPENDS ${JAVA_SOURCES}
     )
 
     add_custom_command(
         OUTPUT "${TESTS_JNI_OUTPUTS}"
-        COMMAND ${Java_JAVAC_EXECUTABLE} -classpath "${JAVAC_CLASSPATH}" -g -d ${TESTS_CLASSES_OUTPUT_DIR} -sourcepath ${PROJECT_SOURCE_DIR} -h ${TESTS_JNI_OUTPUT_DIR} ${JAVA_TEST_SOURCES}
+        COMMAND ${Java_JAVAC_EXECUTABLE} ${JSS_JAVAC_FLAGS} -d ${TESTS_CLASSES_OUTPUT_DIR} -h ${TESTS_JNI_OUTPUT_DIR} ${JAVA_TEST_SOURCES}
         COMMAND touch "${TESTS_JNI_OUTPUTS}"
         DEPENDS ${JAVA_TEST_SOURCES}
     )

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -115,7 +115,13 @@ macro(jss_config_cflags)
 
     # This list of C flags was taken from the original build scripts for
     # debug and release builds.
-    list(APPEND JSS_RAW_C_FLAGS "-g")
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+        list(APPEND JSS_RAW_C_FLAGS "-Og")
+        list(APPEND JSS_RAW_C_FLAGS "-ggdb")
+    else()
+        list(APPEND JSS_RAW_C_FLAGS "-O2")
+    endif()
+
     list(APPEND JSS_RAW_C_FLAGS "-Wall")
     list(APPEND JSS_RAW_C_FLAGS "-Werror-implicit-function-declaration")
     list(APPEND JSS_RAW_C_FLAGS "-Wno-switch")
@@ -215,6 +221,16 @@ macro(jss_config_java)
     # Set class paths
     set(JAVAC_CLASSPATH "${SLF4J_API_JAR}:${CODEC_JAR}:${LANG_JAR}:${JAXB_JAR}")
     set(TEST_CLASSPATH "${JSS_JAR_PATH}:${JSS_TESTS_JAR_PATH}:${JAVAC_CLASSPATH}:${SLF4J_JDK14_JAR}")
+
+    list(APPEND JSS_JAVAC_FLAGS "-classpath")
+    list(APPEND JSS_JAVAC_FLAGS "${JAVAC_CLASSPATH}")
+    list(APPEND JSS_JAVAC_FLAGS "-sourcepath")
+    list(APPEND JSS_JAVAC_FLAGS "${PROJECT_SOURCE_DIR}")
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+        list(APPEND JSS_JAVAC_FLAGS "-g")
+    else()
+        list(APPEND JSS_JAVAC_FLAGS "-O")
+    endif()
 
     # Variables for javadoc building. Note that JSS_PACKAGES needs to be
     # updated whenever a new package is created.


### PR DESCRIPTION
Respect `CMAKE_BUILD_TYPE` for Release vs Debug

This is the final step in enabling CMake builds to replace the old
functionality: specifying `-DCMAKE_BUILD_TYPE=Release` on the CMake
command line is equivalent to setting `BUILD_OPT=1` in the old build
system.

This has been verified by comparing the RPM builds from branch HEAD to the commit before the introduction of CMake and checking the contents of the JAR after extraction. 

Depends on commits from #98 and #99; will be rebased after they merge. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`
