### PR TITLE
Fix LDAPJDK circular dependency

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,6 +5,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="/usr/share/java/commons-lang.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/commons-codec.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/ldapjdk.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/build_java.pl
+++ b/build_java.pl
@@ -162,7 +162,7 @@ sub setup_vars {
     }
     $jni_header_dir = "$dist_dir/private/jss/_jni";
 
-    $classpath = "-classpath /usr/share/java/apache-commons-codec.jar:/usr/share/java/commons-lang.jar:/usr/share/java/ldapjdk.jar:";
+    $classpath = "-classpath /usr/share/java/apache-commons-codec.jar:/usr/share/java/commons-lang.jar:";
     if( $jce_jar ) {
         $classpath .= ":$jce_jar";
     }

--- a/jss.spec.in
+++ b/jss.spec.in
@@ -42,14 +42,12 @@ BuildRequires:  perl-interpreter
 %endif
 BuildRequires:  apache-commons-lang
 BuildRequires:  apache-commons-codec
-BuildRequires:  ldapjdk
 
 Requires:       nss >= 3.28.4-6
 Requires:       java-headless
 Requires:       jpackage-utils
 Requires:       apache-commons-lang
 Requires:       apache-commons-codec
-Requires:       ldapjdk
 
 %description
 Java Security Services (JSS) is a java native interface which provides a bridge


### PR DESCRIPTION
These changes were backported from master; jss no longer requires
ldapjdk so we can remove it from the spec file and the build scripts.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`