### PR TITLE
[WIP] Backport Sync PKI and JSS common classes

### DIFF
--- a/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
+++ b/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
@@ -147,6 +147,6 @@ public class KeyWrapAlgorithm extends Algorithm {
         if (oid.equals(DES_CBC_PAD_OID))
             return DES_CBC_PAD;
 
-        throw new NoSuchAlgorithmException();
+        throw new NoSuchAlgorithmException("Unknown Algorithm for OID: " + wrapOID);
     }
 }

--- a/org/mozilla/jss/netscape/security/pkcs/PKCS12CertInfo.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS12CertInfo.java
@@ -17,25 +17,24 @@
 // --- END COPYRIGHT BLOCK ---
 package org.mozilla.jss.netscape.security.pkcs;
 
-import java.math.BigInteger;
-
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
 public class PKCS12CertInfo {
 
-    BigInteger id;
-    X509CertImpl cert;
-    String nickname;
-    String trustFlags;
+    private byte[] id;
+    private X509CertImpl cert;
+    private String friendlyName;
+    private String trustFlags;
+    private byte[] keyID;
 
     public PKCS12CertInfo() {
     }
 
-    public BigInteger getID() {
+    public byte[] getID() {
         return id;
     }
 
-    public void setID(BigInteger id) {
+    public void setID(byte[] id) {
         this.id = id;
     }
 
@@ -47,12 +46,12 @@ public class PKCS12CertInfo {
         this.cert = cert;
     }
 
-    public String getNickname() {
-        return nickname;
+    public String getFriendlyName() {
+        return friendlyName;
     }
 
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
+    public void setFriendlyName(String friendlyName) {
+        this.friendlyName = friendlyName;
     }
 
     public String getTrustFlags() {
@@ -61,5 +60,13 @@ public class PKCS12CertInfo {
 
     public void setTrustFlags(String trustFlags) {
         this.trustFlags = trustFlags;
+    }
+
+    public byte[] getKeyID() {
+        return keyID;
+    }
+
+    public void setKeyID(byte[] keyID) {
+        this.keyID = keyID;
     }
 }

--- a/org/mozilla/jss/netscape/security/pkcs/PKCS12KeyInfo.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS12KeyInfo.java
@@ -17,8 +17,6 @@
 // --- END COPYRIGHT BLOCK ---
 package org.mozilla.jss.netscape.security.pkcs;
 
-import java.math.BigInteger;
-
 import org.mozilla.jss.crypto.PrivateKey;
 
 /**
@@ -36,8 +34,8 @@ public class PKCS12KeyInfo {
 
     private PrivateKey privateKey;
     private byte[] epkiBytes;
-    BigInteger id;
-    String subjectDN;
+    private byte[] id;
+    private String friendlyName;
 
     public PKCS12KeyInfo() {
     }
@@ -66,19 +64,19 @@ public class PKCS12KeyInfo {
         return epkiBytes;
     }
 
-    public BigInteger getID() {
+    public byte[] getID() {
         return id;
     }
 
-    public void setID(BigInteger id) {
+    public void setID(byte[] id) {
         this.id = id;
     }
 
-    public String getSubjectDN() {
-        return subjectDN;
+    public String getFriendlyName() {
+        return friendlyName;
     }
 
-    public void setSubjectDN(String subjectDN) {
-        this.subjectDN = subjectDN;
+    public void setFriendlyName(String friendlyName) {
+        this.friendlyName = friendlyName;
     }
 }

--- a/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
@@ -27,9 +27,14 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.Principal;
 import java.security.PublicKey;
+import java.security.SecureRandom;
 import java.security.cert.CertificateException;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.ArrayList;
 
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang.StringUtils;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.asn1.ANY;
@@ -45,24 +50,106 @@ import org.mozilla.jss.crypto.EncryptionAlgorithm;
 import org.mozilla.jss.crypto.InternalCertificate;
 import org.mozilla.jss.crypto.NoSuchItemOnTokenException;
 import org.mozilla.jss.crypto.ObjectNotFoundException;
+import org.mozilla.jss.crypto.PBEAlgorithm;
 import org.mozilla.jss.crypto.PrivateKey;
 import org.mozilla.jss.crypto.X509Certificate;
+import org.mozilla.jss.pkcs11.PK11Store;
 import org.mozilla.jss.pkcs12.AuthenticatedSafes;
 import org.mozilla.jss.pkcs12.CertBag;
 import org.mozilla.jss.pkcs12.PFX;
 import org.mozilla.jss.pkcs12.PasswordConverter;
 import org.mozilla.jss.pkcs12.SafeBag;
 import org.mozilla.jss.pkix.primitive.Attribute;
+import org.mozilla.jss.pkix.primitive.EncryptedPrivateKeyInfo;
 import org.mozilla.jss.util.Password;
 
-import netscape.ldap.LDAPDN;
-import netscape.ldap.util.DN;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.naming.InvalidNameException;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
 public class PKCS12Util {
 
+    public final static String NO_ENCRYPTION = "none";
 
+    public final static List<PBEAlgorithm> SUPPORTED_CERT_ENCRYPTIONS = Arrays.asList(new PBEAlgorithm[] {
+            null, // none
+            PBEAlgorithm.PBE_SHA1_RC2_40_CBC
+    });
+
+    public final static List<PBEAlgorithm> SUPPORTED_KEY_ENCRYPTIONS = Arrays.asList(new PBEAlgorithm[] {
+            PBEAlgorithm.PBE_PKCS5_PBES2,
+            PBEAlgorithm.PBE_SHA1_DES3_CBC
+    });
+
+    public final static PBEAlgorithm DEFAULT_CERT_ENCRYPTION = SUPPORTED_CERT_ENCRYPTIONS.get(0);
+    public final static String DEFAULT_CERT_ENCRYPTION_NAME = NO_ENCRYPTION;
+
+    public final static PBEAlgorithm DEFAULT_KEY_ENCRYPTION = SUPPORTED_KEY_ENCRYPTIONS.get(0);
+    public final static String DEFAULT_KEY_ENCRYPTION_NAME = DEFAULT_KEY_ENCRYPTION.toString();
+
+    SecureRandom random;
+    PBEAlgorithm certEncryption = DEFAULT_CERT_ENCRYPTION;
+    PBEAlgorithm keyEncryption = DEFAULT_KEY_ENCRYPTION;
     boolean trustFlagsEnabled = true;
+
+    public PKCS12Util() throws Exception {
+        random = SecureRandom.getInstance("pkcs11prng", "Mozilla-JSS");
+    }
+
+    public void setCertEncryption(String name) throws Exception {
+
+        for (PBEAlgorithm algorithm : SUPPORTED_CERT_ENCRYPTIONS) {
+
+            if (algorithm == null) {
+                if (NO_ENCRYPTION.equals(name)) {
+                    this.certEncryption = null;
+                    return;
+                }
+
+            } else if (algorithm.toString().equals(name)) {
+                this.certEncryption = algorithm;
+                return;
+            }
+        }
+
+        throw new Exception("Unsupported certificate encryption: " + name);
+    }
+
+    public void setCertEncryption(PBEAlgorithm algorithm) throws Exception {
+        this.certEncryption = algorithm;
+    }
+
+    public PBEAlgorithm getCertEncryption() {
+        return certEncryption;
+    }
+
+    public void setKeyEncryption(String name) throws Exception {
+
+        for (PBEAlgorithm algorithm : SUPPORTED_KEY_ENCRYPTIONS) {
+
+            if (algorithm == null) {
+                if (NO_ENCRYPTION.equals(name)) {
+                    this.keyEncryption = null;
+                    return;
+                }
+
+            } else if (algorithm.toString().equals(name)) {
+                this.keyEncryption = algorithm;
+                return;
+            }
+        }
+
+        throw new Exception("Unsupported key encryption: " + name);
+    }
+
+    public void setKeyEncryption(PBEAlgorithm algorithm) throws Exception {
+        this.keyEncryption = algorithm;
+    }
+
+    public PBEAlgorithm getKeyEncryption() {
+        return keyEncryption;
+    }
 
     public boolean isTrustFlagsEnabled() {
         return trustFlagsEnabled;
@@ -99,7 +186,8 @@ public class PKCS12Util {
         icert.setObjectSigningTrust(PKCS12.decodeFlags(flags[2]));
     }
 
-    /** Add a private key to the PKCS #12 object.
+    /**
+     * Add a private key to the PKCS #12 object.
      *
      * The PKCS12KeyInfo object received comes about in two
      * different scenarios:
@@ -121,47 +209,91 @@ public class PKCS12Util {
     public void addKeyBag(PKCS12KeyInfo keyInfo, Password password,
             SEQUENCE encSafeContents) throws Exception {
 
+        byte[] keyID = keyInfo.getID();
+
+        ASN1Value content;
+
         byte[] epkiBytes = keyInfo.getEncryptedPrivateKeyInfoBytes();
-        if (epkiBytes == null) {
-            PrivateKey k = keyInfo.getPrivateKey();
-            if (k == null) {
-                return;
+
+        if (epkiBytes != null) {
+            // private key already encrypted
+            content = new ANY(epkiBytes);
+
+        } else {
+            PrivateKey privateKey = keyInfo.getPrivateKey();
+            if (privateKey == null) {
+                throw new Exception("Missing private key for " + keyInfo.getFriendlyName());
             }
 
-            epkiBytes = CryptoManager.getInstance()
-                .getInternalKeyStorageToken()
-                .getCryptoStore()
-                .getEncryptedPrivateKeyInfo(
-                    /* For compatibility with OpenSSL and NSS >= 3.31,
-                     * do not BMPString-encode the passphrase when using
-                     * non-PKCS #12 PBE scheme such as PKCS #5 PBES2.
-                     *
-                     * The resulting PKCS #12 is not compatible with
-                     * NSS < 3.31.
-                     */
-                    null /* passConverter */,
-                    password,
-                    /* NSS has a bug that causes any AES CBC encryption
-                     * to use AES-256, but AlgorithmID contains chosen
-                     * alg.  To avoid mismatch, use AES_256_CBC. */
-                    EncryptionAlgorithm.AES_256_CBC,
-                    0 /* iterations (default) */,
-                    k);
+            CryptoToken token = CryptoManager.getInstance().getInternalKeyStorageToken();
+
+            if (keyEncryption == PBEAlgorithm.PBE_SHA1_DES3_CBC) {
+                content = create_EPKI_with_PBE_SHA1_DES3_CBC(token, privateKey, password);
+
+            } else if (keyEncryption == PBEAlgorithm.PBE_PKCS5_PBES2) {
+                content = create_EPKI_with_PBE_PKCS5_PBES2(token, privateKey, password);
+
+            } else {
+                throw new Exception("Unsupported key encryption: " + keyEncryption);
+            }
         }
 
         SET keyAttrs = createKeyBagAttrs(keyInfo);
 
-        SafeBag safeBag = new SafeBag(
-            SafeBag.PKCS8_SHROUDED_KEY_BAG, new ANY(epkiBytes), keyAttrs);
+        SafeBag safeBag = new SafeBag(SafeBag.PKCS8_SHROUDED_KEY_BAG, content, keyAttrs);
         encSafeContents.addElement(safeBag);
+    }
+
+    public ASN1Value create_EPKI_with_PBE_SHA1_DES3_CBC(CryptoToken token, PrivateKey privateKey, Password password)
+            throws Exception {
+
+        // Use the same salt size and number of iterations as in pk12util.
+
+        byte[] salt = new byte[16];
+        random.nextBytes(salt);
+
+        return EncryptedPrivateKeyInfo.createPBE(
+                PBEAlgorithm.PBE_SHA1_DES3_CBC,
+                password,
+                salt,
+                100000, // iterations
+                new PasswordConverter(),
+                privateKey,
+                token);
+    }
+
+    public ASN1Value create_EPKI_with_PBE_PKCS5_PBES2(CryptoToken token, PrivateKey privateKey, Password password)
+            throws Exception {
+
+        CryptoStore store = token.getCryptoStore();
+
+        byte[] bytes = store.getEncryptedPrivateKeyInfo(
+                // For compatibility with OpenSSL and NSS >= 3.31,
+                // do not BMPString-encode the passphrase when using
+                // non-PKCS #12 PBE scheme such as PKCS #5 PBES2.
+                //
+                // The resulting PKCS #12 is not compatible with
+                // NSS < 3.31.
+                null, // password converter
+                password,
+                // NSS has a bug that causes any AES CBC encryption
+                // to use AES-256, but AlgorithmID contains chosen
+                // alg.  To avoid mismatch, use AES_256_CBC.
+                EncryptionAlgorithm.AES_256_CBC,
+                0, // iterations (default)
+                privateKey);
+
+        return new ANY(bytes);
     }
 
     public void addCertBag(PKCS12CertInfo certInfo,
             SEQUENCE safeContents) throws Exception {
 
+        byte[] id = certInfo.getID();
 
-        ASN1Value cert = new OCTET_STRING(certInfo.cert.getEncoded());
-        CertBag certBag = new CertBag(CertBag.X509_CERT_TYPE, cert);
+        X509CertImpl cert = certInfo.getCert();
+        ASN1Value certAsn1 = new OCTET_STRING(cert.getEncoded());
+        CertBag certBag = new CertBag(CertBag.X509_CERT_TYPE, certAsn1);
 
         SET certAttrs = createCertBagAttrs(certInfo);
 
@@ -185,20 +317,23 @@ public class PKCS12Util {
 
         SET attrs = new SET();
 
+        String friendlyName = keyInfo.getFriendlyName();
+
         SEQUENCE subjectAttr = new SEQUENCE();
         subjectAttr.addElement(SafeBag.FRIENDLY_NAME);
 
         SET subjectSet = new SET();
-        subjectSet.addElement(new BMPString(keyInfo.subjectDN));
+        subjectSet.addElement(new BMPString(friendlyName));
         subjectAttr.addElement(subjectSet);
 
         attrs.addElement(subjectAttr);
 
+        byte[] keyID = keyInfo.getID();
         SEQUENCE localKeyAttr = new SEQUENCE();
         localKeyAttr.addElement(SafeBag.LOCAL_KEY_ID);
 
         SET localKeySet = new SET();
-        localKeySet.addElement(new OCTET_STRING(keyInfo.id.toByteArray()));
+        localKeySet.addElement(new OCTET_STRING(keyID));
         localKeyAttr.addElement(localKeySet);
 
         attrs.addElement(localKeyAttr);
@@ -210,35 +345,41 @@ public class PKCS12Util {
 
         SET attrs = new SET();
 
+        String friendlyName = certInfo.getFriendlyName();
+
         SEQUENCE nicknameAttr = new SEQUENCE();
         nicknameAttr.addElement(SafeBag.FRIENDLY_NAME);
 
         SET nicknameSet = new SET();
-        nicknameSet.addElement(new BMPString(certInfo.nickname));
+        nicknameSet.addElement(new BMPString(friendlyName));
         nicknameAttr.addElement(nicknameSet);
 
         attrs.addElement(nicknameAttr);
 
-        if (certInfo.getID() != null) {
-            SEQUENCE localKeyAttr = new SEQUENCE();
-            localKeyAttr.addElement(SafeBag.LOCAL_KEY_ID);
+        String trustFlags = certInfo.getTrustFlags();
+        if (trustFlags != null && trustFlagsEnabled) {
 
-            SET localKeySet = new SET();
-            localKeySet.addElement(new OCTET_STRING(certInfo.id.toByteArray()));
-            localKeyAttr.addElement(localKeySet);
-
-            attrs.addElement(localKeyAttr);
-        }
-
-        if (certInfo.trustFlags != null && trustFlagsEnabled) {
             SEQUENCE trustFlagsAttr = new SEQUENCE();
             trustFlagsAttr.addElement(PKCS12.CERT_TRUST_FLAGS_OID);
 
             SET trustFlagsSet = new SET();
-            trustFlagsSet.addElement(new BMPString(certInfo.trustFlags));
+            trustFlagsSet.addElement(new BMPString(trustFlags));
             trustFlagsAttr.addElement(trustFlagsSet);
 
             attrs.addElement(trustFlagsAttr);
+        }
+
+        byte[] keyID = certInfo.getKeyID();
+        if (keyID != null) {
+
+            SEQUENCE localKeyAttr = new SEQUENCE();
+            localKeyAttr.addElement(SafeBag.LOCAL_KEY_ID);
+
+            SET localKeySet = new SET();
+            localKeySet.addElement(new OCTET_STRING(keyID));
+            localKeyAttr.addElement(localKeySet);
+
+            attrs.addElement(localKeyAttr);
         }
 
         return attrs;
@@ -260,94 +401,192 @@ public class PKCS12Util {
         }
     }
 
-    public void loadCertFromNSS(PKCS12 pkcs12, String nickname, boolean includeKey, boolean includeChain) throws Exception {
+    public void loadCertFromNSS(
+            PKCS12 pkcs12,
+            String nickname,
+            boolean includeKey,
+            boolean includeChain) throws Exception {
+
+        loadCertFromNSS(pkcs12, nickname, includeKey, includeChain, null);
+    }
+
+    public void loadCertFromNSS(
+            PKCS12 pkcs12,
+            String nickname,
+            boolean includeKey,
+            boolean includeChain,
+            String friendlyName) throws Exception {
 
         CryptoManager cm = CryptoManager.getInstance();
 
         X509Certificate[] certs = cm.findCertsByNickname(nickname);
+
+        if (certs == null || certs.length == 0) {
+            throw new Exception("Certificate not found: " + nickname);
+        }
+
         for (X509Certificate cert : certs) {
-            loadCertFromNSS(pkcs12, cert, includeKey, includeChain);
+            loadCertFromNSS(pkcs12, cert, includeKey, includeChain, friendlyName);
         }
     }
 
-    public void loadCertFromNSS(PKCS12 pkcs12, X509Certificate cert, boolean includeKey, boolean includeChain) throws Exception {
+    public void loadCertFromNSS(
+            PKCS12 pkcs12,
+            X509Certificate cert,
+            boolean includeKey,
+            boolean includeChain) throws Exception {
+
+        loadCertFromNSS(pkcs12, cert, includeKey, includeChain, null);
+    }
+
+    public void loadCertFromNSS(
+            PKCS12 pkcs12,
+            X509Certificate cert,
+            boolean includeKey,
+            boolean includeChain,
+            String friendlyName) throws Exception {
 
         CryptoManager cm = CryptoManager.getInstance();
 
-        BigInteger id = createLocalID(cert);
+        PKCS12CertInfo certInfo = createCertInfoFromNSS(cert, friendlyName);
+        pkcs12.addCertInfo(certInfo, true);
 
-        // load cert info
-        loadCertInfoFromNSS(pkcs12, cert, id, true);
+        byte[] id = certInfo.getID();
 
         if (includeKey) {
             // load key info if exists
-            loadKeyInfoFromNSS(pkcs12, cert, id);
+
+            try {
+                PrivateKey privateKey = cm.findPrivKeyByCert(cert);
+
+                PKCS12KeyInfo keyInfo = createKeyInfoFromNSS(cert, privateKey, friendlyName);
+                pkcs12.addKeyInfo(keyInfo);
+
+                byte[] keyID = keyInfo.getID();
+                certInfo.setKeyID(keyID);
+            } catch (ObjectNotFoundException e) {
+            }
         }
 
         if (includeChain) {
             // load cert chain
             X509Certificate[] certChain = cm.buildCertificateChain(cert);
             for (int i = 1; i < certChain.length; i++) {
-                X509Certificate c = certChain[i];
-                BigInteger cid = createLocalID(c);
-                loadCertInfoFromNSS(pkcs12, c, cid, false);
+                X509Certificate caCert = certChain[i];
+
+                PKCS12CertInfo caCertInfo = createCertInfoFromNSS(caCert);
+                pkcs12.addCertInfo(caCertInfo, false);
+
+                byte[] caCertID = caCertInfo.getID();
             }
         }
     }
 
-    public void loadCertInfoFromNSS(PKCS12 pkcs12, X509Certificate cert, BigInteger id, boolean replace) throws Exception {
+    public PKCS12CertInfo createCertInfoFromNSS(
+            X509Certificate cert) throws Exception {
 
-        String nickname = cert.getNickname();
-
-        PKCS12CertInfo certInfo = new PKCS12CertInfo();
-        certInfo.id = id;
-        certInfo.nickname = nickname;
-        certInfo.cert = new X509CertImpl(cert.getEncoded());
-        certInfo.trustFlags = getTrustFlags(cert);
-
-        pkcs12.addCertInfo(certInfo, replace);
+        return createCertInfoFromNSS(cert, null);
     }
 
-    public void loadKeyInfoFromNSS(PKCS12 pkcs12, X509Certificate cert, BigInteger id) throws Exception {
+    public PKCS12CertInfo createCertInfoFromNSS(
+            X509Certificate cert,
+            String friendlyName) throws Exception {
 
-        String nickname = cert.getNickname();
+        // generate cert ID from SHA-1 hash of cert data
+        byte[] id = SafeBag.getLocalKeyIDFromCert(cert.getEncoded());
 
-        CryptoManager cm = CryptoManager.getInstance();
-
-        try {
-            PrivateKey privateKey = cm.findPrivKeyByCert(cert);
-
-            PKCS12KeyInfo keyInfo = new PKCS12KeyInfo(privateKey);
-            keyInfo.id = id;
-            keyInfo.subjectDN = cert.getSubjectDN().toString();
-
-            pkcs12.addKeyInfo(keyInfo);
-
-        } catch (ObjectNotFoundException e) {
+        if (friendlyName == null) {
+            friendlyName = cert.getNickname();
         }
+
+        X509CertImpl certImpl = new X509CertImpl(cert.getEncoded());
+        String trustFlags = getTrustFlags(cert);
+
+        PKCS12CertInfo certInfo = new PKCS12CertInfo();
+        certInfo.setID(id);
+        certInfo.setFriendlyName(friendlyName);
+        certInfo.setCert(certImpl);
+        certInfo.setTrustFlags(trustFlags);
+
+        return certInfo;
+    }
+
+    public PKCS12KeyInfo createKeyInfoFromNSS(
+            X509Certificate cert,
+            PrivateKey privateKey) throws Exception {
+
+        return createKeyInfoFromNSS(cert, privateKey, null);
+    }
+
+    public PKCS12KeyInfo createKeyInfoFromNSS(
+            X509Certificate cert,
+            PrivateKey privateKey,
+            String friendlyName) throws Exception {
+
+        byte[] keyID = privateKey.getUniqueID();
+
+        if (friendlyName == null) {
+            friendlyName = cert.getNickname();
+        }
+
+        PKCS12KeyInfo keyInfo = new PKCS12KeyInfo(privateKey);
+        keyInfo.setID(keyID);
+        keyInfo.setFriendlyName(friendlyName);
+
+        return keyInfo;
     }
 
     public PFX generatePFX(PKCS12 pkcs12, Password password) throws Exception {
 
-
-        SEQUENCE safeContents = new SEQUENCE();
-
-        for (PKCS12CertInfo certInfo : pkcs12.getCertInfos()) {
-            addCertBag(certInfo, safeContents);
-        }
-
-        SEQUENCE encSafeContents = new SEQUENCE();
-
-        for (PKCS12KeyInfo keyInfo : pkcs12.getKeyInfos()) {
-            addKeyBag(keyInfo, password, encSafeContents);
-        }
-
         AuthenticatedSafes authSafes = new AuthenticatedSafes();
-        authSafes.addSafeContents(safeContents);
-        authSafes.addSafeContents(encSafeContents);
+
+        Collection<PKCS12KeyInfo> keyInfos = pkcs12.getKeyInfos();
+        Collection<PKCS12CertInfo> certInfos = pkcs12.getCertInfos();
+
+        if (!keyInfos.isEmpty()) {
+            SEQUENCE keySafeContents = new SEQUENCE();
+
+            for (PKCS12KeyInfo keyInfo : keyInfos) {
+                addKeyBag(keyInfo, password, keySafeContents);
+            }
+
+            authSafes.addSafeContents(keySafeContents);
+        }
+
+        if (!certInfos.isEmpty()) {
+            SEQUENCE certSafeContents = new SEQUENCE();
+
+            for (PKCS12CertInfo certInfo : certInfos) {
+                addCertBag(certInfo, certSafeContents);
+            }
+
+            if (certEncryption == null) {
+                authSafes.addSafeContents(certSafeContents);
+
+            } else if (certEncryption == PBEAlgorithm.PBE_SHA1_RC2_40_CBC) {
+
+                byte[] salt = new byte[16];
+                random.nextBytes(salt);
+
+                authSafes.addEncryptedSafeContents(
+                        certEncryption,
+                        password,
+                        salt,
+                        100000, // iterations
+                        certSafeContents);
+
+            } else {
+                throw new Exception("Unsupported certificate encryption: " + certEncryption);
+            }
+        }
 
         PFX pfx = new PFX(authSafes);
-        pfx.computeMacData(password, null, 5);
+
+        // Use the same salt size and number of iterations as in pk12util.
+
+        byte[] salt = new byte[16];
+        random.nextBytes(salt);
+        pfx.computeMacData(password, salt, 100000);
 
         return pfx;
     }
@@ -389,9 +628,9 @@ public class PKCS12Util {
                 ANY value = (ANY) values.elementAt(0);
 
                 ByteArrayInputStream bis = new ByteArrayInputStream(value.getEncoded());
-                BMPString subjectDN = (BMPString) new BMPString.Template().decode(bis);
+                BMPString friendlyName = (BMPString) new BMPString.Template().decode(bis);
 
-                keyInfo.subjectDN = subjectDN.toString();
+                keyInfo.setFriendlyName(friendlyName.toString());
 
             } else if (oid.equals(SafeBag.LOCAL_KEY_ID)) {
 
@@ -399,9 +638,11 @@ public class PKCS12Util {
                 ANY value = (ANY) values.elementAt(0);
 
                 ByteArrayInputStream bis = new ByteArrayInputStream(value.getEncoded());
-                OCTET_STRING keyID = (OCTET_STRING) new OCTET_STRING.Template().decode(bis);
+                OCTET_STRING keyIdAsn1 = (OCTET_STRING) new OCTET_STRING.Template().decode(bis);
 
-                keyInfo.id = new BigInteger(1, keyID.toByteArray());
+                byte[] keyID = keyIdAsn1.toByteArray();
+                keyInfo.setID(keyID);
+
             }
         }
 
@@ -417,8 +658,14 @@ public class PKCS12Util {
         OCTET_STRING certStr = (OCTET_STRING) certBag.getInterpretedCert();
         byte[] x509cert = certStr.toByteArray();
 
-        certInfo.cert = new X509CertImpl(x509cert);
-        Principal subjectDN = certInfo.cert.getSubjectDN();
+        // generate cert ID from SHA-1 hash of cert data
+        byte[] id = SafeBag.getLocalKeyIDFromCert(x509cert);
+        certInfo.setID(id);
+
+        X509CertImpl cert = new X509CertImpl(x509cert);
+        certInfo.setCert(cert);
+
+        Principal subjectDN = cert.getSubjectDN();
 
         SET bagAttrs = bag.getBagAttributes();
 
@@ -433,10 +680,9 @@ public class PKCS12Util {
                 ANY value = (ANY) values.elementAt(0);
 
                 ByteArrayInputStream bis = new ByteArrayInputStream(value.getEncoded());
-                BMPString nickname = (BMPString) (new BMPString.Template()).decode(bis);
+                BMPString friendlyName = (BMPString) (new BMPString.Template()).decode(bis);
 
-                certInfo.nickname = nickname.toString();
-
+                certInfo.setFriendlyName(friendlyName.toString());
 
             } else if (oid.equals(SafeBag.LOCAL_KEY_ID)) {
 
@@ -444,9 +690,10 @@ public class PKCS12Util {
                 ANY value = (ANY) values.elementAt(0);
 
                 ByteArrayInputStream bis = new ByteArrayInputStream(value.getEncoded());
-                OCTET_STRING keyID = (OCTET_STRING) new OCTET_STRING.Template().decode(bis);
+                OCTET_STRING keyIdAsn1 = (OCTET_STRING) new OCTET_STRING.Template().decode(bis);
 
-                certInfo.id = new BigInteger(1, keyID.toByteArray());
+                byte[] keyID = keyIdAsn1.toByteArray();
+                certInfo.setKeyID(keyID);
 
             } else if (oid.equals(PKCS12.CERT_TRUST_FLAGS_OID) && trustFlagsEnabled) {
 
@@ -454,27 +701,35 @@ public class PKCS12Util {
                 ANY value = (ANY) values.elementAt(0);
 
                 ByteArrayInputStream is = new ByteArrayInputStream(value.getEncoded());
-                BMPString trustFlags = (BMPString) (new BMPString.Template()).decode(is);
+                BMPString trustFlagsAsn1 = (BMPString) (new BMPString.Template()).decode(is);
 
-                certInfo.trustFlags = trustFlags.toString();
+                String trustFlags = trustFlagsAsn1.toString();
+                certInfo.setTrustFlags(trustFlags);
+
             }
         }
 
-        if (certInfo.id == null) {
-            certInfo.id = createLocalID(x509cert);
-        }
+        if (certInfo.getFriendlyName() == null) {
+            LdapName dn = new LdapName(subjectDN.getName());
+            ArrayList<String> values = new ArrayList<String>();
 
-        if (certInfo.nickname == null) {
-            DN dn = new DN(subjectDN.getName());
-            String[] values = dn.explodeDN(true);
-            certInfo.nickname = StringUtils.join(values, " - ");
+            // The getRdns method returns the list in reverse order
+            // therefore, we must traverse in reverse order.
+
+            List<Rdn> rdns = dn.getRdns();
+            for (int i = rdns.size() - 1; i >= 0; i--) {
+                Rdn rdn = rdns.get(i);
+                values.add(rdn.getValue().toString());
+            }
+
+            String friendlyName = StringUtils.join(values, " - ");
+            certInfo.setFriendlyName(friendlyName);
         }
 
         return certInfo;
     }
 
     public void getKeyInfos(PKCS12 pkcs12, PFX pfx, Password password) throws Exception {
-
 
         AuthenticatedSafes safes = pfx.getAuthSafes();
 
@@ -496,7 +751,6 @@ public class PKCS12Util {
     }
 
     public void getCertInfos(PKCS12 pkcs12, PFX pfx, Password password) throws Exception {
-
 
         AuthenticatedSafes safes = pfx.getAuthSafes();
 
@@ -560,8 +814,16 @@ public class PKCS12Util {
             throws CertificateException {
 
         for (PKCS12CertInfo certInfo : pkcs12.getCertInfos()) {
-            Principal certSubjectDN = certInfo.cert.getSubjectDN();
-            if (LDAPDN.equals(certSubjectDN.toString(), subjectDN)) return certInfo;
+            Principal certSubjectDN = certInfo.getCert().getSubjectDN();
+
+            try {
+                LdapName certSubjdn  = new LdapName(certSubjectDN.toString());
+                LdapName subjDn = new LdapName(subjectDN);
+                if(certSubjdn.equals(subjDn)) return certInfo;
+            } catch (InvalidNameException e) {
+                return null;
+            }
+
         }
 
         return null;
@@ -573,17 +835,17 @@ public class PKCS12Util {
             String nickname,
             PKCS12KeyInfo keyInfo) throws Exception {
 
-
-        PKCS12CertInfo certInfo = pkcs12.getCertInfoByID(keyInfo.getID());
+        PKCS12CertInfo certInfo = pkcs12.getCertInfoByKeyID(keyInfo.getID());
         if (certInfo == null) {
             return;
         }
 
         CryptoManager cm = CryptoManager.getInstance();
         CryptoToken token = cm.getInternalKeyStorageToken();
-        CryptoStore store = token.getCryptoStore();
+        PK11Store store = (PK11Store)token.getCryptoStore();
 
-        X509Certificate cert = cm.importCACertPackage(certInfo.cert.getEncoded());
+        X509CertImpl certImpl = certInfo.getCert();
+        X509Certificate cert = cm.importCACertPackage(certImpl.getEncoded());
 
         // get public key
         PublicKey publicKey = cert.getPublicKey();
@@ -605,7 +867,7 @@ public class PKCS12Util {
         // delete the cert again (it will be imported again later
         // with the correct nickname)
         try {
-            store.deleteCert(cert);
+            store.deleteCertOnly(cert);
         } catch (NoSuchItemOnTokenException e) {
             // this is OK
         }
@@ -623,33 +885,39 @@ public class PKCS12Util {
         CryptoToken ct = cm.getInternalKeyStorageToken();
         CryptoStore store = ct.getCryptoStore();
 
-        BigInteger id = certInfo.getID();
-        PKCS12KeyInfo keyInfo = pkcs12.getKeyInfoByID(id);
-
-        for (X509Certificate cert : cm.findCertsByNickname(certInfo.nickname)) {
+        String nickname = certInfo.getFriendlyName();
+        for (X509Certificate cert : cm.findCertsByNickname(nickname)) {
             if (!overwrite) {
                 return;
             }
             store.deleteCert(cert);
         }
 
+        X509CertImpl certImpl = certInfo.getCert();
         X509Certificate cert;
-        if (keyInfo != null) { // cert has key
-            importKey(pkcs12, password, certInfo.nickname, keyInfo);
 
-            cert = cm.importUserCACertPackage(certInfo.cert.getEncoded(), certInfo.nickname);
+        byte[] keyID = certInfo.getKeyID();
+
+        if (keyID != null) { // cert has key
+            PKCS12KeyInfo keyInfo = pkcs12.getKeyInfoByID(keyID);
+            importKey(pkcs12, password, certInfo.getFriendlyName(), keyInfo);
+
+            cert = cm.importUserCACertPackage(
+                    certImpl.getEncoded(), certInfo.getFriendlyName());
 
         } else { // cert has no key
             // Note: JSS does not preserve CA certificate nickname
-            cert = cm.importCACertPackage(certInfo.cert.getEncoded());
+            cert = cm.importCACertPackage(certImpl.getEncoded());
         }
 
-        if (certInfo.trustFlags != null && trustFlagsEnabled)
-            setTrustFlags(cert, certInfo.trustFlags);
+        String trustFlags = certInfo.getTrustFlags();
+        if (trustFlags != null && trustFlagsEnabled) {
+            setTrustFlags(cert, trustFlags);
+        }
     }
 
     public void storeCertIntoNSS(PKCS12 pkcs12, Password password, String nickname, boolean overwrite) throws Exception {
-        Collection<PKCS12CertInfo> certInfos = pkcs12.getCertInfosByNickname(nickname);
+        Collection<PKCS12CertInfo> certInfos = pkcs12.getCertInfosByFriendlyName(nickname);
         for (PKCS12CertInfo certInfo : certInfos) {
             storeCertIntoNSS(pkcs12, password, certInfo, overwrite);
         }

--- a/org/mozilla/jss/netscape/security/util/Cert.java
+++ b/org/mozilla/jss/netscape/security/util/Cert.java
@@ -33,6 +33,9 @@ public class Cert {
     public static final String HEADER = "-----BEGIN CERTIFICATE-----";
     public static final String FOOTER = "-----END CERTIFICATE-----";
 
+    public static final String PKCS7_HEADER = "-----BEGIN PKCS7-----";
+    public static final String PKCS7_FOOTER = "-----END PKCS7-----";
+
     // From https://www.rfc-editor.org/rfc/rfc7468.txt
     public static final String REQUEST_HEADER = "-----BEGIN CERTIFICATE REQUEST-----";
     public static final String REQUEST_FOOTER = "-----END CERTIFICATE REQUEST-----";
@@ -68,9 +71,12 @@ public class Cert {
             return s;
         }
 
-        if ((s.startsWith(HEADER)) &&
-                (s.endsWith(FOOTER))) {
-            return (s.substring(27, (s.length() - 25)));
+        if (s.startsWith(HEADER) && s.endsWith(FOOTER)) {
+            return s.substring(HEADER.length(), s.length() - FOOTER.length());
+        }
+
+        if (s.startsWith(PKCS7_HEADER) && s.endsWith(PKCS7_FOOTER)) {
+            return s.substring(PKCS7_HEADER.length(), s.length() - PKCS7_FOOTER.length());
         }
 
         // To support Thawte's header and footer

--- a/org/mozilla/jss/netscape/security/util/ObjectIdentifier.java
+++ b/org/mozilla/jss/netscape/security/util/ObjectIdentifier.java
@@ -184,8 +184,6 @@ final public class ObjectIdentifier implements Serializable {
         initFromEncoding(new DerInputStream(buf), 0);
     }
 
-
-
     /*
      * Helper function -- get the OID from a stream, after tag and
      * length are verified.
@@ -261,7 +259,7 @@ final public class ObjectIdentifier implements Serializable {
     /*
      * n.b. the only public interface is DerOutputStream.putOID()
      */
-    void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) throws IOException {
         DerOutputStream bytes = new DerOutputStream();
         int i;
 
@@ -478,56 +476,5 @@ final public class ObjectIdentifier implements Serializable {
             retval.append(values[i]);
         }
         return getObjectIdentifier(retval.toString());
-    }
-
-    public static void main(String[] args) {
-
-        long[] oid_components_long = { 1L, 3L,6L,1L,4L,1L,5000L,9L,1L,1L,1526913300628L, 1L};
-        int[] oid_components_int =  { 1, 3,6,1,4,1,2312,9,1,1,15269, 1, 1};
-        BigInteger[] oid_components_big_int = { new BigInteger("1"), new BigInteger("3"), new BigInteger("6"), new BigInteger("1"),
-                new BigInteger("4"), new BigInteger("1"), new BigInteger("2312"),
-                new BigInteger("9"), new BigInteger("1"),
-                new BigInteger("152691330062899999999999997777788888888888888889999999999999999"), new BigInteger("1")
-        };
-
-        String oidIn = "1.3.6.1.4.1.2312.9.1.152691330062899999999999997777788888888888888889999999999999999.1";
-        ObjectIdentifier oid = new ObjectIdentifier(oidIn);
-
-        ObjectIdentifier fromDer = null;
-        ObjectIdentifier fromStaticMethod = null;
-        ObjectIdentifier fromComponentList = null;
-        ObjectIdentifier  fromComponentListInt = null;
-        ObjectIdentifier fromComponentListBigInt = null;
-
-        System.out.println("oid: " + oid.toString());
-
-        DerOutputStream out = new DerOutputStream();
-
-        try {
-            oid.encode(out);
-            DerInputStream  in = new DerInputStream(out.toByteArray());
-            fromDer = new ObjectIdentifier(in);
-
-            System.out.println("fromDer: " + fromDer.toString());
-
-            fromStaticMethod = ObjectIdentifier.getObjectIdentifier(oidIn);
-
-            System.out.println("fromStaticMethod: " + fromStaticMethod.toString());
-
-            fromComponentList = new ObjectIdentifier(oid_components_long);
-
-            System.out.println("fromComponentList: " + fromComponentList.toString());
-
-            fromComponentListInt = new ObjectIdentifier(oid_components_int);
-
-            System.out.println("fromComponentListInt: " + fromComponentListInt);
-
-            fromComponentListBigInt = new ObjectIdentifier(oid_components_big_int);
-
-            System.out.println("fromComponentListBigInt: " + fromComponentListBigInt);
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
     }
 }

--- a/org/mozilla/jss/netscape/security/util/Utils.java
+++ b/org/mozilla/jss/netscape/security/util/Utils.java
@@ -303,7 +303,6 @@ public class Utils {
      * Each line is at most 64-character long and terminated with CRLF.
      *
      * @param bytes byte array
-     * @param chunked TODO
      * @return base-64 encoded data
      */
     public static String base64encodeMultiLine(byte[] bytes) {
@@ -335,16 +334,31 @@ public class Utils {
     /**
      * Normalize B64 input String
      *
-     * @pram string base-64 string
+     * @param string base-64 string
      * @return normalized string
      */
     public static String normalizeString(String string) {
+        return normalizeString(string, false);
+    }
+
+    /**
+     * Normalize B64 input String
+     *
+     * @param string base-64 string
+     * @param keepspace a boolean variable to control whether to keep spaces or not
+     * @return normalized string
+     */
+    public static String normalizeString(String string, Boolean keepSpace) {
         if (string == null) {
             return string;
         }
 
         StringBuffer sb = new StringBuffer();
-        StringTokenizer st = new StringTokenizer(string, "\r\n ");
+        StringTokenizer st = null;
+        if (keepSpace)
+            st = new StringTokenizer(string, "\r\n");
+        else
+            st = new StringTokenizer(string, "\r\n ");
 
         while (st.hasMoreTokens()) {
             String nextLine = st.nextToken();
@@ -353,4 +367,5 @@ public class Utils {
         }
         return sb.toString();
     }
+
 }

--- a/org/mozilla/jss/netscape/security/util/WrappingParams.java
+++ b/org/mozilla/jss/netscape/security/util/WrappingParams.java
@@ -1,0 +1,290 @@
+package org.mozilla.jss.netscape.security.util;
+
+import java.security.NoSuchAlgorithmException;
+
+import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
+import org.mozilla.jss.crypto.EncryptionAlgorithm;
+import org.mozilla.jss.crypto.IVParameterSpec;
+import org.mozilla.jss.crypto.KeyGenAlgorithm;
+import org.mozilla.jss.crypto.KeyWrapAlgorithm;
+import org.mozilla.jss.crypto.SymmetricKey;
+import org.mozilla.jss.crypto.SymmetricKey.Type;
+
+public class WrappingParams {
+    // session key attributes
+    SymmetricKey.Type skType;
+    KeyGenAlgorithm skKeyGenAlgorithm;
+    int skLength;
+
+    // wrapping algorithm for session key
+    KeyWrapAlgorithm skWrapAlgorithm;
+
+    // Encryption algorithm for payload
+    EncryptionAlgorithm payloadEncryptionAlgorithm;
+
+    //wrapping algorithm for payload
+    KeyWrapAlgorithm payloadWrapAlgorithm;
+
+    // payload encryption IV
+    IVParameterSpec payloadEncryptionIV;
+
+    // payload wrapping IV
+    IVParameterSpec payloadWrappingIV;
+
+    public WrappingParams(Type skType, KeyGenAlgorithm skKeyGenAlgorithm, int skLength,
+            KeyWrapAlgorithm skWrapAlgorithm, EncryptionAlgorithm payloadEncryptionAlgorithm,
+            KeyWrapAlgorithm payloadWrapAlgorithm, IVParameterSpec payloadEncryptIV, IVParameterSpec payloadWrapIV) {
+        super();
+        this.skType = skType;
+        this.skKeyGenAlgorithm = skKeyGenAlgorithm;
+        this.skLength = skLength;
+        this.skWrapAlgorithm = skWrapAlgorithm;
+        this.payloadEncryptionAlgorithm = payloadEncryptionAlgorithm;
+        this.payloadWrapAlgorithm = payloadWrapAlgorithm;
+        this.payloadEncryptionIV = payloadEncryptIV;
+        this.payloadWrappingIV = payloadWrapIV;
+    }
+
+    public static EncryptionAlgorithm getEncryptionAlgorithmFromName(String name) throws Exception {
+        String fields[] = name.split("//");
+        String alg = fields[0];
+        String mode = fields[1];
+        String padding = fields[2];
+        int strength = Integer.parseInt(fields[3]);
+        return EncryptionAlgorithm.lookup(alg, mode, padding, strength);
+    }
+
+    public WrappingParams() {}
+
+    public WrappingParams(String encryptOID, String wrapName, String priKeyAlgo, IVParameterSpec encryptIV, IVParameterSpec wrapIV)
+            throws NumberFormatException, NoSuchAlgorithmException {
+        EncryptionAlgorithm encrypt = null;
+        OBJECT_IDENTIFIER eccOID = new OBJECT_IDENTIFIER("1.2.840.10045.2.1");
+
+        if (encryptOID.equals(eccOID.toString())) {
+            // old CRMFPopClients send this OID for ECC Keys for no apparent reason.
+            // New clients set this correctly.
+            // We'll assume the old DES3 wrapping here.
+            encrypt = EncryptionAlgorithm.DES_CBC_PAD;
+        } else if (encryptOID.equals(KeyWrapAlgorithm.DES3_CBC_PAD_OID.toString())) {
+            encrypt = EncryptionAlgorithm.DES3_CBC_PAD;
+        } else if (encryptOID.equals(KeyWrapAlgorithm.AES_CBC_PAD_OID.toString())) {
+            encrypt = EncryptionAlgorithm.AES_128_CBC_PAD;
+        } else {
+            encrypt = EncryptionAlgorithm.fromOID(new OBJECT_IDENTIFIER(encryptOID));
+        }
+
+        KeyWrapAlgorithm wrap = null;
+        if (wrapName != null) {
+            wrap = KeyWrapAlgorithm.fromString(wrapName);
+            payloadWrapAlgorithm = wrap;
+        }
+
+        switch (encrypt.getAlg().toString()) {
+        case "AES":
+            // TODO(alee) - Terrible hack till we figure out why GCM is not working
+            // or a way to detect the padding.
+            // We are going to assume AES-128-PAD
+            encrypt = EncryptionAlgorithm.AES_128_CBC_PAD;
+
+            skType = SymmetricKey.AES;
+            skKeyGenAlgorithm = KeyGenAlgorithm.AES;
+            if (wrap == null) payloadWrapAlgorithm = KeyWrapAlgorithm.AES_KEY_WRAP_PAD;
+            break;
+        case "DESede":
+            skType = SymmetricKey.DES3;
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES3;
+            skWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            if (wrap == null) payloadWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            break;
+        case "DES":
+            skType = SymmetricKey.DES;
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES;
+            skWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            if (wrap == null) payloadWrapAlgorithm = KeyWrapAlgorithm.DES_CBC_PAD;
+            break;
+        default:
+            throw new NoSuchAlgorithmException("Invalid algorithm");
+        }
+
+        this.skLength = encrypt.getKeyStrength();
+        if (priKeyAlgo.equals("EC")) {
+            skWrapAlgorithm = KeyWrapAlgorithm.AES_ECB;
+        } else {
+            skWrapAlgorithm = KeyWrapAlgorithm.RSA;
+        }
+
+        payloadEncryptionAlgorithm = encrypt;
+        payloadEncryptionIV = encryptIV;
+
+        if (payloadWrapAlgorithm == KeyWrapAlgorithm.AES_KEY_WRAP_PAD) {
+            // TODO(alee) Hack -- if we pass in null for the iv in the
+            // PKIArchiveOptions, we fail to decode correctly when parsing a
+            // CRMFPopClient request.
+
+            payloadWrappingIV = null;
+        } else {
+            payloadWrappingIV = wrapIV;
+        }
+    }
+
+    private WrappingParams(String wrapOID, String priKeyAlgo, IVParameterSpec wrapIV)
+            throws NumberFormatException, NoSuchAlgorithmException {
+        KeyWrapAlgorithm kwAlg = KeyWrapAlgorithm.fromOID(wrapOID);
+
+        if (kwAlg == KeyWrapAlgorithm.AES_KEY_WRAP_PAD) {
+            skType = SymmetricKey.AES;
+            skKeyGenAlgorithm = KeyGenAlgorithm.AES;
+            payloadWrapAlgorithm = KeyWrapAlgorithm.AES_KEY_WRAP_PAD;
+            payloadEncryptionAlgorithm = EncryptionAlgorithm.AES_128_CBC_PAD;
+            skLength = 128;
+        } else if (kwAlg == KeyWrapAlgorithm.AES_CBC_PAD) {
+            skType = SymmetricKey.AES;
+            skKeyGenAlgorithm = KeyGenAlgorithm.AES;
+            payloadWrapAlgorithm = KeyWrapAlgorithm.AES_CBC_PAD;
+            payloadEncryptionAlgorithm = EncryptionAlgorithm.AES_128_CBC_PAD;
+            skLength = 128;
+        } else if (kwAlg == KeyWrapAlgorithm.DES3_CBC_PAD) {
+            skType = SymmetricKey.DES3;
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES3;
+            skWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            payloadWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            payloadEncryptionAlgorithm = EncryptionAlgorithm.DES3_CBC_PAD;
+            skLength = payloadEncryptionAlgorithm.getKeyStrength();
+        } else if (kwAlg == KeyWrapAlgorithm.DES_CBC_PAD) {
+            skType = SymmetricKey.DES;
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES;
+            skWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            payloadWrapAlgorithm = KeyWrapAlgorithm.DES3_CBC_PAD;
+            payloadEncryptionAlgorithm = EncryptionAlgorithm.DES_CBC_PAD;
+            skLength = payloadEncryptionAlgorithm.getKeyStrength();
+        }
+
+        if (priKeyAlgo.equals("EC")) {
+            skWrapAlgorithm = KeyWrapAlgorithm.AES_ECB;
+        } else {
+            skWrapAlgorithm = KeyWrapAlgorithm.RSA;
+        }
+
+        // set the IVs
+        payloadEncryptionIV = wrapIV;
+
+        if (payloadWrapAlgorithm == KeyWrapAlgorithm.AES_KEY_WRAP_PAD) {
+            // TODO(alee) Hack -- if we pass in null for the iv in the
+            // PKIArchiveOptions, we fail to decode correctly when parsing a
+            // CRMFPopClient request.
+            payloadWrappingIV = null;
+        } else {
+            payloadWrappingIV = wrapIV;
+        }
+    }
+
+    public static WrappingParams getWrappingParamsFromArchiveOptions(String wrapOID, String priKeyAlgo, IVParameterSpec wrapIV)
+            throws NumberFormatException, NoSuchAlgorithmException {
+        return new WrappingParams(wrapOID, priKeyAlgo, wrapIV);
+    }
+
+    public SymmetricKey.Type getSkType() {
+        return skType;
+    }
+
+    public void setSkType(SymmetricKey.Type skType) {
+        this.skType = skType;
+    }
+
+    public void setSkType(String skTypeName) throws NoSuchAlgorithmException {
+        this.skType = SymmetricKey.Type.fromName(skTypeName);
+    }
+
+    public KeyGenAlgorithm getSkKeyGenAlgorithm() {
+        return skKeyGenAlgorithm;
+    }
+
+    public void setSkKeyGenAlgorithm(KeyGenAlgorithm skKeyGenAlgorithm) {
+        this.skKeyGenAlgorithm = skKeyGenAlgorithm;
+    }
+
+    public void setSkKeyGenAlgorithm(String algName) throws NoSuchAlgorithmException {
+        // JSS mapping is not working.  Lets just do something brain-dead to
+        // handle the cases we expect.
+        if (algName.equalsIgnoreCase("AES")) {
+            skKeyGenAlgorithm = KeyGenAlgorithm.AES;
+        } else if (algName.equalsIgnoreCase("DES")) {
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES;
+        } else if (algName.equalsIgnoreCase("DESede")) {
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES3;
+        } else if (algName.equalsIgnoreCase("DES3")) {
+            skKeyGenAlgorithm = KeyGenAlgorithm.DES3;
+        }
+    }
+
+    public int getSkLength() {
+        return skLength;
+    }
+
+    public void setSkLength(int skLength) {
+        this.skLength = skLength;
+    }
+
+    public KeyWrapAlgorithm getSkWrapAlgorithm() {
+        return skWrapAlgorithm;
+    }
+
+    public void setSkWrapAlgorithm(KeyWrapAlgorithm skWrapAlgorithm) {
+        this.skWrapAlgorithm = skWrapAlgorithm;
+    }
+
+    public void setSkWrapAlgorithm(String name) throws NoSuchAlgorithmException {
+        this.skWrapAlgorithm = KeyWrapAlgorithm.fromString(name);
+    }
+
+    public EncryptionAlgorithm getPayloadEncryptionAlgorithm() {
+        return payloadEncryptionAlgorithm;
+    }
+
+    public void setPayloadEncryptionAlgorithm(EncryptionAlgorithm payloadEncryptionAlgorithm) {
+        this.payloadEncryptionAlgorithm = payloadEncryptionAlgorithm;
+    }
+
+    public void setPayloadEncryptionAlgorithm(String algName, String modeName, String paddingName, int keyStrength)
+            throws NoSuchAlgorithmException {
+        this.payloadEncryptionAlgorithm = EncryptionAlgorithm.lookup(algName, modeName, paddingName, keyStrength);
+    }
+
+    public String getPayloadEncryptionAlgorithmName() {
+        // work around some of the issues with OIDs in JSS
+        int strength = payloadEncryptionAlgorithm.getKeyStrength();
+        String mode = payloadEncryptionAlgorithm.getMode().toString();
+        String padding = payloadEncryptionAlgorithm.getPadding().toString();
+        String alg = payloadEncryptionAlgorithm.getAlg().toString();
+        return alg + "/" + mode + "/" + padding + "/" + Integer.toString(strength);
+    }
+
+    public KeyWrapAlgorithm getPayloadWrapAlgorithm() {
+        return payloadWrapAlgorithm;
+    }
+
+    public void setPayloadWrapAlgorithm(KeyWrapAlgorithm payloadWrapAlgorithm) {
+        this.payloadWrapAlgorithm = payloadWrapAlgorithm;
+    }
+
+    public void setPayloadWrapAlgorithm(String name) throws NoSuchAlgorithmException {
+        this.payloadWrapAlgorithm = KeyWrapAlgorithm.fromString(name);
+    }
+
+    public IVParameterSpec getPayloadEncryptionIV() {
+        return payloadEncryptionIV;
+    }
+
+    public void setPayloadEncryptionIV(IVParameterSpec payloadEncryptionIV) {
+        this.payloadEncryptionIV = payloadEncryptionIV;
+    }
+
+    public IVParameterSpec getPayloadWrappingIV() {
+        return payloadWrappingIV;
+    }
+
+    public void setPayloadWrappingIV(IVParameterSpec payloadWrappingIV) {
+        this.payloadWrappingIV = payloadWrappingIV;
+    }
+}

--- a/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
+++ b/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
@@ -142,7 +142,16 @@ public class AlgorithmId implements Serializable, DerEncoder {
          * Figure out what class (if any) knows about this oid's
          * parameters.  Make one, and give it the data to decode.
          */
-        AlgorithmId alg = new AlgorithmId(algid, params);
+        AlgorithmId alg = null;
+        // omit parameter field for ECDSA
+        if (!algid.equals(sha224WithEC_oid) &&
+                !algid.equals(sha256WithEC_oid) &&
+                !algid.equals(sha384WithEC_oid) &&
+                !algid.equals(sha512WithEC_oid)) {
+            alg = new AlgorithmId(algid, params);
+        } else {
+            alg = new AlgorithmId(algid);
+        }
         if (params != null)
             alg.decodeParams();
 
@@ -789,17 +798,17 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * Supported signing algorithms for a RSA key.
      */
     public static final String[] RSA_SIGNING_ALGORITHMS = new String[]
-    { "SHA1withRSA", "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "MD5withRSA", "MD2withRSA" };
+    { "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withRSA" };
 
     public static final String[] EC_SIGNING_ALGORITHMS = new String[]
-    { "SHA1withEC", "SHA256withEC", "SHA384withEC", "SHA512withEC" };
+    { "SHA256withEC", "SHA384withEC", "SHA512withEC", "SHA1withEC" };
 
     /**
      * All supported signing algorithms.
      */
     public static final String[] ALL_SIGNING_ALGORITHMS = new String[]
     {
-            "SHA1withRSA", "MD5withRSA", "MD2withRSA", "SHA1withDSA", "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withEC",
-            "SHA256withEC", "SHA384withEC", "SHA512withEC" };
-
+        "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withRSA",
+        "SHA256withEC", "SHA384withEC", "SHA512withEC", "SHA1withEC"
+    };
 }

--- a/org/mozilla/jss/netscape/security/x509/CIDRNetmask.java
+++ b/org/mozilla/jss/netscape/security/x509/CIDRNetmask.java
@@ -1,0 +1,77 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package org.mozilla.jss.netscape.security.x509;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Netmask that is the number of significant bits.
+ */
+public class CIDRNetmask {
+    private int n;
+
+    public CIDRNetmask(String s) {
+        this(Integer.parseInt(s));
+    }
+
+    public CIDRNetmask(int n) {
+        if (n < 0)
+            throw new InvalidNetmaskException("cannot be negative");
+        this.n = n;
+    }
+
+    /**
+     * Write the netmask into a byte buffer.
+     *
+     * Throw InvalidNetmaskException if negative or if the
+     * size exceeds the size of the address type inferred
+     * from the remaining buffer space (which must be 4
+     * bytes for IPv4 and 16 bytes for IPv6).
+     *
+     * exceeds the size of the buffer
+     */
+    protected void write(ByteBuffer buf) {
+        // determine type of addr based on bytes left in buffer
+        int remaining = buf.remaining();
+        int bits = 0;
+        if (remaining == 4)
+            bits = 32;
+        else if (remaining == 16)
+            bits = 128;
+        else
+            throw new InvalidNetmaskException(
+                "cannot determine type of address for netmask");
+
+        if (n > bits)
+            throw new InvalidNetmaskException("netmask exceed address size");
+
+        int maskSigBits = n;
+        for (; remaining > 0; remaining--) {
+            int maskByteSigBits = Math.min(8, maskSigBits);
+            byte maskByte = (byte) (0xff - (0xff >> maskByteSigBits));
+            buf.put(maskByte);
+            maskSigBits = Math.max(maskSigBits - 8, 0);
+        }
+    }
+
+    public String toString() {
+        return "/" + n;
+    }
+
+}

--- a/org/mozilla/jss/netscape/security/x509/GeneralName.java
+++ b/org/mozilla/jss/netscape/security/x509/GeneralName.java
@@ -197,6 +197,18 @@ public class GeneralName implements GeneralNameInterface {
         }
     }
 
+    @Override
+    public boolean validSingle() {
+        if (this == name) return false;  // can't happen, but just in case...
+        return name.validSingle();
+    }
+
+    @Override
+    public boolean validSubtree() {
+        if (this == name) return false;  // can't happen, but just in case...
+        return name.validSubtree();
+    }
+
     /**
      * Unwrap this GeneralName until we reach something that is not
      * a GeneralName.

--- a/org/mozilla/jss/netscape/security/x509/GeneralNameInterface.java
+++ b/org/mozilla/jss/netscape/security/x509/GeneralNameInterface.java
@@ -57,4 +57,20 @@ public interface GeneralNameInterface extends java.io.Serializable {
      *                encoded.
      */
     void encode(DerOutputStream out) throws IOException;
+
+    /**
+     * Whether the name is valid as a single name (e.g. for use in
+     * Subject Alternative Name extension).
+     */
+    default boolean validSingle() {
+        return true;
+    }
+
+    /**
+     * Whether the name is valid as a subtree name (e.g. for use in
+     * Name Constraints extension)
+     */
+    default boolean validSubtree() {
+        return true;
+    }
 }

--- a/org/mozilla/jss/netscape/security/x509/InvalidNetmaskException.java
+++ b/org/mozilla/jss/netscape/security/x509/InvalidNetmaskException.java
@@ -1,0 +1,27 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package org.mozilla.jss.netscape.security.x509;
+
+public class InvalidNetmaskException extends RuntimeException {
+
+    public InvalidNetmaskException(String desc) {
+        super("Invalid netmask (" + desc + ")");
+    }
+
+}

--- a/org/mozilla/jss/tests/BigObjectIdentifier.java
+++ b/org/mozilla/jss/tests/BigObjectIdentifier.java
@@ -1,0 +1,54 @@
+package org.mozilla.jss.tests;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import org.mozilla.jss.netscape.security.util.*;
+
+public class BigObjectIdentifier {
+    public static void main(String[] args) throws Exception {
+
+        long[] oid_components_long = { 1L, 3L,6L,1L,4L,1L,5000L,9L,1L,1L,1526913300628L, 1L};
+        int[] oid_components_int =  { 1, 3,6,1,4,1,2312,9,1,1,15269, 1, 1};
+        BigInteger[] oid_components_big_int = { new BigInteger("1"), new BigInteger("3"), new BigInteger("6"), new BigInteger("1"),
+            new BigInteger("4"), new BigInteger("1"), new BigInteger("2312"),
+            new BigInteger("9"), new BigInteger("1"),
+            new BigInteger("152691330062899999999999997777788888888888888889999999999999999"), new BigInteger("1")
+        };
+
+        String oidIn = "1.3.6.1.4.1.2312.9.1.152691330062899999999999997777788888888888888889999999999999999.1";
+        ObjectIdentifier oid = new ObjectIdentifier(oidIn);
+
+        ObjectIdentifier fromDer = null;
+        ObjectIdentifier fromStaticMethod = null;
+        ObjectIdentifier fromComponentList = null;
+        ObjectIdentifier  fromComponentListInt = null;
+        ObjectIdentifier fromComponentListBigInt = null;
+
+        System.out.println("oid: " + oid.toString());
+
+        DerOutputStream out = new DerOutputStream();
+
+        oid.encode(out);
+        DerInputStream  in = new DerInputStream(out.toByteArray());
+        fromDer = new ObjectIdentifier(in);
+
+        System.out.println("fromDer: " + fromDer.toString());
+
+        fromStaticMethod = ObjectIdentifier.getObjectIdentifier(oidIn);
+
+        System.out.println("fromStaticMethod: " + fromStaticMethod.toString());
+
+        fromComponentList = new ObjectIdentifier(oid_components_long);
+
+        System.out.println("fromComponentList: " + fromComponentList.toString());
+
+        fromComponentListInt = new ObjectIdentifier(oid_components_int);
+
+        System.out.println("fromComponentListInt: " + fromComponentListInt);
+
+        fromComponentListBigInt = new ObjectIdentifier(oid_components_big_int);
+
+        System.out.println("fromComponentListBigInt: " + fromComponentListBigInt);
+    }
+}

--- a/org/mozilla/jss/tests/all.pl
+++ b/org/mozilla/jss/tests/all.pl
@@ -637,6 +637,10 @@ $testname = "Disable FipsMODE";
 $command = "$java -cp $jss_classpath org.mozilla.jss.tests.FipsTest $testdir disable";
 run_test($testname, $command);
 
+$testname = "Test Big Object Identifiers"
+$command = "$java -cp $jss_classpath -ea org.mozilla.jss.tests.BigObjectIdentifier";
+run_test($testname, $command);
+
 #
 # Test for JSS jar and library revision
 #


### PR DESCRIPTION
Backport of #101. ~Depends on #109.~

Each commit in question includes two paths: the path under the JSS source repo and the path under the PKI source repo. This allows easy review: clone PKI at master, clone JSS at this PR's `HEAD`, and diff each of the changed files. The changes should be minimal, only changing associated imports and other fully qualified package names.

This will allow us to remove the code from PKI, release a new JSS version with the changes, make PKI depend on this new JSS version, and remove from PKI these classes. See: 

 - [PKI PR#121](https://github.com/dogtagpki/pki/pull/121) - which updates package paths (`netscape.security` -> `org.mozilla.jss.netscape.security`)
 - [PKI PR#122](https://github.com/dogtagpki/pki/pull/122) - which removes `netscape.security` from the PKI tree. 
 - [PKI PR#123](https://github.com/dogtagpki/pki/pull/123) - which removes the `getKeyWrapAlgorithmFromOID(...)` function from the PKI tree. This is implemented as part of #104. 

These combined commits (this PR and the three against PKI) have been tested with [`ansible-vms`](https://github.com/cipherboy/ansible-vms/blob/master/pki-integration.yml) and a CA set up. This ensures that PKI builds after these changes and is a basic sanity check to make sure PKI installs and runs.

A helpful script for minimizing differences is available [on my gist](https://gist.githubusercontent.com/cipherboy/07995403dd194b7e76bbbed62180cecf/raw/7516984cfaded4bc8028118cbe1559925c657c1a/filter_packages.sh). Usage is `filter_packages.sh > /tmp/output < pki/some_input_class.java`, and then you can run `diff /tmp/output jss/some_input_class.java` and have minimal differences.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`