### PR TITLE
Bump NSS version to 3.30 for SSLAlert

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This project has the following dependencies:
 
  - [NSPR](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR)
  - [NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS)
+    - Minimum version: 3.30
     - A c and c++ compiler such as [gcc](ttps://gcc.gnu.org/)
     - [zlib](https://zlib.net/)
  - [OpenJDK 1.8.0](https://openjdk.java.net/)

--- a/jss.spec
+++ b/jss.spec
@@ -38,8 +38,8 @@ BuildRequires:  cmake
 
 BuildRequires:  gcc-c++
 BuildRequires:  nspr-devel >= 4.13.1
-BuildRequires:  nss-devel >= 3.28.4-6
-BuildRequires:  nss-tools >= 3.28.4-6
+BuildRequires:  nss-devel >= 3.30
+BuildRequires:  nss-tools >= 3.30
 BuildRequires:  java-devel
 BuildRequires:  jpackage-utils
 BuildRequires:  slf4j
@@ -56,7 +56,7 @@ BuildRequires:  apache-commons-codec
 BuildRequires:  perl-interpreter
 %endif
 
-Requires:       nss >= 3.28.4-6
+Requires:       nss >= 3.30
 Requires:       java-headless
 Requires:       jpackage-utils
 Requires:       slf4j


### PR DESCRIPTION
Reported by @emaldona via email.

Minimum NSS version is 3.28 in the spec file, but SSLAlert is introduced in 3.30:

https://github.com/nss-dev/nss/blob/NSS_3_28_BRANCH/lib/ssl/ssl.h
https://github.com/nss-dev/nss/blob/NSS_3_29_BRANCH/lib/ssl/ssl.h
https://github.com/nss-dev/nss/blob/NSS_3_30_BRANCH/lib/ssl/ssl.h#L832

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`