### PR TITLE
JNI improvements: ToByteArray

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11Cert.c
+++ b/org/mozilla/jss/pkcs11/PK11Cert.c
@@ -34,7 +34,6 @@ JNIEXPORT jbyteArray JNICALL Java_org_mozilla_jss_pkcs11_PK11Cert_getEncoded
 	CERTCertificate *cert;
 	SECItem *derCert;
 	jbyteArray derArray=NULL;
-	jbyte *pByte;
 
 	pThread = PR_AttachThread(PR_SYSTEM_THREAD, 0, NULL);
 	PR_ASSERT(pThread != NULL);
@@ -60,18 +59,11 @@ JNIEXPORT jbyteArray JNICALL Java_org_mozilla_jss_pkcs11_PK11Cert_getEncoded
 	/*
 	 * Copy the DER data to a new Java byte array
 	 */
-	derArray = (*env)->NewByteArray(env, derCert->len);
-	if(derArray==NULL) {
+	derArray = JSS_ToByteArray(env, derCert->data, derCert->len);
+	if (derArray == NULL) {
 		JSS_throw(env, OUT_OF_MEMORY_ERROR);
 		goto finish;
 	}
-	pByte = (*env)->GetByteArrayElements(env, derArray, NULL);
-	if(pByte==NULL) {
-		JSS_throw(env, OUT_OF_MEMORY_ERROR);
-		goto finish;
-	}
-	memcpy(pByte, derCert->data, derCert->len);
-	(*env)->ReleaseByteArrayElements(env, derArray, pByte, 0);
 
 finish:
 	PR_DetachThread();
@@ -544,14 +536,9 @@ Java_org_mozilla_jss_pkcs11_PK11Cert_getUniqueID
     /***************************************************
      * Write the id to a new byte array
      ***************************************************/
-    byteArray = (*env)->NewByteArray(env, id->len);
-    if(byteArray == NULL) {
+    byteArray = JSS_ToByteArray(env, id->data, id->len);
+    if (byteArray == NULL) {
         ASSERT_OUTOFMEM(env);
-        goto finish;
-    }
-    (*env)->SetByteArrayRegion(env, byteArray, 0, id->len, (jbyte*)id->data);
-    if( (*env)->ExceptionOccurred(env) != NULL) {
-        PR_ASSERT(PR_FALSE);
         goto finish;
     }
 

--- a/org/mozilla/jss/pkcs11/PK11Cipher.c
+++ b/org/mozilla/jss/pkcs11/PK11Cipher.c
@@ -163,17 +163,13 @@ Java_org_mozilla_jss_pkcs11_PK11Cipher_updateContext
     PR_ASSERT(outlen >= 0);
 
     /* convert output buffer to byte array */
-    outArray = (*env)->NewByteArray(env, outlen);
-    if(outArray == NULL) {
+    outArray = JSS_ToByteArray(env, outbuf, outlen);
+    if (outArray == NULL) {
         ASSERT_OUTOFMEM(env);
         goto finish;
     }
-    (*env)->SetByteArrayRegion(env, outArray, 0, outlen, (jbyte*)outbuf);
 
 finish:
-    if(inbuf) {
-        (*env)->ReleaseByteArrayElements(env, inputBA, inbuf, JNI_ABORT);
-    }
     if(outbuf) {
         PR_Free(outbuf);
     }
@@ -222,12 +218,11 @@ Java_org_mozilla_jss_pkcs11_PK11Cipher_finalizeContext
 
     /* convert output buffer to byte array */
     PR_ASSERT(newOutLen >= 0);
-    outBA = (*env)->NewByteArray(env, newOutLen);
+    outBA = JSS_ToByteArray(env, outBuf, newOutLen);
     if(outBA == NULL) {
         ASSERT_OUTOFMEM(env);
         goto finish;
     }
-    (*env)->SetByteArrayRegion(env, outBA, 0, newOutLen, (jbyte*)outBuf);
 
 finish:
     if(outBuf) {

--- a/org/mozilla/jss/pkcs11/PK11PrivKey.c
+++ b/org/mozilla/jss/pkcs11/PK11PrivKey.c
@@ -352,15 +352,9 @@ Java_org_mozilla_jss_pkcs11_PK11PrivKey_getUniqueID
      * Write the key id to a new byte array
      ***************************************************/
     PR_ASSERT(idItem->len > 0);
-    byteArray = (*env)->NewByteArray(env, idItem->len);
-    if(byteArray == NULL) {
+    byteArray = JSS_ToByteArray(env, idItem->data, idItem->len);
+    if (byteArray == NULL) {
         ASSERT_OUTOFMEM(env);
-        goto finish;
-    }
-    (*env)->SetByteArrayRegion(env, byteArray, 0, idItem->len,
-                (jbyte*)idItem->data);
-    if( (*env)->ExceptionOccurred(env) != NULL) {
-        PR_ASSERT(PR_FALSE);
         goto finish;
     }
 
@@ -709,16 +703,13 @@ Java_org_mozilla_jss_pkcs11_PK11RSAPrivateKey_getModulusByteArray
     length = (jint)publicKey->u.rsa.modulus.len;
 
     // create byte array
-    array = (*env)->NewByteArray(env, length);
+    array = JSS_ToByteArray(env, value, length);
 
     // check byte array creation
     if (array == NULL) {
         JSS_throw(env, OUT_OF_MEMORY_ERROR);
         goto finish;
     }
-
-    // copy modulus into byte array
-    (*env)->SetByteArrayRegion(env, array, 0, length, value);
 
 finish:
     if (publicKey) {

--- a/org/mozilla/jss/pkcs11/PK11Signature.c
+++ b/org/mozilla/jss/pkcs11/PK11Signature.c
@@ -205,7 +205,6 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineSignNative
     SigContextType type;
     SECItem signature;
     jbyteArray sigArray=NULL;
-    jbyte *sigBytes=NULL;
 
     PR_ASSERT(env!=NULL && this!=NULL);
 
@@ -232,22 +231,13 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineSignNative
     /*
      * Convert SECItem signature to Java byte array
      */
-    sigArray = (*env)->NewByteArray(env, signature.len);
-    if(sigArray == NULL) {
+    sigArray = JSS_ToByteArray(env, signature.data, signature.len);
+    if (sigArray == NULL) {
         ASSERT_OUTOFMEM(env);
         goto finish;
     }
-    sigBytes = (*env)->GetByteArrayElements(env, sigArray, NULL);
-    if(sigBytes == NULL) {
-        ASSERT_OUTOFMEM(env);
-        goto finish;
-    }
-    memcpy(sigBytes, signature.data, signature.len);
     
 finish:
-    if(sigBytes != NULL) {
-        (*env)->ReleaseByteArrayElements(env, sigArray, sigBytes, 0);
-    }
     if( signature.data != NULL ) {
         PR_Free(signature.data);
     }

--- a/org/mozilla/jss/ssl/common.c
+++ b/org/mozilla/jss/ssl/common.c
@@ -694,14 +694,9 @@ Java_org_mozilla_jss_ssl_SocketBase_getPeerAddressByteArrayNative
         address = (jbyte *) &addr.inet.ip;
     }
 
-    byteArray = (*env)->NewByteArray(env,size);
-    if(byteArray == NULL) {
+    byteArray = JSS_ToByteArray(env, address, size);
+    if (byteArray == NULL) {
         ASSERT_OUTOFMEM(env);
-        goto finish;
-    }
-    (*env)->SetByteArrayRegion(env, byteArray, 0,size ,address);
-    if( (*env)->ExceptionOccurred(env) != NULL) {
-        PR_ASSERT(PR_FALSE);
         goto finish;
     }
 
@@ -729,14 +724,9 @@ Java_org_mozilla_jss_ssl_SocketBase_getLocalAddressByteArrayNative
         address = (jbyte *) &addr.inet.ip;
     }
 
-    byteArray = (*env)->NewByteArray(env,size);
-    if(byteArray == NULL) {
+    byteArray = JSS_ToByteArray(env, address, size);
+    if (byteArray == NULL) {
         ASSERT_OUTOFMEM(env);
-        goto finish;
-    }
-    (*env)->SetByteArrayRegion(env, byteArray, 0,size,address);
-    if( (*env)->ExceptionOccurred(env) != NULL) {
-        PR_ASSERT(PR_FALSE);
         goto finish;
     }
 

--- a/org/mozilla/jss/ssl/javasock.c
+++ b/org/mozilla/jss/ssl/javasock.c
@@ -430,24 +430,10 @@ jsock_send(PRFileDesc *fd, const void *buf, PRInt32 amount,
     /*
      * Turn buf into byte array
      */
-    {
-        jbyte *bytes;
-
-        byteArray = (*env)->NewByteArray(env, amount);
-        if( byteArray == NULL ) {
-            ASSERT_OUTOFMEM(env);
-            goto finish;
-        }
-
-        bytes = (*env)->GetByteArrayElements(env, byteArray, NULL);
-        if( bytes == NULL ) {
-            ASSERT_OUTOFMEM(env);
-            goto finish;
-        }
-
-        memcpy(bytes, buf, amount);
-
-        (*env)->ReleaseByteArrayElements(env, byteArray, bytes, 0);
+    byteArray = JSS_ToByteArray(env, buf, amount);
+    if (byteArray == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
     }
 
     retval = writebuf(env, fd, sockObj, byteArray);

--- a/org/mozilla/jss/util/jssutil.c
+++ b/org/mozilla/jss/util/jssutil.c
@@ -317,20 +317,7 @@ JSS_getPtrFromProxyOwner(JNIEnv *env, jobject proxyOwner, char* proxyFieldName,
 jbyteArray
 JSS_ptrToByteArray(JNIEnv *env, void *ptr)
 {
-    jbyteArray byteArray;
-
-    /* Construct byte array from the pointer */
-    byteArray = (*env)->NewByteArray(env, sizeof(ptr));
-    if(byteArray==NULL) {
-        PR_ASSERT( (*env)->ExceptionOccurred(env) != NULL);
-        return NULL;
-    }
-    (*env)->SetByteArrayRegion(env, byteArray, 0, sizeof(ptr), (jbyte*)&ptr);
-    if((*env)->ExceptionOccurred(env) != NULL) {
-        PR_ASSERT(PR_FALSE);
-        return NULL;
-    }
-    return byteArray;
+    return JSS_ToByteArray(env, (void *)&ptr, sizeof(ptr));
 }
 
 
@@ -593,6 +580,32 @@ finish:
     return item;
 }
 
+/************************************************************************
+** JSS_ToByteArray.
+**
+** Converts the given chararacter array to a Java byte array.
+**
+** Returns
+**  The new jbyteArray object or NULL on failure.
+*/
+jbyteArray JSS_ToByteArray(JNIEnv *env, const void *data, int length)
+{
+    jbyteArray byteArray;
+
+    byteArray = (*env)->NewByteArray(env, length);
+    if (byteArray == NULL) {
+        PR_ASSERT((*env)->ExceptionOccurred(env) != NULL);
+        return NULL;
+    }
+
+    (*env)->SetByteArrayRegion(env, byteArray, 0, length, (jbyte *)data);
+    if ((*env)->ExceptionOccurred(env) != NULL) {
+        PR_ASSERT(PR_FALSE);
+        return NULL;
+    }
+
+    return byteArray;
+}
 
 /*
  * External references to the rcs and sccsc ident information in 

--- a/org/mozilla/jss/util/jssutil.h
+++ b/org/mozilla/jss/util/jssutil.h
@@ -286,6 +286,16 @@ void JSS_initErrcodeTranslationTable();
 */
 int JSS_ConvertNativeErrcodeToJava(int nativeErrcode);
 
+/************************************************************************
+** JSS_ToByteArray.
+**
+** Converts the given chararacter array to a Java byte array.
+**
+** Returns
+**  The new jbyteArray object or NULL on failure.
+*/
+jbyteArray JSS_ToByteArray(JNIEnv *env, const void *data, int length);
+
 PR_END_EXTERN_C
 
 #endif


### PR DESCRIPTION
~Includes a commit from #124. Will be rebased after that PR is merged.~

A small helper method with consistent implementation for creating a new `jByteArray` from an existing array-like item in JSS. This proved useful in #122, so I split it off here. 

Ultimately I'd like more small wrappers like this around JNI functionality to have more consistent error handling.

I'm not sure what we should do instead of `assert` in C when `env` is `NULL`, but I'm guessing we don't have many options. Wrapping error handling would be another series of good JNI improvements. 