### PR TITLE
Backport CI Improvements

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,6 +5,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="/usr/share/java/commons-lang.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/commons-codec.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/ldapjdk.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,21 @@
 # All rights reserved.
 # END COPYRIGHT BLOCK
 
+language: java
+
 services:
   - docker
 
-install:
-  - docker pull registry.fedoraproject.org/fedora:27
-  - docker run
-      --name=container
-      --detach
-      -i
-      -v $(pwd):/root/jss
-      registry.fedoraproject.org/fedora:27
-  - docker exec container dnf install -y dnf-plugins-core gcc make rpm-build
-  - docker exec container dnf builddep -y --spec /root/jss/jss.spec.in
-  - docker exec container /root/jss/build.sh --with-timestamp --with-commit-id rpm
+stages:
+  - test
+
+env:
+  - BASE_IMAGE="fedora_26"
+  - BASE_IMAGE="fedora_29"
+  - BASE_IMAGE="centos_7"
 
 script:
-  - docker exec container rpm -Uvh /root/build/jss/RPMS/*
+  - bash tools/run_container.sh "$BASE_IMAGE"
+
+matrix:
+  fast_finish: true

--- a/build.sh
+++ b/build.sh
@@ -52,17 +52,21 @@ generate_rpm_sources() {
             echo "Generating $TARBALL from $SOURCE_TAG tag"
         fi
 
-        git -C "$SRC_DIR" \
+        pushd "$SCR_DIR"
+        git \
             archive \
             --format=tar.gz \
             --prefix $NAME-$VERSION/ \
             -o "$WORK_DIR/SOURCES/$TARBALL" \
             $SOURCE_TAG
+        popd
 
         if [ "$SOURCE_TAG" != "HEAD" ] ; then
 
-            TAG_ID=`git -C "$SRC_DIR" rev-parse $SOURCE_TAG`
-            HEAD_ID=`git -C "$SRC_DIR" rev-parse HEAD`
+            pushd "$SRC_DIR"
+            TAG_ID=`git rev-parse $SOURCE_TAG`
+            HEAD_ID=`git rev-parse HEAD`
+            popd
 
             if [ "$TAG_ID" != "$HEAD_ID" ] ; then
                 generate_patch
@@ -92,11 +96,13 @@ generate_patch() {
         echo "Generating $PATCH for all changes since $SOURCE_TAG tag"
     fi
 
-    git -C "$SRC_DIR" \
+    pushd "$SRC_DIR"
+    git \
         format-patch \
         --stdout \
         $SOURCE_TAG \
         > "$WORK_DIR/SOURCES/$PATCH"
+    popd
 }
 
 generate_rpm_spec() {
@@ -224,7 +230,9 @@ if [ "$DEBUG" = true ] ; then
 fi
 
 if [ "$WITH_COMMIT_ID" = true ]; then
-    COMMIT_ID="`git -C "$SRC_DIR" rev-parse --short=8 HEAD`"
+    pushd "$SRC_DIR"
+    COMMIT_ID="`git rev-parse --short=8 HEAD`"
+    popd
     _COMMIT_ID=".$COMMIT_ID"
 fi
 

--- a/build_java.pl
+++ b/build_java.pl
@@ -162,7 +162,7 @@ sub setup_vars {
     }
     $jni_header_dir = "$dist_dir/private/jss/_jni";
 
-    $classpath = "-classpath /usr/share/java/apache-commons-codec.jar:/usr/share/java/commons-lang.jar:/usr/share/java/ldapjdk.jar:";
+    $classpath = "-classpath /usr/share/java/apache-commons-codec.jar:/usr/share/java/commons-lang.jar:";
     if( $jce_jar ) {
         $classpath .= ":$jce_jar";
     }

--- a/jss.spec.in
+++ b/jss.spec.in
@@ -42,14 +42,12 @@ BuildRequires:  perl-interpreter
 %endif
 BuildRequires:  apache-commons-lang
 BuildRequires:  apache-commons-codec
-BuildRequires:  ldapjdk
 
 Requires:       nss >= 3.28.4-6
 Requires:       java-headless
 Requires:       jpackage-utils
 Requires:       apache-commons-lang
 Requires:       apache-commons-codec
-Requires:       ldapjdk
 
 %description
 Java Security Services (JSS) is a java native interface which provides a bridge

--- a/jss.spec.in
+++ b/jss.spec.in
@@ -84,7 +84,9 @@ mv jss %{name}-%{version}
 ################################################################################
 %build
 
+%if 0%{?fedora} >= 27
 %set_build_flags
+%endif
 
 [ -z "$JAVA_HOME" ] && export JAVA_HOME=%{_jvmdir}/java
 [ -z "$USE_INSTALLED_NSPR" ] && export USE_INSTALLED_NSPR=1

--- a/tools/Dockerfiles/centos_7
+++ b/tools/Dockerfiles/centos_7
@@ -1,0 +1,25 @@
+FROM centos:7
+
+# Install generic dependencies to build jss
+RUN true \
+        && yum update -y \
+        && yum install -y yum-plugins-core gcc make rpm-build yum-builddep \
+        && yum-builddep -y jss \
+        && mkdir -p /home/sandbox \
+        && yum clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && bash ./build.sh spec \
+        && yum-builddep -y /root/build/jss/SPECS/jss.spec \
+        && bash ./build.sh --with-timestamp --with-commit-id rpm \
+        && yum install -y /root/build/jss/RPMS/*.rpm \
+        && true

--- a/tools/Dockerfiles/fedora_26
+++ b/tools/Dockerfiles/fedora_26
@@ -1,0 +1,25 @@
+FROM fedora:26
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+        && dnf build-dep -y jss \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && bash ./build.sh spec \
+        && dnf build-dep -y --spec /root/build/jss/SPECS/jss.spec \
+        && bash ./build.sh --with-timestamp --with-commit-id rpm \
+        && dnf install -y /root/build/jss/RPMS/*.rpm \
+        && true

--- a/tools/Dockerfiles/fedora_27
+++ b/tools/Dockerfiles/fedora_27
@@ -1,0 +1,25 @@
+FROM fedora:27
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+        && dnf build-dep -y jss \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && bash ./build.sh spec \
+        && dnf build-dep -y --spec /root/build/jss/SPECS/jss.spec \
+        && bash ./build.sh --with-timestamp --with-commit-id rpm \
+        && dnf install -y /root/build/jss/RPMS/*.rpm \
+        && true

--- a/tools/Dockerfiles/fedora_28
+++ b/tools/Dockerfiles/fedora_28
@@ -1,0 +1,25 @@
+FROM fedora:28
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+        && dnf build-dep -y jss \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && bash ./build.sh spec \
+        && dnf build-dep -y --spec /root/build/jss/SPECS/jss.spec \
+        && bash ./build.sh --with-timestamp --with-commit-id rpm \
+        && dnf install -y /root/build/jss/RPMS/*.rpm \
+        && true

--- a/tools/Dockerfiles/fedora_29
+++ b/tools/Dockerfiles/fedora_29
@@ -1,0 +1,25 @@
+FROM fedora:29
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+        && dnf build-dep -y jss \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && bash ./build.sh spec \
+        && dnf build-dep -y --spec /root/build/jss/SPECS/jss.spec \
+        && bash ./build.sh --with-timestamp --with-commit-id rpm \
+        && dnf install -y /root/build/jss/RPMS/*.rpm \
+        && true

--- a/tools/run_container.sh
+++ b/tools/run_container.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# This tool attempts to detect the presence of various tools to run the CI
+# images. If present, it'll use them to run the specified container image.
+
+function rc_buildah() {
+    buildah_path="$(command -v buildah)"
+    podman_path="$(command -v podman)"
+
+    [ "x$buildah_path" != "x" ] && [ "x$podman_path" != "x" ]
+}
+
+function rc_docker() {
+    docker_path="$(command -v docker)"
+
+    [ "x$docker_path" != "x" ]
+}
+
+function rc_run() {
+    local image="$1"
+    local ret=0
+
+    if [ ! -f "tools/Dockerfiles/$image" ]; then
+        echo "Error: tools/Dockerfiles/$image is not a file; must be an" 1>&2
+        echo "existing location to launch container." 1>&2
+
+        exit 1
+    fi
+
+    if rc_buildah; then
+        buildah bud --tag "jss_$image:latest" -f "tools/Dockerfiles/$image" .
+        ret="$?"
+        if [ "x$ret" != "x0" ]; then
+            echo "Container build exited with status: $ret"
+            return $ret
+        fi
+
+        podman run "jss_$image:latest"
+        ret="$?"
+        if [ "x$ret" != "x0" ]; then
+            echo "Container run exited with status: $ret"
+            return $ret
+        fi
+    elif rc_docker; then
+        docker build --tag "jss_$image:latest" -f "tools/Dockerfiles/$image" .
+        ret="$?"
+        if [ "x$ret" != "x0" ]; then
+            echo "Container build exited with status: $ret"
+            return $ret
+        fi
+
+        docker run "jss_$image:latest"
+        ret="$?"
+        if [ "x$ret" != "x0" ]; then
+            echo "Container run exited with status: $ret"
+            return $ret
+        fi
+    else
+        echo "No supported container platform; please rerun with podman" 1>&2
+        echo "and buildah or docker installed." 1>&2
+    fi
+}
+
+if [[ "x$1" =~ "help" ]] || [ "x$1" = "x-h" ]; then
+    echo "Usage: $0 <image>" 1>&2
+    echo "" 1>&2
+    echo "Run the container task <image> using buildah+podman or docker" 1>&2
+    echo "Note: <image> must be the name of a file located under" 1>&2
+    echo "      tools/Dockerfiles in the main repo." 1>&2
+    exit 0
+fi
+
+rc_run "$1"


### PR DESCRIPTION
This backports most of the CI improvements from `master` to `v4.4.x` and fixes the build on older Fedoras (pre F27) and CentOS 7. 

In particular:

 - Backport Containerized (`Dockerfile`) based CI
 - Fix `pki.spec.in` to not use pre-F27 macros.
 - Fix `build.sh` to not use `git -C` as CentOS doesn't support `git -C`.
 - Backport Travis configuration.

Note that `build.sh` doesn't pass `ShellCheck` and while we could include the `test_perl_style.sh` as the `v4.4.x` still uses the Perl build and test system, I've decided to omit the `stylecheck` CI pass.

@SilleBille Thoughts from the CI czar? :)