### PR TITLE
Release JSS version 4.5.1

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -2,7 +2,7 @@ macro(jss_config)
     # Set the current JSS release number. Arguments are:
     #   MAJOR MINOR PATCH BETA
     # When BETA is zero, it isn't a beta release.
-    jss_config_version(4 5 0 0)
+    jss_config_version(4 5 1 0)
 
     # Configure output directories
     jss_config_outputs()

--- a/jss.spec
+++ b/jss.spec
@@ -6,7 +6,7 @@ Summary:        Java Security Services (JSS)
 URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
-Version:        4.5.0
+Version:        4.5.1
 Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
 # global         _phase -a1
 


### PR DESCRIPTION
A several notable changes have been made since 4.5.0:

 - A new CMake build system has been introduced to replace coreconf,
 - Support for OpenJDK versions 8 through 11 has been added,
 - Reproducible JAR builds,
 - Minor DER encoding issues have been fixed,
 - Synced supported TLS ciphersuites with NSS,
 - Introduced PKCS11 Constants in JSS to replace Sun constants,
 - And various other minor changes.

Thanks to everyone who has contributed since 4.5.0!

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`