### PR TITLE
Cleanup remaining warnings

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -123,6 +123,8 @@ macro(jss_config_cflags)
     endif()
 
     list(APPEND JSS_RAW_C_FLAGS "-Wall")
+    list(APPEND JSS_RAW_C_FLAGS "-Wno-cast-function-type")
+    list(APPEND JSS_RAW_C_FLAGS "-Wno-unused-parameter")
     list(APPEND JSS_RAW_C_FLAGS "-Werror-implicit-function-declaration")
     list(APPEND JSS_RAW_C_FLAGS "-Wno-switch")
     list(APPEND JSS_RAW_C_FLAGS "-I${NSPR_INCLUDE_DIR}")

--- a/org/mozilla/jss/PK11Finder.c
+++ b/org/mozilla/jss/PK11Finder.c
@@ -597,12 +597,12 @@ data_start(unsigned char *buf, int length, unsigned int *data_length,
 
         *data_length = 0;
 
-        while (len_count-- > 0) {
+        while (len_count-- > 0 && used_length < length) {
             *data_length = (*data_length << 8) | buf[used_length++];
         }
     }
 
-    if (*data_length > (length-used_length) ) {
+    if (*data_length > (unsigned)(length-used_length) ) {
         *data_length = length-used_length;
         return NULL;
     }

--- a/org/mozilla/jss/pkcs11/PK11KeyGenerator.c
+++ b/org/mozilla/jss/pkcs11/PK11KeyGenerator.c
@@ -166,8 +166,8 @@ finish:
 
 static void FUNCTION_MAY_NOT_BE_USED
 print_secitem(SECItem *item) {
-    int i;
-    int online;
+    unsigned int i;
+    unsigned int online;
 
     if(item==NULL) {
         return;

--- a/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.c
+++ b/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.c
@@ -416,7 +416,7 @@ void
 DumpItem(SECItem *item)
 {
   unsigned char *data = item->data;
-  int i;
+  unsigned int i;
 
   for (i=0; i < item->len; i++) {
     printf(" %02x",data[i]);


### PR DESCRIPTION
This fixes a `-Werror=sign-compare` mistake in three locations and blacklists two other casts.

We don't currently pass `-Wall -Werror -Wextra` on clang, but that's for another time... This at least passes it on GCC.

The two whitelisted warnings are due to JNI and NSPR. 