### PR TITLE
JNI for NSS's `SSL_` methods - 1:1

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -82,6 +82,11 @@ macro(jss_tests)
         NAME "JSS_Test_PR_FileDesc"
         COMMAND "org.mozilla.jss.tests.TestPRFD"
     )
+    jss_test_java(
+        NAME "JSS_Test_Raw_SSL"
+        COMMAND "org.mozilla.jss.tests.TestRawSSL" "${RESULTS_NSSDB_OUTPUT_DIR}"
+        DEPENDS "Setup_DBs"
+    )
     if ((${Java_VERSION_MAJOR} EQUAL 1) AND (${Java_VERSION_MINOR} LESS 9))
         jss_test_java(
             NAME "Test_PKCS11Constants.java_for_Sun_compatibility"

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -348,6 +348,15 @@ Java_org_mozilla_jss_nss_PR_NewTCPSocket;
 Java_org_mozilla_jss_nss_PR_Shutdown;
 Java_org_mozilla_jss_nss_PR_GetError;
 Java_org_mozilla_jss_nss_PR_GetErrorText;
+
+Java_org_mozilla_jss_nss_SSL_ImportFD;
+Java_org_mozilla_jss_nss_SSL_OptionSet;
+Java_org_mozilla_jss_nss_SSL_SetURL;
+Java_org_mozilla_jss_nss_SSL_SecurityStatus;
+Java_org_mozilla_jss_nss_SSL_ResetHandshake;
+Java_org_mozilla_jss_nss_SSL_ForceHandshake;
+Java_org_mozilla_jss_nss_SSL_ConfigSecureServer;
+Java_org_mozilla_jss_nss_SSL_ConfigServerSessionIDCache;
     local:
         *;
 };

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -1,0 +1,217 @@
+#include <nspr.h>
+#include <nss.h>
+#include <ssl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <jni.h>
+
+#include "java_ids.h"
+#include "jssutil.h"
+#include "pk11util.h"
+#include "PRFDProxy.h"
+
+#include "_jni/org_mozilla_jss_nss_SSL.h"
+
+jobject JSS_NewSecurityStatusResult(JNIEnv *env, int on, char *cipher,
+    int keySize, int secretKeySize, char *issuer, char *subject)
+{
+    jclass resultClass;
+    jmethodID constructor;
+    jobject result = NULL;
+    jbyteArray cipher_java = NULL;
+    jbyteArray issuer_java = NULL;
+    jbyteArray subject_java = NULL;
+
+    PR_ASSERT(env != NULL);
+
+    resultClass = (*env)->FindClass(env, SECURITY_STATUS_CLASS_NAME);
+    if (resultClass == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+
+    constructor = (*env)->GetMethodID(env, resultClass, PLAIN_CONSTRUCTOR,
+        SECURITY_STATUS_CONSTRUCTOR_SIG);
+    if (constructor == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+
+    if (cipher) {
+        cipher_java = JSS_ToByteArray(env, cipher, strlen(cipher));
+    }
+
+    if (issuer) {
+        issuer_java = JSS_ToByteArray(env, issuer, strlen(issuer));
+    }
+
+    if (subject) {
+        subject_java = JSS_ToByteArray(env, subject, strlen(subject));
+    }
+
+    result = (*env)->NewObject(env, resultClass, constructor, on, cipher_java,
+        keySize, secretKeySize, issuer_java, subject_java);
+
+finish:
+    return result;
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_mozilla_jss_nss_SSL_ImportFD(JNIEnv *env, jclass clazz, jobject model,
+    jobject fd)
+{
+    PRFileDesc *result = NULL;
+    PRFileDesc *real_model = NULL;
+    PRFileDesc *real_fd = NULL;
+
+    PR_ASSERT(env != NULL);
+
+    /* Note: NSS calling semantics state that either model or fd can be
+     * NULL; so when the Java Object is not-NULL, dereference it. */
+    if (model != NULL && JSS_PR_getPRFileDesc(env, model, &real_model) != PR_SUCCESS) {
+        return NULL;
+    }
+
+    if (fd != NULL && JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return NULL;
+    }
+
+    result = SSL_ImportFD(real_model, real_fd);
+
+    return JSS_PR_wrapPRFDProxy(env, &result);
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_SSL_OptionSet(JNIEnv *env, jclass clazz, jobject fd,
+    jint option, jint val)
+{
+    PRFileDesc *real_fd = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    return SSL_OptionSet(real_fd, option, val);
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_SSL_SetURL(JNIEnv *env, jclass clazz, jobject fd,
+    jstring url)
+{
+    PRFileDesc *real_fd = NULL;
+    char *real_url = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    real_url = (char *)(*env)->GetStringUTFChars(env, url, NULL);
+    if (real_url == NULL) {
+        return SECFailure;
+    }
+
+    return SSL_SetURL(real_fd, real_url);
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_mozilla_jss_nss_SSL_SecurityStatus(JNIEnv *env, jclass clazz,
+    jobject fd)
+{
+    PRFileDesc *real_fd = NULL;
+    int on;
+    char *cipher;
+    int keySize;
+    int secretKeySize;
+    char *issuer;
+    char *subject;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return NULL;
+    }
+
+    if (SSL_SecurityStatus(real_fd, &on, &cipher, &keySize, &secretKeySize, &issuer, &subject) != SECSuccess) {
+        return NULL;
+    }
+
+    return JSS_NewSecurityStatusResult(env, on, cipher, keySize, secretKeySize,
+        issuer, subject);
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_SSL_ResetHandshake(JNIEnv *env, jclass clazz,
+    jobject fd, jboolean asServer)
+{
+    PRFileDesc *real_fd = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    return SSL_ResetHandshake(real_fd, asServer);
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_SSL_ForceHandshake(JNIEnv *env, jclass clazz,
+    jobject fd)
+{
+    PRFileDesc *real_fd = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    return SSL_ForceHandshake(real_fd);
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_SSL_ConfigSecureServer(JNIEnv *env, jclass clazz,
+    jobject fd, jobject cert, jobject key, jint kea)
+{
+    PRFileDesc *real_fd = NULL;
+    CERTCertificate *real_cert = NULL;
+    SECKEYPrivateKey *real_key = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    if (JSS_PK11_getCertPtr(env, cert, &real_cert) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    if (JSS_PK11_getPrivKeyPtr(env, key, &real_key) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    return SSL_ConfigSecureServer(real_fd, real_cert, real_key, kea);
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_SSL_ConfigServerSessionIDCache(JNIEnv *env, jclass clazz,
+    jint maxCacheEntries, jlong timeout, jlong ssl3_timeout, jstring directory)
+{
+    const char *dir_path;
+    SECStatus ret = SECFailure;
+
+    PR_ASSERT(env != NULL);
+
+    dir_path = JSS_RefJString(env, directory);
+
+    ret = SSL_ConfigServerSessionIDCache(maxCacheEntries, timeout,
+        ssl3_timeout, dir_path);
+
+    JSS_DerefJString(env, directory, dir_path);
+    return ret;
+}

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -9,21 +9,61 @@ import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.pkcs11.PK11PrivKey;
 
 public class SSL {
+    /**
+     * Import a file descriptor to create a new SSL file descriptor out of it.
+     *
+     * See also: SSL_ImportFD in /usr/include/nss3/ssl.h
+     */
     public static native PRFDProxy ImportFD(PRFDProxy model, PRFDProxy fd);
 
+    /**
+     * Set the value of a SSL option on the specified PRFileDesc.
+     *
+     * See also: SSL_OptionSet in /usr/include/nss3/ssl.h
+     */
     public static native int OptionSet(PRFDProxy fd, int option, int val);
 
+    /**
+     * Set the hostname of a handshake on the specified PRFileDesc.
+     *
+     * See also: SSL_SetURL in /usr/include/nss3/ssl.h
+     */
     public static native int SetURL(PRFDProxy fd, String url);
 
+    /**
+     * Check the security status of a SSL handshake.
+     *
+     * See also: SSL_SecurityStatus in /usr/include/nss3/ssl.h
+     */
     public static native SecurityStatusResult SecurityStatus(PRFDProxy fd);
 
+    /**
+     * Reset the handshake status, optionally handshaking as a server.
+     *
+     * See also: SSL_ResetHandshake in /usr/include/nss3/ssl.h
+     */
     public static native int ResetHandshake(PRFDProxy fd, boolean asServer);
 
+    /**
+     * Force a handshake to occur if not started, else step one.
+     *
+     * See also: SSL_ForceHandshake in /usr/include/nss3/ssl.h
+     */
     public static native int ForceHandshake(PRFDProxy fd);
 
+    /**
+     * Configure the certificate and private key for a server socket.
+     *
+     * See also: SSL_ConfigSecureServer in /usr/include/nss3/ssl.h
+     */
     public static native int ConfigSecureServer(PRFDProxy fd, PK11Cert cert,
         PK11PrivKey key, int kea);
 
+    /**
+     * Configure the server's session cache.
+     *
+     * See also: SSL_ConfigServerSessionIDCache in /usr/include/nss3/ssl.h
+     */
     public static native int ConfigServerSessionIDCache(int maxCacheEntries,
         long timeout, long ssl3_timeout, String directory);
 }

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -1,0 +1,29 @@
+package org.mozilla.jss.nss;
+
+/**
+ * This class provides static access to raw NSS calls with the SSL prefix,
+ * and handles the usage of NativeProxy objects.
+ */
+
+import org.mozilla.jss.pkcs11.PK11Cert;
+import org.mozilla.jss.pkcs11.PK11PrivKey;
+
+public class SSL {
+    public static native PRFDProxy ImportFD(PRFDProxy model, PRFDProxy fd);
+
+    public static native int OptionSet(PRFDProxy fd, int option, int val);
+
+    public static native int SetURL(PRFDProxy fd, String url);
+
+    public static native SecurityStatusResult SecurityStatus(PRFDProxy fd);
+
+    public static native int ResetHandshake(PRFDProxy fd, boolean asServer);
+
+    public static native int ForceHandshake(PRFDProxy fd);
+
+    public static native int ConfigSecureServer(PRFDProxy fd, PK11Cert cert,
+        PK11PrivKey key, int kea);
+
+    public static native int ConfigServerSessionIDCache(int maxCacheEntries,
+        long timeout, long ssl3_timeout, String directory);
+}

--- a/org/mozilla/jss/nss/SecurityStatusResult.java
+++ b/org/mozilla/jss/nss/SecurityStatusResult.java
@@ -1,0 +1,22 @@
+package org.mozilla.jss.nss;
+
+public class SecurityStatusResult {
+    public int on;
+    public byte[] cipher;
+    public int keySize;
+    public int secretKeySize;
+    public byte[] issuer;
+    public byte[] subject;
+
+    public SecurityStatusResult(int _on, byte[] _cipher, int _keySize,
+        int _secretKeySize, byte[] _issuer, byte[] _subject)
+    {
+        this.on = _on;
+        this.cipher = _cipher;
+        this.keySize = _keySize;
+        this.secretKeySize = _secretKeySize;
+        this.issuer = _issuer;
+        this.subject = _subject;
+    }
+}
+

--- a/org/mozilla/jss/nss/SecurityStatusResult.java
+++ b/org/mozilla/jss/nss/SecurityStatusResult.java
@@ -1,11 +1,29 @@
 package org.mozilla.jss.nss;
 
+/**
+ * The fields in a SecurityStatusResult indicate whether a given SSL-enabled
+ * PRFileDesc has completed its handshake and the resulting handshake-specific
+ * information.
+ *
+ * These object is returned by org.mozilla.jss.nss.SSL.SecurityStatus(fd).
+ */
 public class SecurityStatusResult {
+    /* Whether or not the handshake has completed successfully. */
     public int on;
+
+    /* The current ciphersuite used. */
     public byte[] cipher;
+
+    /* Size of the negotiated peer key. */
     public int keySize;
+
+    /* Size of the session secret key. */
     public int secretKeySize;
+
+    /* Issuer of the peer's certificate. */
     public byte[] issuer;
+
+    /* Subject of the peer's certificate. */
     public byte[] subject;
 
     public SecurityStatusResult(int _on, byte[] _cipher, int _keySize,

--- a/org/mozilla/jss/tests/TestRawSSL.java
+++ b/org/mozilla/jss/tests/TestRawSSL.java
@@ -1,0 +1,99 @@
+package org.mozilla.jss.tests;
+
+import org.mozilla.jss.nss.PR;
+import org.mozilla.jss.nss.PRFDProxy;
+import org.mozilla.jss.nss.SSL;
+import org.mozilla.jss.nss.SecurityStatusResult;
+
+public class TestRawSSL {
+    public static void TestSSLImportFD() {
+        PRFDProxy fd = PR.NewTCPSocket();
+        assert(fd != null);
+
+        PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
+        assert(ssl_fd != null);
+
+        assert(PR.Close(ssl_fd) == 0);
+    }
+
+    public static void TestSSLOptionSet() {
+        PRFDProxy fd = PR.NewTCPSocket();
+        assert(fd != null);
+
+        PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
+        assert(ssl_fd != null);
+
+        // 7 == SSL_ENABLE_SSL2; disable it
+        assert(SSL.OptionSet(ssl_fd, 7, 0) == 0);
+
+        // Ensure that setting an invalid option fails
+        assert(SSL.OptionSet(ssl_fd, 799999, 0) != 0);
+
+        assert(PR.Close(ssl_fd) == 0);
+    }
+
+    public static void TestSSLSetURL() {
+        PRFDProxy fd = PR.NewTCPSocket();
+        assert(fd != null);
+
+        assert(SSL.SetURL(fd, "https://google.com") != 0);
+
+        PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
+        assert(ssl_fd != null);
+
+        assert(SSL.SetURL(ssl_fd, "https://google.com") == 0);
+
+        assert(PR.Close(ssl_fd) == 0);
+    }
+
+    public static void TestSSLSecurityStatus() {
+        PRFDProxy fd = PR.NewTCPSocket();
+        assert(fd != null);
+
+        assert(SSL.SecurityStatus(fd) == null);
+
+        PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
+        assert(ssl_fd != null);
+
+        SecurityStatusResult r = SSL.SecurityStatus(ssl_fd);
+        assert(r.on == 0);
+
+        assert(PR.Close(ssl_fd) == 0);
+    }
+
+    public static void TestSSLResetHandshake() {
+        PRFDProxy fd = PR.NewTCPSocket();
+        assert(fd != null);
+
+        assert(SSL.ResetHandshake(fd, false) != 0);
+
+        PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
+        assert(SSL.ResetHandshake(fd, false) == 0);
+
+        assert(PR.Close(ssl_fd) == 0);
+    }
+
+    public static void main(String[] args) {
+        System.loadLibrary("jss4");
+
+        if (args.length != 1) {
+            System.out.println("Usage: TestRawSSL /path/to/nssdb");
+            System.exit(1);
+        }
+
+        System.out.println("Calling TestSSLImportFD()...");
+        TestSSLImportFD();
+
+        System.out.println("Calling TestSSLOptionSet()...");
+        TestSSLOptionSet();
+
+        System.out.println("Calling TestSSLSetURL()...");
+        TestSSLSetURL();
+
+        System.out.println("Calling TestSSLSecurityStatus()...");
+        TestSSLSecurityStatus();
+
+        System.out.println("Calling TestSSLResetHandshake()...");
+        TestSSLResetHandshake();
+    }
+}

--- a/org/mozilla/jss/util/java_ids.h
+++ b/org/mozilla/jss/util/java_ids.h
@@ -386,6 +386,12 @@ PR_BEGIN_EXTERN_C
 #define PRFD_PROXY_CLASS_NAME "org/mozilla/jss/nss/PRFDProxy"
 #define PRFD_PROXY_CONSTRUCTOR_SIG "([B)V"
 
+/*
+ * SecurityStatusResult
+ */
+#define SECURITY_STATUS_CLASS_NAME "org/mozilla/jss/nss/SecurityStatusResult"
+#define SECURITY_STATUS_CONSTRUCTOR_SIG "(I[BII[B[B)V"
+
 PR_END_EXTERN_C
 
 #endif


### PR DESCRIPTION
~Depends on and includes commits from #122. Will be rebased once that merges.~

~Independent from #130.~ -- PR #130 has been closed as unnecessary. 

This begins implementing methods from NSS with the `SSL_` in an abstraction/JNI layer. This lets us pull the calls away from C, using them later from Java, without having to write a bunch of messy JNI.

These methods were ones included in the example C code from #93. The end goal will be a parallel implementation of the test in #93 except in Java.

(Commits currently messy; missing functionality). 