### PR TITLE
Sync PKI and JSS common classes

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -22,6 +22,10 @@ macro(jss_tests)
         NAME "JSS_Test_Empty_DER_Value"
         COMMAND "org.mozilla.jss.tests.EmptyDerValue"
     )
+    jss_test_java(
+        NAME "BigObjectIdentifier"
+        COMMAND "org.mozilla.jss.tests.BigObjectIdentifier"
+    )
     if ((${Java_VERSION_MAJOR} EQUAL 1) AND (${Java_VERSION_MINOR} LESS 9))
         jss_test_java(
             NAME "Test_PKCS11Constants.java_for_Sun_compatibility"

--- a/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
+++ b/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
@@ -147,6 +147,6 @@ public class KeyWrapAlgorithm extends Algorithm {
         if (oid.equals(DES_CBC_PAD_OID))
             return DES_CBC_PAD;
 
-        throw new NoSuchAlgorithmException();
+        throw new NoSuchAlgorithmException("Unknown Algorithm for OID: " + wrapOID);
     }
 }

--- a/org/mozilla/jss/netscape/security/pkcs/PKCS10.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS10.java
@@ -26,16 +26,19 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import org.mozilla.jss.netscape.security.util.Cert;
 import org.mozilla.jss.netscape.security.util.BigInt;
 import org.mozilla.jss.netscape.security.util.DerInputStream;
 import org.mozilla.jss.netscape.security.util.DerOutputStream;
 import org.mozilla.jss.netscape.security.util.DerValue;
+import org.mozilla.jss.netscape.security.util.Utils;
 import org.mozilla.jss.netscape.security.x509.AlgorithmId;
 import org.mozilla.jss.netscape.security.x509.X500Name;
 import org.mozilla.jss.netscape.security.x509.X500Signer;
 import org.mozilla.jss.netscape.security.x509.X509Key;
-import org.mozilla.jss.netscape.security.util.Utils;
 /**
  * PKCS #10 certificate requests are created and sent to Certificate
  * Authorities, which then create X.509 certificates and return them to
@@ -70,6 +73,9 @@ import org.mozilla.jss.netscape.security.util.Utils;
  * @version 1.28
  */
 public class PKCS10 {
+
+    public static Logger logger = LoggerFactory.getLogger(PKCS10.class);
+
     /**
      * Constructs an unsigned PKCS #10 certificate request. Before this
      * request may be used, it must be encoded and signed. Then it
@@ -122,12 +128,11 @@ public class PKCS10 {
         byte sigData[];
         Signature sig;
 
-        String method = "PKCS10: PKCS10: ";
         String msg = "";
 
-        System.out.println(method + "begins");
+        logger.debug("PKCS10: begins");
         if (data == null) {
-            throw new IllegalArgumentException(method + "param data cann't be null");
+            throw new IllegalArgumentException("Missing PKCS #10 data");
         }
         certificateRequest = data;
 
@@ -138,11 +143,12 @@ public class PKCS10 {
         in = new DerInputStream(data);
         seq = in.getSequence(3);
         if (seq == null) {
-            throw new IllegalArgumentException(method + "in.getSequence null");
+            throw new IllegalArgumentException("in.getSequence null");
         }
 
-        if (seq.length != 3)
-            throw new IllegalArgumentException(method + "not a PKCS #10 request");
+        if (seq.length != 3) {
+            throw new IllegalArgumentException("Invalid PKCS #10 request");
+        }
 
         data = seq[0].toByteArray(); // reusing this variable
         certRequestInfo = seq[0].toByteArray(); // make a copy
@@ -167,8 +173,8 @@ public class PKCS10 {
         subjectPublicKeyInfo = X509Key.parse(new DerValue(val1));
         PublicKey publicKey = X509Key.parsePublicKey(new DerValue(val1));
         if (publicKey == null) {
-            System.out.println(method + msg + "publicKey null");
-            throw new SignatureException (method + msg + "publicKey null");
+            logger.error("PKCS10: " + msg + "publicKey null");
+            throw new SignatureException(msg + "publicKey null");
         }
 
         // Cope with a somewhat common illegal PKCS #10 format
@@ -213,15 +219,15 @@ public class PKCS10 {
                 sig.initVerify(publicKey);
                 sig.update(data);
                 if (!sig.verify(sigData)) {
-                    System.out.println(method + msg + "sig.verify() failed");
-                        throw new SignatureException(method + msg + "Invalid PKCS #10 signature");
+                    logger.error("PKCS10: " + msg + "sig.verify() failed");
+                    throw new SignatureException(msg + "Invalid PKCS #10 signature");
                 }
             }
         } catch (InvalidKeyException e) {
-            System.out.println(method + msg + e.toString());
-            throw new SignatureException(method + msg + "invalid key");
+            logger.error("PKCS10: " + msg + e.getMessage());
+            throw new SignatureException(msg + "invalid key", e);
         }
-        System.out.println(method + "ends");
+        logger.debug("PKCS10: ends");
     }
 
     public PKCS10(byte data[])
@@ -336,9 +342,9 @@ public class PKCS10 {
         if (certificateRequest == null)
             throw new SignatureException("Cert request was not signed");
 
-        out.println("-----BEGIN NEW CERTIFICATE REQUEST-----");
+        out.println(Cert.REQUEST_HEADER);
         out.println(Utils.base64encode(certificateRequest, true));
-        out.println("-----END NEW CERTIFICATE REQUEST-----");
+        out.println(Cert.REQUEST_FOOTER);
     }
 
     /**

--- a/org/mozilla/jss/netscape/security/pkcs/PKCS12CertInfo.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS12CertInfo.java
@@ -17,25 +17,24 @@
 // --- END COPYRIGHT BLOCK ---
 package org.mozilla.jss.netscape.security.pkcs;
 
-import java.math.BigInteger;
-
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
 public class PKCS12CertInfo {
 
-    BigInteger id;
-    X509CertImpl cert;
-    String nickname;
-    String trustFlags;
+    private byte[] id;
+    private X509CertImpl cert;
+    private String friendlyName;
+    private String trustFlags;
+    private byte[] keyID;
 
     public PKCS12CertInfo() {
     }
 
-    public BigInteger getID() {
+    public byte[] getID() {
         return id;
     }
 
-    public void setID(BigInteger id) {
+    public void setID(byte[] id) {
         this.id = id;
     }
 
@@ -47,12 +46,12 @@ public class PKCS12CertInfo {
         this.cert = cert;
     }
 
-    public String getNickname() {
-        return nickname;
+    public String getFriendlyName() {
+        return friendlyName;
     }
 
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
+    public void setFriendlyName(String friendlyName) {
+        this.friendlyName = friendlyName;
     }
 
     public String getTrustFlags() {
@@ -61,5 +60,13 @@ public class PKCS12CertInfo {
 
     public void setTrustFlags(String trustFlags) {
         this.trustFlags = trustFlags;
+    }
+
+    public byte[] getKeyID() {
+        return keyID;
+    }
+
+    public void setKeyID(byte[] keyID) {
+        this.keyID = keyID;
     }
 }

--- a/org/mozilla/jss/netscape/security/pkcs/PKCS12KeyInfo.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS12KeyInfo.java
@@ -17,8 +17,6 @@
 // --- END COPYRIGHT BLOCK ---
 package org.mozilla.jss.netscape.security.pkcs;
 
-import java.math.BigInteger;
-
 import org.mozilla.jss.crypto.PrivateKey;
 
 /**
@@ -36,8 +34,8 @@ public class PKCS12KeyInfo {
 
     private PrivateKey privateKey;
     private byte[] epkiBytes;
-    BigInteger id;
-    String subjectDN;
+    private byte[] id;
+    private String friendlyName;
 
     public PKCS12KeyInfo() {
     }
@@ -66,19 +64,19 @@ public class PKCS12KeyInfo {
         return epkiBytes;
     }
 
-    public BigInteger getID() {
+    public byte[] getID() {
         return id;
     }
 
-    public void setID(BigInteger id) {
+    public void setID(byte[] id) {
         this.id = id;
     }
 
-    public String getSubjectDN() {
-        return subjectDN;
+    public String getFriendlyName() {
+        return friendlyName;
     }
 
-    public void setSubjectDN(String subjectDN) {
-        this.subjectDN = subjectDN;
+    public void setFriendlyName(String friendlyName) {
+        this.friendlyName = friendlyName;
     }
 }

--- a/org/mozilla/jss/netscape/security/util/Cert.java
+++ b/org/mozilla/jss/netscape/security/util/Cert.java
@@ -33,6 +33,9 @@ public class Cert {
     public static final String HEADER = "-----BEGIN CERTIFICATE-----";
     public static final String FOOTER = "-----END CERTIFICATE-----";
 
+    public static final String PKCS7_HEADER = "-----BEGIN PKCS7-----";
+    public static final String PKCS7_FOOTER = "-----END PKCS7-----";
+
     // From https://www.rfc-editor.org/rfc/rfc7468.txt
     public static final String REQUEST_HEADER = "-----BEGIN CERTIFICATE REQUEST-----";
     public static final String REQUEST_FOOTER = "-----END CERTIFICATE REQUEST-----";
@@ -68,9 +71,12 @@ public class Cert {
             return s;
         }
 
-        if ((s.startsWith(HEADER)) &&
-                (s.endsWith(FOOTER))) {
-            return (s.substring(27, (s.length() - 25)));
+        if (s.startsWith(HEADER) && s.endsWith(FOOTER)) {
+            return s.substring(HEADER.length(), s.length() - FOOTER.length());
+        }
+
+        if (s.startsWith(PKCS7_HEADER) && s.endsWith(PKCS7_FOOTER)) {
+            return s.substring(PKCS7_HEADER.length(), s.length() - PKCS7_FOOTER.length());
         }
 
         // To support Thawte's header and footer

--- a/org/mozilla/jss/netscape/security/util/ObjectIdentifier.java
+++ b/org/mozilla/jss/netscape/security/util/ObjectIdentifier.java
@@ -184,8 +184,6 @@ final public class ObjectIdentifier implements Serializable {
         initFromEncoding(new DerInputStream(buf), 0);
     }
 
-
-
     /*
      * Helper function -- get the OID from a stream, after tag and
      * length are verified.
@@ -261,7 +259,7 @@ final public class ObjectIdentifier implements Serializable {
     /*
      * n.b. the only public interface is DerOutputStream.putOID()
      */
-    void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) throws IOException {
         DerOutputStream bytes = new DerOutputStream();
         int i;
 
@@ -478,56 +476,5 @@ final public class ObjectIdentifier implements Serializable {
             retval.append(values[i]);
         }
         return getObjectIdentifier(retval.toString());
-    }
-
-    public static void main(String[] args) {
-
-        long[] oid_components_long = { 1L, 3L,6L,1L,4L,1L,5000L,9L,1L,1L,1526913300628L, 1L};
-        int[] oid_components_int =  { 1, 3,6,1,4,1,2312,9,1,1,15269, 1, 1};
-        BigInteger[] oid_components_big_int = { new BigInteger("1"), new BigInteger("3"), new BigInteger("6"), new BigInteger("1"),
-                new BigInteger("4"), new BigInteger("1"), new BigInteger("2312"),
-                new BigInteger("9"), new BigInteger("1"),
-                new BigInteger("152691330062899999999999997777788888888888888889999999999999999"), new BigInteger("1")
-        };
-
-        String oidIn = "1.3.6.1.4.1.2312.9.1.152691330062899999999999997777788888888888888889999999999999999.1";
-        ObjectIdentifier oid = new ObjectIdentifier(oidIn);
-
-        ObjectIdentifier fromDer = null;
-        ObjectIdentifier fromStaticMethod = null;
-        ObjectIdentifier fromComponentList = null;
-        ObjectIdentifier  fromComponentListInt = null;
-        ObjectIdentifier fromComponentListBigInt = null;
-
-        System.out.println("oid: " + oid.toString());
-
-        DerOutputStream out = new DerOutputStream();
-
-        try {
-            oid.encode(out);
-            DerInputStream  in = new DerInputStream(out.toByteArray());
-            fromDer = new ObjectIdentifier(in);
-
-            System.out.println("fromDer: " + fromDer.toString());
-
-            fromStaticMethod = ObjectIdentifier.getObjectIdentifier(oidIn);
-
-            System.out.println("fromStaticMethod: " + fromStaticMethod.toString());
-
-            fromComponentList = new ObjectIdentifier(oid_components_long);
-
-            System.out.println("fromComponentList: " + fromComponentList.toString());
-
-            fromComponentListInt = new ObjectIdentifier(oid_components_int);
-
-            System.out.println("fromComponentListInt: " + fromComponentListInt);
-
-            fromComponentListBigInt = new ObjectIdentifier(oid_components_big_int);
-
-            System.out.println("fromComponentListBigInt: " + fromComponentListBigInt);
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
     }
 }

--- a/org/mozilla/jss/netscape/security/util/Utils.java
+++ b/org/mozilla/jss/netscape/security/util/Utils.java
@@ -314,7 +314,6 @@ public class Utils {
      * Each line is at most 64-character long and terminated with CRLF.
      *
      * @param bytes byte array
-     * @param chunked TODO
      * @return base-64 encoded data
      */
     public static String base64encodeMultiLine(byte[] bytes) {
@@ -346,16 +345,31 @@ public class Utils {
     /**
      * Normalize B64 input String
      *
-     * @pram string base-64 string
+     * @param string base-64 string
      * @return normalized string
      */
     public static String normalizeString(String string) {
+        return normalizeString(string, false);
+    }
+
+    /**
+     * Normalize B64 input String
+     *
+     * @param string base-64 string
+     * @param keepspace a boolean variable to control whether to keep spaces or not
+     * @return normalized string
+     */
+    public static String normalizeString(String string, Boolean keepSpace) {
         if (string == null) {
             return string;
         }
 
         StringBuffer sb = new StringBuffer();
-        StringTokenizer st = new StringTokenizer(string, "\r\n ");
+        StringTokenizer st = null;
+        if (keepSpace)
+            st = new StringTokenizer(string, "\r\n");
+        else
+            st = new StringTokenizer(string, "\r\n ");
 
         while (st.hasMoreTokens()) {
             String nextLine = st.nextToken();
@@ -364,4 +378,5 @@ public class Utils {
         }
         return sb.toString();
     }
+
 }

--- a/org/mozilla/jss/netscape/security/util/WrappingParams.java
+++ b/org/mozilla/jss/netscape/security/util/WrappingParams.java
@@ -1,0 +1,290 @@
+package org.mozilla.jss.netscape.security.util;
+
+import java.security.NoSuchAlgorithmException;
+
+import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
+import org.mozilla.jss.crypto.EncryptionAlgorithm;
+import org.mozilla.jss.crypto.IVParameterSpec;
+import org.mozilla.jss.crypto.KeyGenAlgorithm;
+import org.mozilla.jss.crypto.KeyWrapAlgorithm;
+import org.mozilla.jss.crypto.SymmetricKey;
+import org.mozilla.jss.crypto.SymmetricKey.Type;
+
+public class WrappingParams {
+    // session key attributes
+    SymmetricKey.Type skType;
+    KeyGenAlgorithm skKeyGenAlgorithm;
+    int skLength;
+
+    // wrapping algorithm for session key
+    KeyWrapAlgorithm skWrapAlgorithm;
+
+    // Encryption algorithm for payload
+    EncryptionAlgorithm payloadEncryptionAlgorithm;
+
+    //wrapping algorithm for payload
+    KeyWrapAlgorithm payloadWrapAlgorithm;
+
+    // payload encryption IV
+    IVParameterSpec payloadEncryptionIV;
+
+    // payload wrapping IV
+    IVParameterSpec payloadWrappingIV;
+
+    public WrappingParams(Type skType, KeyGenAlgorithm skKeyGenAlgorithm, int skLength,
+            KeyWrapAlgorithm skWrapAlgorithm, EncryptionAlgorithm payloadEncryptionAlgorithm,
+            KeyWrapAlgorithm payloadWrapAlgorithm, IVParameterSpec payloadEncryptIV, IVParameterSpec payloadWrapIV) {
+        super();
+        this.skType = skType;
+        this.skKeyGenAlgorithm = skKeyGenAlgorithm;
+        this.skLength = skLength;
+        this.skWrapAlgorithm = skWrapAlgorithm;
+        this.payloadEncryptionAlgorithm = payloadEncryptionAlgorithm;
+        this.payloadWrapAlgorithm = payloadWrapAlgorithm;
+        this.payloadEncryptionIV = payloadEncryptIV;
+        this.payloadWrappingIV = payloadWrapIV;
+    }
+
+    public static EncryptionAlgorithm getEncryptionAlgorithmFromName(String name) throws Exception {
+        String fields[] = name.split("//");
+        String alg = fields[0];
+        String mode = fields[1];
+        String padding = fields[2];
+        int strength = Integer.parseInt(fields[3]);
+        return EncryptionAlgorithm.lookup(alg, mode, padding, strength);
+    }
+
+    public WrappingParams() {}
+
+    public WrappingParams(String encryptOID, String wrapName, String priKeyAlgo, IVParameterSpec encryptIV, IVParameterSpec wrapIV)
+            throws NumberFormatException, NoSuchAlgorithmException {
+        EncryptionAlgorithm encrypt = null;
+        OBJECT_IDENTIFIER eccOID = new OBJECT_IDENTIFIER("1.2.840.10045.2.1");
+
+        if (encryptOID.equals(eccOID.toString())) {
+            // old CRMFPopClients send this OID for ECC Keys for no apparent reason.
+            // New clients set this correctly.
+            // We'll assume the old DES3 wrapping here.
+            encrypt = EncryptionAlgorithm.DES_CBC_PAD;
+        } else if (encryptOID.equals(KeyWrapAlgorithm.DES3_CBC_PAD_OID.toString())) {
+            encrypt = EncryptionAlgorithm.DES3_CBC_PAD;
+        } else if (encryptOID.equals(KeyWrapAlgorithm.AES_CBC_PAD_OID.toString())) {
+            encrypt = EncryptionAlgorithm.AES_128_CBC_PAD;
+        } else {
+            encrypt = EncryptionAlgorithm.fromOID(new OBJECT_IDENTIFIER(encryptOID));
+        }
+
+        KeyWrapAlgorithm wrap = null;
+        if (wrapName != null) {
+            wrap = KeyWrapAlgorithm.fromString(wrapName);
+            payloadWrapAlgorithm = wrap;
+        }
+
+        switch (encrypt.getAlg().toString()) {
+        case "AES":
+            // TODO(alee) - Terrible hack till we figure out why GCM is not working
+            // or a way to detect the padding.
+            // We are going to assume AES-128-PAD
+            encrypt = EncryptionAlgorithm.AES_128_CBC_PAD;
+
+            skType = SymmetricKey.AES;
+            skKeyGenAlgorithm = KeyGenAlgorithm.AES;
+            if (wrap == null) payloadWrapAlgorithm = KeyWrapAlgorithm.AES_KEY_WRAP_PAD;
+            break;
+        case "DESede":
+            skType = SymmetricKey.DES3;
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES3;
+            skWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            if (wrap == null) payloadWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            break;
+        case "DES":
+            skType = SymmetricKey.DES;
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES;
+            skWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            if (wrap == null) payloadWrapAlgorithm = KeyWrapAlgorithm.DES_CBC_PAD;
+            break;
+        default:
+            throw new NoSuchAlgorithmException("Invalid algorithm");
+        }
+
+        this.skLength = encrypt.getKeyStrength();
+        if (priKeyAlgo.equals("EC")) {
+            skWrapAlgorithm = KeyWrapAlgorithm.AES_ECB;
+        } else {
+            skWrapAlgorithm = KeyWrapAlgorithm.RSA;
+        }
+
+        payloadEncryptionAlgorithm = encrypt;
+        payloadEncryptionIV = encryptIV;
+
+        if (payloadWrapAlgorithm == KeyWrapAlgorithm.AES_KEY_WRAP_PAD) {
+            // TODO(alee) Hack -- if we pass in null for the iv in the
+            // PKIArchiveOptions, we fail to decode correctly when parsing a
+            // CRMFPopClient request.
+
+            payloadWrappingIV = null;
+        } else {
+            payloadWrappingIV = wrapIV;
+        }
+    }
+
+    private WrappingParams(String wrapOID, String priKeyAlgo, IVParameterSpec wrapIV)
+            throws NumberFormatException, NoSuchAlgorithmException {
+        KeyWrapAlgorithm kwAlg = KeyWrapAlgorithm.fromOID(wrapOID);
+
+        if (kwAlg == KeyWrapAlgorithm.AES_KEY_WRAP_PAD) {
+            skType = SymmetricKey.AES;
+            skKeyGenAlgorithm = KeyGenAlgorithm.AES;
+            payloadWrapAlgorithm = KeyWrapAlgorithm.AES_KEY_WRAP_PAD;
+            payloadEncryptionAlgorithm = EncryptionAlgorithm.AES_128_CBC_PAD;
+            skLength = 128;
+        } else if (kwAlg == KeyWrapAlgorithm.AES_CBC_PAD) {
+            skType = SymmetricKey.AES;
+            skKeyGenAlgorithm = KeyGenAlgorithm.AES;
+            payloadWrapAlgorithm = KeyWrapAlgorithm.AES_CBC_PAD;
+            payloadEncryptionAlgorithm = EncryptionAlgorithm.AES_128_CBC_PAD;
+            skLength = 128;
+        } else if (kwAlg == KeyWrapAlgorithm.DES3_CBC_PAD) {
+            skType = SymmetricKey.DES3;
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES3;
+            skWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            payloadWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            payloadEncryptionAlgorithm = EncryptionAlgorithm.DES3_CBC_PAD;
+            skLength = payloadEncryptionAlgorithm.getKeyStrength();
+        } else if (kwAlg == KeyWrapAlgorithm.DES_CBC_PAD) {
+            skType = SymmetricKey.DES;
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES;
+            skWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            payloadWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            payloadEncryptionAlgorithm = EncryptionAlgorithm.DES_CBC_PAD;
+            skLength = payloadEncryptionAlgorithm.getKeyStrength();
+        }
+
+        if (priKeyAlgo.equals("EC")) {
+            skWrapAlgorithm = KeyWrapAlgorithm.AES_ECB;
+        } else {
+            skWrapAlgorithm = KeyWrapAlgorithm.RSA;
+        }
+
+        // set the IVs
+        payloadEncryptionIV = wrapIV;
+
+        if (payloadWrapAlgorithm == KeyWrapAlgorithm.AES_KEY_WRAP_PAD) {
+            // TODO(alee) Hack -- if we pass in null for the iv in the
+            // PKIArchiveOptions, we fail to decode correctly when parsing a
+            // CRMFPopClient request.
+            payloadWrappingIV = null;
+        } else {
+            payloadWrappingIV = wrapIV;
+        }
+    }
+
+    public static WrappingParams getWrappingParamsFromArchiveOptions(String wrapOID, String priKeyAlgo, IVParameterSpec wrapIV)
+            throws NumberFormatException, NoSuchAlgorithmException {
+        return new WrappingParams(wrapOID, priKeyAlgo, wrapIV);
+    }
+
+    public SymmetricKey.Type getSkType() {
+        return skType;
+    }
+
+    public void setSkType(SymmetricKey.Type skType) {
+        this.skType = skType;
+    }
+
+    public void setSkType(String skTypeName) throws NoSuchAlgorithmException {
+        this.skType = SymmetricKey.Type.fromName(skTypeName);
+    }
+
+    public KeyGenAlgorithm getSkKeyGenAlgorithm() {
+        return skKeyGenAlgorithm;
+    }
+
+    public void setSkKeyGenAlgorithm(KeyGenAlgorithm skKeyGenAlgorithm) {
+        this.skKeyGenAlgorithm = skKeyGenAlgorithm;
+    }
+
+    public void setSkKeyGenAlgorithm(String algName) throws NoSuchAlgorithmException {
+        // JSS mapping is not working.  Lets just do something brain-dead to
+        // handle the cases we expect.
+        if (algName.equalsIgnoreCase("AES")) {
+            skKeyGenAlgorithm = KeyGenAlgorithm.AES;
+        } else if (algName.equalsIgnoreCase("DES")) {
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES;
+        } else if (algName.equalsIgnoreCase("DESede")) {
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES3;
+        } else if (algName.equalsIgnoreCase("DES3")) {
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES3;
+        }
+    }
+
+    public int getSkLength() {
+        return skLength;
+    }
+
+    public void setSkLength(int skLength) {
+        this.skLength = skLength;
+    }
+
+    public KeyWrapAlgorithm getSkWrapAlgorithm() {
+        return skWrapAlgorithm;
+    }
+
+    public void setSkWrapAlgorithm(KeyWrapAlgorithm skWrapAlgorithm) {
+        this.skWrapAlgorithm = skWrapAlgorithm;
+    }
+
+    public void setSkWrapAlgorithm(String name) throws NoSuchAlgorithmException {
+        this.skWrapAlgorithm = KeyWrapAlgorithm.fromString(name);
+    }
+
+    public EncryptionAlgorithm getPayloadEncryptionAlgorithm() {
+        return payloadEncryptionAlgorithm;
+    }
+
+    public void setPayloadEncryptionAlgorithm(EncryptionAlgorithm payloadEncryptionAlgorithm) {
+        this.payloadEncryptionAlgorithm = payloadEncryptionAlgorithm;
+    }
+
+    public void setPayloadEncryptionAlgorithm(String algName, String modeName, String paddingName, int keyStrength)
+            throws NoSuchAlgorithmException {
+        this.payloadEncryptionAlgorithm = EncryptionAlgorithm.lookup(algName, modeName, paddingName, keyStrength);
+    }
+
+    public String getPayloadEncryptionAlgorithmName() {
+        // work around some of the issues with OIDs in JSS
+        int strength = payloadEncryptionAlgorithm.getKeyStrength();
+        String mode = payloadEncryptionAlgorithm.getMode().toString();
+        String padding = payloadEncryptionAlgorithm.getPadding().toString();
+        String alg = payloadEncryptionAlgorithm.getAlg().toString();
+        return alg + "/" + mode + "/" + padding + "/" + Integer.toString(strength);
+    }
+
+    public KeyWrapAlgorithm getPayloadWrapAlgorithm() {
+        return payloadWrapAlgorithm;
+    }
+
+    public void setPayloadWrapAlgorithm(KeyWrapAlgorithm payloadWrapAlgorithm) {
+        this.payloadWrapAlgorithm = payloadWrapAlgorithm;
+    }
+
+    public void setPayloadWrapAlgorithm(String name) throws NoSuchAlgorithmException {
+        this.payloadWrapAlgorithm = KeyWrapAlgorithm.fromString(name);
+    }
+
+    public IVParameterSpec getPayloadEncryptionIV() {
+        return payloadEncryptionIV;
+    }
+
+    public void setPayloadEncryptionIV(IVParameterSpec payloadEncryptionIV) {
+        this.payloadEncryptionIV = payloadEncryptionIV;
+    }
+
+    public IVParameterSpec getPayloadWrappingIV() {
+        return payloadWrappingIV;
+    }
+
+    public void setPayloadWrappingIV(IVParameterSpec payloadWrappingIV) {
+        this.payloadWrappingIV = payloadWrappingIV;
+    }
+}

--- a/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
+++ b/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
@@ -142,7 +142,16 @@ public class AlgorithmId implements Serializable, DerEncoder {
          * Figure out what class (if any) knows about this oid's
          * parameters.  Make one, and give it the data to decode.
          */
-        AlgorithmId alg = new AlgorithmId(algid, params);
+        AlgorithmId alg = null;
+        // omit parameter field for ECDSA
+        if (!algid.equals(sha224WithEC_oid) &&
+                !algid.equals(sha256WithEC_oid) &&
+                !algid.equals(sha384WithEC_oid) &&
+                !algid.equals(sha512WithEC_oid)) {
+            alg = new AlgorithmId(algid, params);
+        } else {
+            alg = new AlgorithmId(algid);
+        }
         if (params != null)
             alg.decodeParams();
 
@@ -790,17 +799,17 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * Supported signing algorithms for a RSA key.
      */
     public static final String[] RSA_SIGNING_ALGORITHMS = new String[]
-    { "SHA1withRSA", "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "MD5withRSA", "MD2withRSA" };
+    { "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withRSA" };
 
     public static final String[] EC_SIGNING_ALGORITHMS = new String[]
-    { "SHA1withEC", "SHA256withEC", "SHA384withEC", "SHA512withEC" };
+    { "SHA256withEC", "SHA384withEC", "SHA512withEC", "SHA1withEC" };
 
     /**
      * All supported signing algorithms.
      */
     public static final String[] ALL_SIGNING_ALGORITHMS = new String[]
     {
-            "SHA1withRSA", "MD5withRSA", "MD2withRSA", "SHA1withDSA", "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withEC",
-            "SHA256withEC", "SHA384withEC", "SHA512withEC" };
-
+        "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withRSA",
+        "SHA256withEC", "SHA384withEC", "SHA512withEC", "SHA1withEC"
+    };
 }

--- a/org/mozilla/jss/netscape/security/x509/CIDRNetmask.java
+++ b/org/mozilla/jss/netscape/security/x509/CIDRNetmask.java
@@ -1,0 +1,77 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package org.mozilla.jss.netscape.security.x509;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Netmask that is the number of significant bits.
+ */
+public class CIDRNetmask {
+    private int n;
+
+    public CIDRNetmask(String s) {
+        this(Integer.parseInt(s));
+    }
+
+    public CIDRNetmask(int n) {
+        if (n < 0)
+            throw new InvalidNetmaskException("cannot be negative");
+        this.n = n;
+    }
+
+    /**
+     * Write the netmask into a byte buffer.
+     *
+     * Throw InvalidNetmaskException if negative or if the
+     * size exceeds the size of the address type inferred
+     * from the remaining buffer space (which must be 4
+     * bytes for IPv4 and 16 bytes for IPv6).
+     *
+     * exceeds the size of the buffer
+     */
+    protected void write(ByteBuffer buf) {
+        // determine type of addr based on bytes left in buffer
+        int remaining = buf.remaining();
+        int bits = 0;
+        if (remaining == 4)
+            bits = 32;
+        else if (remaining == 16)
+            bits = 128;
+        else
+            throw new InvalidNetmaskException(
+                "cannot determine type of address for netmask");
+
+        if (n > bits)
+            throw new InvalidNetmaskException("netmask exceed address size");
+
+        int maskSigBits = n;
+        for (; remaining > 0; remaining--) {
+            int maskByteSigBits = Math.min(8, maskSigBits);
+            byte maskByte = (byte) (0xff - (0xff >> maskByteSigBits));
+            buf.put(maskByte);
+            maskSigBits = Math.max(maskSigBits - 8, 0);
+        }
+    }
+
+    public String toString() {
+        return "/" + n;
+    }
+
+}

--- a/org/mozilla/jss/netscape/security/x509/GeneralName.java
+++ b/org/mozilla/jss/netscape/security/x509/GeneralName.java
@@ -197,6 +197,18 @@ public class GeneralName implements GeneralNameInterface {
         }
     }
 
+    @Override
+    public boolean validSingle() {
+        if (this == name) return false;  // can't happen, but just in case...
+        return name.validSingle();
+    }
+
+    @Override
+    public boolean validSubtree() {
+        if (this == name) return false;  // can't happen, but just in case...
+        return name.validSubtree();
+    }
+
     /**
      * Unwrap this GeneralName until we reach something that is not
      * a GeneralName.

--- a/org/mozilla/jss/netscape/security/x509/GeneralNameInterface.java
+++ b/org/mozilla/jss/netscape/security/x509/GeneralNameInterface.java
@@ -57,4 +57,20 @@ public interface GeneralNameInterface extends java.io.Serializable {
      *                encoded.
      */
     void encode(DerOutputStream out) throws IOException;
+
+    /**
+     * Whether the name is valid as a single name (e.g. for use in
+     * Subject Alternative Name extension).
+     */
+    default boolean validSingle() {
+        return true;
+    }
+
+    /**
+     * Whether the name is valid as a subtree name (e.g. for use in
+     * Name Constraints extension)
+     */
+    default boolean validSubtree() {
+        return true;
+    }
 }

--- a/org/mozilla/jss/netscape/security/x509/InvalidNetmaskException.java
+++ b/org/mozilla/jss/netscape/security/x509/InvalidNetmaskException.java
@@ -1,0 +1,27 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package org.mozilla.jss.netscape.security.x509;
+
+public class InvalidNetmaskException extends RuntimeException {
+
+    public InvalidNetmaskException(String desc) {
+        super("Invalid netmask (" + desc + ")");
+    }
+
+}

--- a/org/mozilla/jss/tests/BigObjectIdentifier.java
+++ b/org/mozilla/jss/tests/BigObjectIdentifier.java
@@ -1,0 +1,54 @@
+package org.mozilla.jss.tests;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import org.mozilla.jss.netscape.security.util.*;
+
+public class BigObjectIdentifier {
+    public static void main(String[] args) throws Exception {
+
+        long[] oid_components_long = { 1L, 3L,6L,1L,4L,1L,5000L,9L,1L,1L,1526913300628L, 1L};
+        int[] oid_components_int =  { 1, 3,6,1,4,1,2312,9,1,1,15269, 1, 1};
+        BigInteger[] oid_components_big_int = { new BigInteger("1"), new BigInteger("3"), new BigInteger("6"), new BigInteger("1"),
+            new BigInteger("4"), new BigInteger("1"), new BigInteger("2312"),
+            new BigInteger("9"), new BigInteger("1"),
+            new BigInteger("152691330062899999999999997777788888888888888889999999999999999"), new BigInteger("1")
+        };
+
+        String oidIn = "1.3.6.1.4.1.2312.9.1.152691330062899999999999997777788888888888888889999999999999999.1";
+        ObjectIdentifier oid = new ObjectIdentifier(oidIn);
+
+        ObjectIdentifier fromDer = null;
+        ObjectIdentifier fromStaticMethod = null;
+        ObjectIdentifier fromComponentList = null;
+        ObjectIdentifier  fromComponentListInt = null;
+        ObjectIdentifier fromComponentListBigInt = null;
+
+        System.out.println("oid: " + oid.toString());
+
+        DerOutputStream out = new DerOutputStream();
+
+        oid.encode(out);
+        DerInputStream  in = new DerInputStream(out.toByteArray());
+        fromDer = new ObjectIdentifier(in);
+
+        System.out.println("fromDer: " + fromDer.toString());
+
+        fromStaticMethod = ObjectIdentifier.getObjectIdentifier(oidIn);
+
+        System.out.println("fromStaticMethod: " + fromStaticMethod.toString());
+
+        fromComponentList = new ObjectIdentifier(oid_components_long);
+
+        System.out.println("fromComponentList: " + fromComponentList.toString());
+
+        fromComponentListInt = new ObjectIdentifier(oid_components_int);
+
+        System.out.println("fromComponentListInt: " + fromComponentListInt);
+
+        fromComponentListBigInt = new ObjectIdentifier(oid_components_big_int);
+
+        System.out.println("fromComponentListBigInt: " + fromComponentListBigInt);
+    }
+}


### PR DESCRIPTION
This PR depends on #104 and includes commits from that series; it will be rebased when that PR is merged.

Each commit in question includes two paths: the path under the JSS source repo and the path under the PKI source repo. This allows easy review: clone PKI at master, clone JSS at this PR's `HEAD`, and diff each of the changed files. The changes should be minimal, only changing associated imports and other fully qualified package names.


This will allow us to remove the code from PKI, release a new JSS version with the changes, make PKI depend on this new JSS version, and remove from PKI these classes. See: 

 - [PKI PR#121](https://github.com/dogtagpki/pki/pull/121) - which updates package paths (`netscape.security` -> `org.mozilla.jss.netscape.security`)
 - [PKI PR#122](https://github.com/dogtagpki/pki/pull/122) - which removes `netscape.security` from the PKI tree. 
 - [PKI PR#123](https://github.com/dogtagpki/pki/pull/123) - which removes the `getKeyWrapAlgorithmFromOID(...)` function from the PKI tree. This is implemented as part of #104. 

These combined commits (this PR and the three against PKI) have been tested with [`ansible-vms`](https://github.com/cipherboy/ansible-vms/blob/master/pki-integration.yml) and a CA set up. This ensures that PKI builds after these changes and is a basic sanity check to make sure PKI installs and runs.

A helpful script for minimizing differences is available [on my gist](https://gist.githubusercontent.com/cipherboy/07995403dd194b7e76bbbed62180cecf/raw/7516984cfaded4bc8028118cbe1559925c657c1a/filter_packages.sh). Usage is `filter_packages.sh > /tmp/output < pki/some_input_class.java`, and then you can run `diff /tmp/output jss/some_input_class.java` and have minimal differences.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`