### PR TITLE
Backport - Bump keysizes to 4096

### DIFF
--- a/org/mozilla/jss/tests/GenerateTestCert.java
+++ b/org/mozilla/jss/tests/GenerateTestCert.java
@@ -34,7 +34,7 @@ public class GenerateTestCert {
     static final private String SERVERCERT_NICKNAME = "JSSTestServerCert";
     static final private String CLIENTCERT_NICKNAME = "JSSTestClientCert";
     private String keyType = "RSA";
-    private int keyLength = 1024;
+    private int keyLength = 4096;
     private SignatureAlgorithm sigAlg =
         SignatureAlgorithm.RSASignatureWithSHA256Digest;
     
@@ -100,13 +100,11 @@ public class GenerateTestCert {
             sigAlg = SignatureAlgorithm.ECSignatureWithSHA512Digest;
         } else { usage(); }
         
-        //For keyLength we are going to use default 1024 key for RSA/DSA
-        //and 256 key for ECDSA
-        
         if (alg.endsWith("RSA")) {
             keyType = "RSA";
         } else if (alg.endsWith("DSA")) {
             keyType = "DSA";
+            keyLength = 1024;
         } else if (alg.endsWith("EC")) {
             keyType = "EC";
             keyLength = 256;

--- a/org/mozilla/jss/tests/SSLClientAuth.java
+++ b/org/mozilla/jss/tests/SSLClientAuth.java
@@ -169,7 +169,7 @@ public class SSLClientAuth implements Runnable {
     private void generateCerts(CryptoManager cm, int serialNum) {
         
         // RSA Key with default exponent
-        int keyLength = 1024;
+        int keyLength = 4096;
         try {
             java.security.KeyPairGenerator kpg =
                     java.security.KeyPairGenerator.getInstance("RSA",

--- a/org/mozilla/jss/tests/X509CertTest.java
+++ b/org/mozilla/jss/tests/X509CertTest.java
@@ -76,12 +76,12 @@ public class X509CertTest {
             CryptoManager cryptoManager = CryptoManager.getInstance();
             CryptoToken token = cryptoManager.getInternalKeyStorageToken();
             KeyPairGenerator gen = token.getKeyPairGenerator(KeyPairAlgorithm.RSA);
-            gen.initialize(2048);
+            gen.initialize(4096);
             KeyPair keypairCA = gen.genKeyPair();
             PublicKey pubCA = keypairCA.getPublic();
 
-            
-            gen.initialize(2048);
+
+            gen.initialize(4096);
             KeyPair keypairUser = gen.genKeyPair();
             PublicKey pubUser = keypairUser.getPublic();
 


### PR DESCRIPTION
Backport of #92.

This is required if we wish to run the JSS test suite on a system
with the FUTURE cryptopolicy currently enforcing. In particular, key
sizes of 1024 and 2048 are too small for later use by NSS, causing test
failures. Note that FUTURE currently sets a minimum key length for RSA
of 3072 bits.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`