### PR TITLE
Backport two DER encoding fixes

### DIFF
--- a/org/mozilla/jss/netscape/security/util/DerOutputStream.java
+++ b/org/mozilla/jss/netscape/security/util/DerOutputStream.java
@@ -206,7 +206,7 @@ public class DerOutputStream
             }
         } else {
             // positive case
-            for (length = 4; length > 0; --length) {
+            for (length = 4; length > 1; --length) {
                 if ((i & bytemask) != 0)
                     break;
                 bytemask = bytemask >>> 8;


### PR DESCRIPTION
This backports two DER encoding fixes from master to the v4.4.x branch.

#69 and #89.