### PR TITLE
CI changes: ctest --output-on-failure and remove stylecheck image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ services:
   - docker
 
 stages:
-  - validate
   - test
   - extra
 
@@ -23,8 +22,6 @@ script:
 matrix:
   fast_finish: true
   include:
-    - stage: validate
-      env: BASE_IMAGE="stylecheck"
     - stage: extra
       env: BASE_IMAGE="pkcs11check"
     - stage: extra

--- a/tools/Dockerfiles/debian_jdk11
+++ b/tools/Dockerfiles/debian_jdk11
@@ -29,5 +29,6 @@ CMD true \
         && mkdir build \
         && cd build \
         && cmake .. \
-        && make all test \
+        && make all \
+        && ctest --output-on-failure \
         && true

--- a/tools/Dockerfiles/fedora_29_jdk11
+++ b/tools/Dockerfiles/fedora_29_jdk11
@@ -27,5 +27,6 @@ CMD true \
         && mkdir build \
         && cd build \
         && cmake .. \
-        && make all test \
+        && make all \
+        && ctest --output-on-failure \
         && true

--- a/tools/Dockerfiles/fedora_rawhide
+++ b/tools/Dockerfiles/fedora_rawhide
@@ -27,5 +27,6 @@ CMD true \
         && mkdir build \
         && cd build \
         && cmake .. \
-        && make all test \
+        && make all \
+        && ctest --output-on-failure \
         && true

--- a/tools/Dockerfiles/ubuntu_jdk8
+++ b/tools/Dockerfiles/ubuntu_jdk8
@@ -28,5 +28,6 @@ CMD true \
         && mkdir build \
         && cd build \
         && cmake .. \
-        && make all test \
+        && make all \
+        && ctest --output-on-failure \
         && true


### PR DESCRIPTION
Like #127, we add `ctest --output-on-failure` to the container images.

We also remove the `stylecheck` / `validate` stage of the Travis build to save time. The python and shell scripts aren't changing much so there's little point in running it every time.