### PR TITLE
Disable x25519 in FIPS mode

### DIFF
--- a/org/mozilla/jss/CryptoManager.c
+++ b/org/mozilla/jss/CryptoManager.c
@@ -976,8 +976,14 @@ JNIEXPORT jboolean JNICALL
 Java_org_mozilla_jss_CryptoManager_FIPSEnabled(JNIEnv *env, jobject this)
 {
     if( PK11_IsFIPS() ) {
+        /* There's a bug in NSS where it won't disable x25519 in FIPS mode.
+         * Since they won't fix the bug, we have to do it ourselves. */
+        NSS_SetAlgorithmPolicy(SEC_OID_CURVE25519, 0, NSS_USE_ALG_IN_SSL_KX);
         return JNI_TRUE;
     } else {
+        /* In case FIPS mode is toggled, re-enable x25519 as it is a good
+         * curve. */
+        NSS_SetAlgorithmPolicy(SEC_OID_CURVE25519, 1, NSS_USE_ALG_IN_SSL_KX);
         return JNI_FALSE;
     }
 }

--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -838,6 +838,8 @@ public final class CryptoManager implements TokenSupplier
         if(instance==null) {
             throw new NotInitializedException();
         }
+        /* throw away call -- disables x25519 if we're in FIPS mode */
+        instance.FIPSEnabled();
         return instance;
     }
 


### PR DESCRIPTION
NSS's pkcs11.txt includes global ciphersuite options, however, it
doesn't understand Curve25519 as a parameter. Until such support is
added (or NIST finally approves Curve25519 for FIPS 140-2 usage!),
manually disable Curve25519 when FIPS mode is enabled.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`