### PR TITLE
JNI for NSS's PRFileDesc - 1:0

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -78,6 +78,10 @@ macro(jss_tests)
         NAME "BigObjectIdentifier"
         COMMAND "org.mozilla.jss.tests.BigObjectIdentifier"
     )
+    jss_test_java(
+        NAME "JSS_Test_PR_FileDesc"
+        COMMAND "org.mozilla.jss.tests.TestPRFD"
+    )
     if ((${Java_VERSION_MAJOR} EQUAL 1) AND (${Java_VERSION_MINOR} LESS 9))
         jss_test_java(
             NAME "Test_PKCS11Constants.java_for_Sun_compatibility"
@@ -344,6 +348,7 @@ function(jss_test_java)
     list(APPEND EXEC_COMMAND "-classpath")
     list(APPEND EXEC_COMMAND "${TEST_CLASSPATH}")
     list(APPEND EXEC_COMMAND "-ea")
+    list(APPEND EXEC_COMMAND "-Djava.library.path=${CMAKE_BINARY_DIR}")
     set(EXEC_COMMAND "${EXEC_COMMAND};${TEST_JAVA_COMMAND}")
 
     if(TEST_JAVA_DEPENDS)

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -336,3 +336,18 @@ Java_org_mozilla_jss_CryptoManager_getJSSPatchVersion;
     local:
        *;
 };
+JSS_4.5.3 {
+    global:
+Java_org_mozilla_jss_nss_PR_Open;
+Java_org_mozilla_jss_nss_PR_Close;
+Java_org_mozilla_jss_nss_PR_Write;
+Java_org_mozilla_jss_nss_PR_Read;
+Java_org_mozilla_jss_nss_PR_Send;
+Java_org_mozilla_jss_nss_PR_Recv;
+Java_org_mozilla_jss_nss_PR_NewTCPSocket;
+Java_org_mozilla_jss_nss_PR_Shutdown;
+Java_org_mozilla_jss_nss_PR_GetError;
+Java_org_mozilla_jss_nss_PR_GetErrorText;
+    local:
+        *;
+};

--- a/org/mozilla/jss/nss/PR.c
+++ b/org/mozilla/jss/nss/PR.c
@@ -1,0 +1,254 @@
+#include <nspr.h>
+#include <limits.h>
+#include <stdint.h>
+#include <jni.h>
+
+#include "jssutil.h"
+#include "PRFDProxy.h"
+
+#include "_jni/org_mozilla_jss_nss_PR.h"
+
+JNIEXPORT jobject JNICALL
+Java_org_mozilla_jss_nss_PR_Open(JNIEnv *env, jclass clazz, jstring name,
+    jint flags, jint mode)
+{
+    PRFileDesc *fd;
+    char *path;
+
+    PR_ASSERT(env != NULL);
+
+    path = (char *)(*env)->GetStringUTFChars(env, name, NULL);
+    if (path == NULL) {
+         return NULL;
+    }
+
+    fd = PR_Open(path, flags, mode);
+    if (fd == NULL) {
+        return NULL;
+    }
+
+    return JSS_PR_wrapPRFDProxy(env, &fd);
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_mozilla_jss_nss_PR_NewTCPSocket(JNIEnv *env, jclass clazz)
+{
+    PRFileDesc *fd;
+
+    PR_ASSERT(env != NULL);
+
+    fd = PR_NewTCPSocket();
+    if (fd == NULL) {
+        return NULL;
+    }
+
+    return JSS_PR_wrapPRFDProxy(env, &fd);
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_PR_Close(JNIEnv *env, jclass clazz, jobject fd)
+{
+    PRFileDesc *real_fd = NULL;
+
+    PR_ASSERT(env != NULL);
+
+    if (fd == NULL) {
+        return PR_SUCCESS;
+    }
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return PR_FAILURE;
+    }
+
+    return PR_Close(real_fd);
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_PR_Shutdown(JNIEnv *env, jclass clazz, jobject fd,
+    jint how)
+{
+    PRFileDesc *real_fd = NULL;
+
+    PR_ASSERT(env != NULL);
+
+    if (fd == NULL) {
+        return PR_SUCCESS;
+    }
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return PR_FAILURE;
+    }
+
+    return PR_Shutdown(real_fd, how);
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_mozilla_jss_nss_PR_Read(JNIEnv *env, jclass clazz, jobject fd,
+    jint amount)
+{
+    PRFileDesc *real_fd = NULL;
+    jobject result = NULL;
+    int read_amount = 0;
+    uint8_t *buffer = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL && amount >= 0);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return NULL;
+    }
+
+    PR_ASSERT(real_fd != NULL);
+
+    buffer = calloc(amount, sizeof(uint8_t));
+
+    read_amount = PR_Read(real_fd, buffer, amount);
+
+    if (read_amount <= 0) {
+        goto done;
+    }
+
+    result = JSS_ToByteArray(env, buffer, read_amount);
+
+done:
+    free(buffer);
+    return result;
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_PR_Write(JNIEnv *env, jclass clazz, jobject fd,
+    jbyteArray buf)
+{
+    PRFileDesc *real_fd = NULL;
+    unsigned int real_length = 0;
+    int max_length = 0;
+    uint8_t *buffer = NULL;
+    int result = 0;
+
+    PR_ASSERT(env != NULL && fd != NULL && buf != NULL);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return 0;
+    }
+
+    PR_ASSERT(real_fd != NULL);
+
+    real_length = (*env)->GetArrayLength(env, buf);
+    if (real_length > INT_MAX) {
+        max_length = INT_MAX;
+    } else {
+        max_length = (int)(real_length % INT_MAX);
+    }
+
+    buffer = (uint8_t*)((*env)->GetByteArrayElements(env, buf, NULL));
+    if (buffer == NULL) {
+        return 0;
+    }
+
+    result = PR_Write(real_fd, buffer, max_length);
+    (*env)->ReleaseByteArrayElements(env, buf, (jbyte *)buffer, JNI_ABORT);
+
+    return result;
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_mozilla_jss_nss_PR_Recv(JNIEnv *env, jclass clazz, jobject fd,
+    jint amount, jint flags, jlong timeout)
+{
+    PRFileDesc *real_fd = NULL;
+    PRIntervalTime timeout_interval = (PRIntervalTime)(timeout % UINT32_MAX);
+    jobject result = NULL;
+    int read_amount = 0;
+    uint8_t *buffer = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL && amount >= 0 && flags >= 0 &&
+              timeout >= 0 && timeout <= UINT32_MAX);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return NULL;
+    }
+
+    PR_ASSERT(real_fd != NULL);
+
+    buffer = calloc(amount, sizeof(uint8_t));
+
+    read_amount = PR_Recv(real_fd, buffer, amount, flags, timeout_interval);
+
+    if (read_amount <= 0) {
+        goto done;
+    }
+
+    result = JSS_ToByteArray(env, buffer, read_amount);
+
+done:
+    free(buffer);
+    return result;
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_PR_Send(JNIEnv *env, jclass clazz, jobject fd,
+    jbyteArray buf, jint flags, jlong timeout)
+{
+    PRFileDesc *real_fd = NULL;
+    unsigned int real_length = 0;
+    int max_length = 0;
+    uint8_t *buffer = NULL;
+    PRIntervalTime timeout_interval = (PRIntervalTime)(timeout % UINT32_MAX);
+    int result = 0;
+
+    PR_ASSERT(env != NULL && fd != NULL && buf != NULL && flags >= 0 &&
+              timeout >= 0 && timeout <= UINT32_MAX);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return 0;
+    }
+
+    PR_ASSERT(real_fd != NULL);
+
+    real_length = (*env)->GetArrayLength(env, buf);
+    if (real_length > INT_MAX) {
+        max_length = INT_MAX;
+    } else {
+        max_length = (int)(real_length % INT_MAX);
+    }
+
+    buffer = (uint8_t*)((*env)->GetByteArrayElements(env, buf, NULL));
+    if (buffer == NULL) {
+        return 0;
+    }
+
+    result = PR_Send(real_fd, buffer, max_length, flags, timeout_interval);
+    (*env)->ReleaseByteArrayElements(env, buf, (jbyte *)buffer, JNI_ABORT);
+
+    return result;
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_PR_GetError(JNIEnv *env, jclass clazz)
+{
+    return PR_GetError();
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_org_mozilla_jss_nss_PR_GetErrorText(JNIEnv *env, jclass clazz)
+{
+    ssize_t error_size;
+    char *error_text = NULL;
+    jbyteArray result = NULL;
+
+    PR_ASSERT(env != NULL);
+
+    error_size = PR_GetErrorTextLength();
+    if (error_size < 0) {
+        return NULL;
+    }
+
+    error_text = calloc(error_size + 1, sizeof(char));
+    if (PR_GetErrorText(error_text) == 0) {
+        free(error_text);
+        return NULL;
+    }
+
+    result = JSS_ToByteArray(env, error_text, error_size);
+    free(error_text);
+    return result;
+}

--- a/org/mozilla/jss/nss/PR.java
+++ b/org/mozilla/jss/nss/PR.java
@@ -1,0 +1,31 @@
+package org.mozilla.jss.nss;
+
+/**
+ * This class provides static access to raw NSPS calls with the PR prefix,
+ * and handles the usage of NativeProxy objects.
+ */
+
+public class PR {
+
+    public static native PRFDProxy Open(String name, int flags, int mode);
+
+    public static native PRFDProxy NewTCPSocket();
+
+    public static native int Close(PRFDProxy fd);
+
+    public static native int Shutdown(PRFDProxy fd, int how);
+
+    public static native byte[] Read(PRFDProxy fd, int amount);
+
+    public static native byte[] Recv(PRFDProxy fd, int amount, int flags,
+                                     long timeout);
+
+    public static native int Write(PRFDProxy fd, byte[] buf);
+
+    public static native int Send(PRFDProxy fd, byte[] buf, int flags,
+                                  long timeout);
+
+    public static native int GetError();
+
+    public static native byte[] GetErrorText();
+}

--- a/org/mozilla/jss/nss/PR.java
+++ b/org/mozilla/jss/nss/PR.java
@@ -7,25 +7,84 @@ package org.mozilla.jss.nss;
 
 public class PR {
 
+    /**
+     * Open the file at name (with the specified flags and mode) and create
+     * a new PRFDProxy (to a NSPR PRFileDesc *) for that file.
+     *
+     * See also: PR_Open in /usr/include/nspr4/prio.h
+     */
     public static native PRFDProxy Open(String name, int flags, int mode);
 
+    /**
+     * Open a new TCP Socket and create a new PRFDProxy for that socket.
+     *
+     * See also: PR_NewTCPSocket in /usr/include/nspr4/prio.h
+     */
     public static native PRFDProxy NewTCPSocket();
 
+    /**
+     * Close an existing PRFDProxy.
+     *
+     * See also: PR_Close in /usr/include/nspr4/prio.h
+     */
     public static native int Close(PRFDProxy fd);
 
+    /**
+     * Shutdown an existing PRFDProxy.
+     * This is usually used with TCP modes.
+     *
+     * See also: PR_Shutdown in /usr/include/nspr4/prio.h
+     */
     public static native int Shutdown(PRFDProxy fd, int how);
 
+    /**
+     * Read up to amount bytes from a PRFDProxy.
+     *
+     * See also: PR_Read in /usr/include/nspr4/prio.h
+     */
     public static native byte[] Read(PRFDProxy fd, int amount);
 
+    /**
+     * Recv up to amount bytes from a PRFDProxy, given the specified receive
+     * flags and timeout value.
+     *
+     * See also: PR_Recv in /usr/include/nspr4/prio.h
+     */
     public static native byte[] Recv(PRFDProxy fd, int amount, int flags,
                                      long timeout);
 
+    /**
+     * Write the specified bytes to the PRFDProxy.
+     *
+     * Note: Unlike PR_Write, this method assumes the entire buffer is being
+     * written.
+     *
+     * See also: PR_Write in /usr/include/nspr4/prio.h
+     */
     public static native int Write(PRFDProxy fd, byte[] buf);
 
+    /**
+     * Send the specified bytes via the PRFDProxy, given the specified
+     * send flags and timeout value.
+     *
+     * See also: PR_Send in /usr/include/nspr4/prio.h
+     */
     public static native int Send(PRFDProxy fd, byte[] buf, int flags,
                                   long timeout);
 
+    /**
+     * Get the value of the current PR error. This is cleared on each NSPR
+     * call.
+     *
+     * See also: PR_GetError in /usr/include/nspr4/prio.h
+     */
     public static native int GetError();
 
+    /**
+     * Get the error text of the current PR error. This is cleared on each
+     * NSPR call.
+     *
+     * See also: PR_GetErrorText in /usr/include/nspr4/prio.h
+     */
     public static native byte[] GetErrorText();
 }

--- a/org/mozilla/jss/nss/PRFDProxy.c
+++ b/org/mozilla/jss/nss/PRFDProxy.c
@@ -1,0 +1,54 @@
+#include <nspr.h>
+#include <jni.h>
+
+#include "java_ids.h"
+#include "jssutil.h"
+#include "PRFDProxy.h"
+
+jobject
+JSS_PR_wrapPRFDProxy(JNIEnv *env, PRFileDesc **fd)
+{
+    jbyteArray pointer = NULL;
+    jclass proxyClass;
+    jmethodID constructor;
+    jobject fdObj = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL && *fd != NULL);
+
+    /* convert pointer to byte array */
+    pointer = JSS_ptrToByteArray(env, *fd);
+
+    /* Lookup the class and constructor */
+    proxyClass = (*env)->FindClass(env, PRFD_PROXY_CLASS_NAME);
+    if(proxyClass == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+    constructor = (*env)->GetMethodID(env, proxyClass,
+                            PLAIN_CONSTRUCTOR,
+                            PRFD_PROXY_CONSTRUCTOR_SIG);
+    if(constructor == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+
+    /* call the constructor */
+    fdObj = (*env)->NewObject(env, proxyClass, constructor, pointer);
+
+finish:
+    if (fdObj == NULL && *fd != NULL) {
+        /* didn't work, so free resources */
+        PR_Close(*fd);
+    }
+
+    *fd = NULL;
+
+    PR_ASSERT(fdObj || (*env)->ExceptionOccurred(env));
+    return fdObj;
+}
+
+PRStatus
+JSS_PR_getPRFileDesc(JNIEnv *env, jobject prfd_proxy, PRFileDesc **fd)
+{
+    return JSS_getPtrFromProxy(env, prfd_proxy, (void**)fd);
+}

--- a/org/mozilla/jss/nss/PRFDProxy.h
+++ b/org/mozilla/jss/nss/PRFDProxy.h
@@ -1,0 +1,7 @@
+#include <nspr.h>
+#include <jni.h>
+
+#pragma once
+
+jobject JSS_PR_wrapPRFDProxy(JNIEnv *env, PRFileDesc **fd);
+PRStatus JSS_PR_getPRFileDesc(JNIEnv *env, jobject prfd_proxy, PRFileDesc **fd);

--- a/org/mozilla/jss/nss/PRFDProxy.h
+++ b/org/mozilla/jss/nss/PRFDProxy.h
@@ -3,5 +3,8 @@
 
 #pragma once
 
+/* Wrap a C/NSPR PRFileDesc into a Java PRFDProxy, closing the fd on error. */
 jobject JSS_PR_wrapPRFDProxy(JNIEnv *env, PRFileDesc **fd);
+
+/* Extract the C/NSPR PRFileDesc from an instance of a Java PRFDProxy. */
 PRStatus JSS_PR_getPRFileDesc(JNIEnv *env, jobject prfd_proxy, PRFileDesc **fd);

--- a/org/mozilla/jss/nss/PRFDProxy.java
+++ b/org/mozilla/jss/nss/PRFDProxy.java
@@ -1,0 +1,13 @@
+package org.mozilla.jss.nss;
+
+public class PRFDProxy extends org.mozilla.jss.util.NativeProxy {
+    public PRFDProxy(byte[] pointer) {
+        super(pointer);
+    }
+
+    protected native void releaseNativeResources();
+
+    protected void finalize() throws Throwable {
+        super.finalize();
+    }
+}

--- a/org/mozilla/jss/tests/TestPRFD.java
+++ b/org/mozilla/jss/tests/TestPRFD.java
@@ -1,0 +1,97 @@
+package org.mozilla.jss.tests;
+
+import org.mozilla.jss.nss.PR;
+import org.mozilla.jss.nss.PRFDProxy;
+
+public class TestPRFD {
+    public static void TestPROpenNoCreate() {
+        String name = "path_which_should_not_exist_on_any_reasonable_system";
+        PRFDProxy fd = PR.Open(name, 0x02, 00644);
+        assert(fd == null);
+    }
+
+    public static void TestPROpenClose() {
+        PRFDProxy fd = PR.Open("results/prfd_open_close", 0x04 | 0x08, 00644);
+        assert(fd != null);
+
+        assert(PR.Close(fd) == 0);
+    }
+
+    public static void TestPROpenWriteClose() {
+        PRFDProxy fd = PR.Open("results/prfd_open_write_close", 0x04 | 0x08, 00644);
+        assert(fd != null);
+
+        byte[] data = {0x2a, 0x20, 0x2a, 0x20};
+        assert(PR.Write(fd, data) == 4);
+
+        assert(PR.Close(fd) == 0);
+    }
+
+    public static void TestPRRead() {
+        byte[] data = {0x2a, 0x20, 0x2a, 0x20};
+
+        PRFDProxy fd = PR.Open("results/prfd_open_write_close", 0x04, 00644);
+        assert(fd != null);
+
+        byte[] read_data = PR.Read(fd, 10);
+        assert(read_data != null);
+        assert(read_data.length == data.length);
+
+        for (int i = 0; i < data.length; i++) {
+            assert(read_data[i] == data[i]);
+        }
+
+        assert(PR.Close(fd) == 0);
+    }
+
+    public static void TestPREmptyRead() {
+        PRFDProxy fd = PR.Open("results/prfd_open_close", 0x04, 00644);
+        assert(fd != null);
+
+        byte[] read_data = PR.Read(fd, 10);
+        assert(read_data == null || read_data.length == 0);
+
+        assert(PR.Close(fd) == 0);
+    }
+
+    public static void TestNewTCPSocket() {
+        PRFDProxy fd = PR.NewTCPSocket();
+        assert(fd != null);
+    }
+
+    public static void TestShutdown() {
+        PRFDProxy fd = PR.NewTCPSocket();
+        assert(fd != null);
+
+        PR.Shutdown(fd, 0);
+        PR.Shutdown(fd, 1);
+        PR.Shutdown(fd, 2);
+
+        assert(PR.Close(fd) == 0);
+    }
+
+    public static void main(String[] args) {
+        System.loadLibrary("jss4");
+
+        System.out.println("Calling TestPROpenNoCreate()...");
+        TestPROpenNoCreate();
+
+        System.out.println("Calling TestPROpenClose()...");
+        TestPROpenClose();
+
+        System.out.println("Calling TestPROpenWriteClose()...");
+        TestPROpenWriteClose();
+
+        System.out.println("Calling TestPRRead()...");
+        TestPRRead();
+
+        System.out.println("Calling TestPREmptyRead()...");
+        TestPREmptyRead();
+
+        System.out.println("Calling TestNewTCPSocket()...");
+        TestNewTCPSocket();
+
+        System.out.println("Calling TestShutdown()...");
+        TestShutdown();
+    }
+}

--- a/org/mozilla/jss/util/java_ids.h
+++ b/org/mozilla/jss/util/java_ids.h
@@ -380,6 +380,12 @@ PR_BEGIN_EXTERN_C
 #define SSL_VERSION_RANGE_CONSTRUCTOR_NAME "<init>"
 #define SSL_VERSION_RANGE_CONSTRUCTOR_SIG "(II)V"
 
+/*
+ * PRFDProxy
+ */
+#define PRFD_PROXY_CLASS_NAME "org/mozilla/jss/nss/PRFDProxy"
+#define PRFD_PROXY_CONSTRUCTOR_SIG "([B)V"
+
 PR_END_EXTERN_C
 
 #endif

--- a/org/mozilla/jss/util/jssutil.h
+++ b/org/mozilla/jss/util/jssutil.h
@@ -1,3 +1,5 @@
+#include <secitem.h>
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */


### PR DESCRIPTION
This includes commits from ~#125~ and ~#129~.

The goal here is to pull methods up from the C layer and place them in Java land. We're ultimately going to write a SSLEngine entirely in Java, by forking out to the relevant wrapper methods when appropriate.

This should help to complete some of our NSS API wrapping as well. Rather than only exposing "complex" methods which potentially make several NSS/NSPR calls, expose simpler calls and wrap them in higher-level objects.

I realize that the `org.mozilla.jss.nss` folder is a bit of a misnomer right now as it only contains NSPR methods, but I figured I'd prefer to place everything "raw" under `org.mozilla.jss.nss` rather than splitting them.

Alternatively, we could call it `org.mozilla.jss.raw.` but I wasn't as happy with that name.