### PR TITLE
Cleanup warnings

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11Store.c
+++ b/org/mozilla/jss/pkcs11/PK11Store.c
@@ -650,6 +650,7 @@ Java_org_mozilla_jss_pkcs11_PK11Store_getEncryptedPrivateKeyInfo(
     SECItem epkiItem;
     epkiItem.data = NULL;
     epkiItem.len = 0;
+    jbyteArray encodedEpki = NULL;
 
     PR_ASSERT(env != NULL && this != NULL);
 
@@ -709,7 +710,7 @@ Java_org_mozilla_jss_pkcs11_PK11Store_getEncryptedPrivateKeyInfo(
     }
 
     // convert to Java byte array
-    jbyteArray encodedEpki = JSS_SECItemToByteArray(env, &epkiItem);
+    encodedEpki = JSS_SECItemToByteArray(env, &epkiItem);
 
 finish:
     if (epki != NULL) {

--- a/org/mozilla/jss/ssl/callbacks.c
+++ b/org/mozilla/jss/ssl/callbacks.c
@@ -286,6 +286,12 @@ JSSL_AlertReceivedCallback(const PRFileDesc *fd, void *arg, const SSLAlert *aler
     PR_ASSERT(rc == JNI_OK);
     PR_ASSERT(env != NULL);
 
+    /* Fast return when assumptions are incorrect. */
+    if (socket != NULL || socket->socketObject != NULL ||
+            rc != JNI_OK || env != NULL) {
+        return;
+    }
+
     /* SSLAlertEvent event = new SSLAlertEvent(socket); */
 
     socketClass = (*env)->FindClass(env, SSLSOCKET_CLASS);
@@ -345,6 +351,12 @@ JSSL_AlertSentCallback(const PRFileDesc *fd, void *arg, const SSLAlert *alert)
     rc = (*JSS_javaVM)->AttachCurrentThread(JSS_javaVM, (void**)&env, NULL);
     PR_ASSERT(rc == JNI_OK);
     PR_ASSERT(env != NULL);
+
+    /* Fast return when assumptions are incorrect. */
+    if (socket != NULL || socket->socketObject != NULL ||
+            rc != JNI_OK || env != NULL) {
+        return;
+    }
 
     /* SSLAlertEvent event = new SSLAlertEvent(socket); */
 


### PR DESCRIPTION
This PR fixes two warnings during the build: an unused variable in `callbacks.c` and more importantly, fix an uninitialized return in error cases in `PK11Store.c`.

I'm scheduling this for 4.5.2 time frame as it is only a minor change.