### PR TITLE
JNI JString improvements

### DIFF
--- a/org/mozilla/jss/SecretDecoderRing/KeyManager.c
+++ b/org/mozilla/jss/SecretDecoderRing/KeyManager.c
@@ -119,7 +119,7 @@ Java_org_mozilla_jss_SecretDecoderRing_KeyManager_generateUniqueNamedKeyNative
     }
 
     /* convert the Java String into a native "C" string */
-    keyname = (*env)->GetStringUTFChars( env, nickname, 0 );
+    keyname = JSS_RefJString(env, nickname);
 
     /* name the key */
     status = PK11_SetSymKeyNickname( symk, keyname );
@@ -136,10 +136,9 @@ finish:
     if( keyID != NULL ) {
         SECITEM_FreeItem(keyID, PR_TRUE /*freeit*/);
     }
-    if( keyname != NULL ) {
-        /* free the native "C" string */
-        (*env)->ReleaseStringUTFChars(env, nickname, keyname);
-    }
+
+    /* free the native "C" string */
+    JSS_DerefJString(env, nickname, keyname);
     return;
 }
 
@@ -234,7 +233,7 @@ Java_org_mozilla_jss_SecretDecoderRing_KeyManager_lookupUniqueNamedKeyNative
     }
 
     /* convert the Java String into a native "C" string */
-    keyname = (*env)->GetStringUTFChars( env, nickname, 0 );
+    keyname = JSS_RefJString(env, nickname);
 
     /* initialize the symmetric key list. */
     symKey = PK11_ListFixedKeysInSlot(
@@ -313,10 +312,10 @@ finish:
     if( symKey != NULL ) {
         PK11_FreeSymKey(symKey);
     }
-    if( keyname != NULL ) {
-        /* free the native "C" string */
-        (*env)->ReleaseStringUTFChars(env, nickname, keyname);
-    }
+
+    /* free the native "C" string */
+    JSS_DerefJString(env, nickname, keyname);
+
     return symKeyObj;
 }
 

--- a/org/mozilla/jss/pkcs11/PK11Cert.c
+++ b/org/mozilla/jss/pkcs11/PK11Cert.c
@@ -291,7 +291,7 @@ findSlotByTokenNameAndCert(char *name, CERTCertificate *cert)
  * key slot (which contains the permanent database token) is returned.
  */
 CERTCertificate *
-JSS_PK11_findCertAndSlotFromNickname(char *nickname, void *wincx,
+JSS_PK11_findCertAndSlotFromNickname(const char *nickname, void *wincx,
     PK11SlotInfo **ppSlot)
 {
     CERTCertificate *cert;

--- a/org/mozilla/jss/pkcs11/PK11Store.c
+++ b/org/mozilla/jss/pkcs11/PK11Store.c
@@ -833,7 +833,7 @@ Java_org_mozilla_jss_pkcs11_PK11Store_importEncryptedPrivateKeyInfo(
     }
 
     // prepare nickname
-    nicknameChars = (*env)->GetStringUTFChars(env, nickname, NULL);
+    nicknameChars = JSS_RefJString(env, nickname);
     if (nicknameChars == NULL) {
         ASSERT_OUTOFMEM(env);
         goto finish;
@@ -881,9 +881,8 @@ finish:
     if (pubKey != NULL) {
         SECKEY_DestroyPublicKey(pubKey);
     }
-    if (nicknameChars != NULL) {
-        (*env)->ReleaseStringUTFChars(env, nickname, nicknameChars);
-    }
+
+    JSS_DerefJString(env, nickname, nicknameChars);
 }
 
 /* Process the given password through the given PasswordConverter,

--- a/org/mozilla/jss/pkcs11/PK11SymKey.c
+++ b/org/mozilla/jss/pkcs11/PK11SymKey.c
@@ -184,7 +184,7 @@ Java_org_mozilla_jss_pkcs11_PK11SymKey_setNickNameNative
     }
 
     /* convert the Java String into a native "C" string */
-    keyname = (*env)->GetStringUTFChars( env, nickname, 0 );
+    keyname = JSS_RefJString(env, nickname);
 
     /* name the key */
     status = PK11_SetSymKeyNickname( key, keyname );
@@ -193,13 +193,8 @@ Java_org_mozilla_jss_pkcs11_PK11SymKey_setNickNameNative
             "Failed to name symmetric key");
     }
 finish:
-
-    if( keyname != NULL ) {
-        /* free the native "C" string */
-        (*env)->ReleaseStringUTFChars(env, nickname, keyname);
-    }
-
-    return;
+    /* free the native "C" string */
+    JSS_DerefJString(env, nickname, keyname);
 }
 
 /***********************************************************************

--- a/org/mozilla/jss/pkcs11/PK11Token.c
+++ b/org/mozilla/jss/pkcs11/PK11Token.c
@@ -930,19 +930,17 @@ JNIEXPORT jstring JNICALL Java_org_mozilla_jss_pkcs11_PK11Token_generatePK10
 {
     PK11SlotInfo *slot;
     const char* c_subject=NULL;
-    jboolean isCopy = JNI_FALSE;
     unsigned char *b64request=NULL;
     SECItem p, q, g;
     PQGParams *dsaParams=NULL;
     const char* c_keyType;
-    jboolean k_isCopy = JNI_FALSE;
     SECOidTag signType = SEC_OID_UNKNOWN;
     PK11RSAGenParams rsaParams;
     void *params = NULL;
 
     PR_ASSERT(env!=NULL && this!=NULL);
     /* get keytype */
-    c_keyType = (*env)->GetStringUTFChars(env, keyType, &k_isCopy);
+    c_keyType = JSS_RefJString(env, keyType);
 
     if (0 == PL_strcasecmp(c_keyType, KEYTYPE_RSA_STRING)) {
       signType = SEC_OID_PKCS1_MD5_WITH_RSA_ENCRYPTION;
@@ -999,21 +997,17 @@ JNIEXPORT jstring JNICALL Java_org_mozilla_jss_pkcs11_PK11Token_generatePK10
     }
 
     /* get subject */
-    c_subject = (*env)->GetStringUTFChars(env, subject, &isCopy);
+    c_subject = JSS_RefJString(env, subject);
 
     /* call GenerateCertRequest() */
     GenerateCertRequest(env, signType, c_subject, slot, &b64request, params);
 
 finish:
-    if (isCopy == JNI_TRUE) {
-      /* release memory */
-      (*env)->ReleaseStringUTFChars(env, subject, c_subject);
-    }
+    /* release memory */
+    JSS_DerefJString(env, subject, c_subject);
 
-    if (k_isCopy == JNI_TRUE) {
-      /* release memory */
-      (*env)->ReleaseStringUTFChars(env, keyType, c_keyType);
-    }
+    /* release memory */
+    JSS_DerefJString(env, keyType, c_keyType);
 
     if (signType == SEC_OID_ANSIX9_DSA_SIGNATURE_WITH_SHA1_DIGEST) {
       SECITEM_FreeItem(&p, PR_FALSE);

--- a/org/mozilla/jss/pkcs11/pk11util.h
+++ b/org/mozilla/jss/pkcs11/pk11util.h
@@ -179,7 +179,7 @@ JSS_PK11_getCertSlotPtr(JNIEnv *env, jobject certObject, PK11SlotInfo **ptr);
  * key slot (which contains the permanent database token) is returned.
  */
 CERTCertificate *
-JSS_PK11_findCertAndSlotFromNickname(char *nickname, void *wincx,
+JSS_PK11_findCertAndSlotFromNickname(const char *nickname, void *wincx,
     PK11SlotInfo **ppSlot);
 
 

--- a/org/mozilla/jss/provider/java/security/JSSKeyStoreSpi.c
+++ b/org/mozilla/jss/provider/java/security/JSSKeyStoreSpi.c
@@ -421,7 +421,7 @@ Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineDeleteEntry
     }
 
     /* get the nickname */
-    cbinfo.targetNickname = (*env)->GetStringUTFChars(env, aliasString, NULL);
+    cbinfo.targetNickname = JSS_RefJString(env, aliasString);
     if( cbinfo.targetNickname == NULL ) {
         goto finish;
     }
@@ -437,9 +437,7 @@ Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineDeleteEntry
                             (void*) &cbinfo);
 
 finish:
-    if( cbinfo.targetNickname != NULL ) {
-        (*env)->ReleaseStringUTFChars(env, aliasString, cbinfo.targetNickname);
-    }
+    JSS_DerefJString(env, aliasString, cbinfo.targetNickname);
 }
 
 typedef struct {
@@ -484,7 +482,7 @@ lookupCertByNickname(JNIEnv *env, jobject this, jstring alias)
         goto finish;
     }
 
-    cbinfo.targetNickname = (*env)->GetStringUTFChars(env, alias, NULL);
+    cbinfo.targetNickname = JSS_RefJString(env, alias);
     if(cbinfo.targetNickname == NULL ) goto finish;
 
     status  = traverseTokenObjects( env,
@@ -494,9 +492,8 @@ lookupCertByNickname(JNIEnv *env, jobject this, jstring alias)
                                     (void*) &cbinfo);
 
 finish:
-    if( cbinfo.targetNickname != NULL ) {
-        (*env)->ReleaseStringUTFChars(env, alias, cbinfo.targetNickname);
-    }
+    JSS_DerefJString(env, alias, cbinfo.targetNickname);
+
     if( status != PR_SUCCESS && cbinfo.cert != NULL) {
         CERT_DestroyCertificate(cbinfo.cert);
         cbinfo.cert = NULL;
@@ -712,7 +709,7 @@ Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineGetKeyNative
      * first look for a matching key
      */
 
-    keyCbinfo.label = (*env)->GetStringUTFChars(env, alias, NULL);
+    keyCbinfo.label = JSS_RefJString(env, alias);
     if( keyCbinfo.label == NULL ) {
         goto finish;
     }
@@ -740,7 +737,7 @@ Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineGetKeyNative
          * If we didn't find a matching key, look for a matching cert
          */
 
-        certCbinfo.targetNickname = (*env)->GetStringUTFChars(env, alias, NULL);
+        certCbinfo.targetNickname = JSS_RefJString(env, alias);
         if(certCbinfo.targetNickname == NULL ) goto finish;
 
         if( traverseTokenObjects(   env,
@@ -760,12 +757,9 @@ Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineGetKeyNative
     }
 
 finish:
-    if( keyCbinfo.label != NULL ) {
-        (*env)->ReleaseStringUTFChars(env, alias, keyCbinfo.label);
-    }
-    if( certCbinfo.targetNickname != NULL ) {
-        (*env)->ReleaseStringUTFChars(env, alias, certCbinfo.targetNickname);
-    }
+    JSS_DerefJString(env, alias, keyCbinfo.label);
+    JSS_DerefJString(env, alias, certCbinfo.targetNickname);
+
     PR_ASSERT( keyCbinfo.privk==NULL && keyCbinfo.symk==NULL);
     PR_ASSERT( certCbinfo.privk==NULL );
 
@@ -787,7 +781,7 @@ Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineIsCertificateEn
         goto finish;
     }
 
-    cbinfo.targetNickname = (*env)->GetStringUTFChars(env, alias, NULL);
+    cbinfo.targetNickname = JSS_RefJString(env, alias);
     if(cbinfo.targetNickname == NULL ) goto finish;
 
     if( traverseTokenObjects(   env,
@@ -821,9 +815,8 @@ Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineIsCertificateEn
     }
 
 finish:
-    if( cbinfo.targetNickname != NULL ) {
-        (*env)->ReleaseStringUTFChars(env, alias, cbinfo.targetNickname);
-    }
+    JSS_DerefJString(env, alias, cbinfo.targetNickname);
+
     if( cbinfo.cert != NULL) {
         CERT_DestroyCertificate(cbinfo.cert);
     }
@@ -845,7 +838,7 @@ Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineSetKeyEntryNati
         goto finish;
     }
 
-    nickname = (*env)->GetStringUTFChars(env, alias, NULL);
+    nickname = JSS_RefJString(env, alias);
     if( nickname == NULL ) {
         ASSERT_OUTOFMEM(env);
         goto finish;
@@ -906,9 +899,8 @@ Java_org_mozilla_jss_provider_java_security_JSSKeyStoreSpi_engineSetKeyEntryNati
     }
 
 finish:
-    if( nickname != NULL ) {
-        (*env)->ReleaseStringUTFChars(env, alias, nickname);
-    }
+    JSS_DerefJString(env, alias, nickname);
+
     if( tokenPrivk != NULL ) {
         SECKEY_DestroyPrivateKey(tokenPrivk);
     }

--- a/org/mozilla/jss/ssl/SSLServerSocket.c
+++ b/org/mozilla/jss/ssl/SSLServerSocket.c
@@ -180,9 +180,7 @@ Java_org_mozilla_jss_ssl_SSLServerSocket_configServerSessionIDCache(
     const char* dirName = NULL;
     SECStatus status;
 
-    if (nameString != NULL) {
-        dirName = (*env)->GetStringUTFChars(env, nameString, NULL);
-    }
+    dirName = JSS_RefJString(env, nameString);
 
     status = SSL_ConfigServerSessionIDCache(
                 maxEntries, ssl2Timeout, ssl3Timeout, dirName);
@@ -193,9 +191,7 @@ Java_org_mozilla_jss_ssl_SSLServerSocket_configServerSessionIDCache(
     }
 
 finish:
-    if(dirName != NULL) {
-        (*env)->ReleaseStringUTFChars(env, nameString, dirName);
-    }
+    JSS_DerefJString(env, nameString, dirName);
 }
 
 /*

--- a/org/mozilla/jss/ssl/SSLSocket.c
+++ b/org/mozilla/jss/ssl/SSLSocket.c
@@ -658,7 +658,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_socketConnect
      * Tell SSL the URL we think we want to connect to.
      * This prevents man-in-the-middle attacks.
      */
-    hostnameStr = (*env)->GetStringUTFChars(env, hostname, NULL);
+    hostnameStr = JSS_RefJString(env, hostname);
     if( hostnameStr == NULL ) goto finish;
     stat = SSL_SetURL(sock->fd, (char*)hostnameStr);
     if( stat != 0 ) {
@@ -706,9 +706,8 @@ finish:
     /* This method should never be called on a Java socket wrapper. */
     PR_ASSERT( sock==NULL || sock->jsockPriv==NULL);
 
-    if( hostnameStr != NULL ) {
-        (*env)->ReleaseStringUTFChars(env, hostname, hostnameStr);
-    }
+    JSS_DerefJString(env, hostname, hostnameStr);
+
     if( addrBAelems != NULL ) {
         (*env)->ReleaseByteArrayElements(env, addrBA, addrBAelems, JNI_ABORT);
     }

--- a/org/mozilla/jss/ssl/common.c
+++ b/org/mozilla/jss/ssl/common.c
@@ -170,9 +170,11 @@ Java_org_mozilla_jss_ssl_SocketBase_socketCreate(JNIEnv *env, jobject self,
         const char *chars;
         int retval;
         PR_ASSERT( javaSock != NULL );
-        chars = (*env)->GetStringUTFChars(env, host, NULL);
+
+        chars = JSS_RefJString(env, host);
         retval = SSL_SetURL(sockdata->fd, chars);
-        (*env)->ReleaseStringUTFChars(env, host, chars);
+        JSS_DerefJString(env, host, chars);
+
         if( retval ) {
             JSSL_throwSSLSocketException(env,
                 "Failed to set SSL domain name");

--- a/org/mozilla/jss/util/jssutil.h
+++ b/org/mozilla/jss/util/jssutil.h
@@ -57,7 +57,7 @@ extern JavaVM *JSS_javaVM;
  *      return -1;
  */
 void
-JSS_throwMsg(JNIEnv *env, char *throwableClassName, char *message);
+JSS_throwMsg(JNIEnv *env, const char *throwableClassName, const char *message);
 
 #define JSS_nativeThrowMsg JSS_throwMsg
 
@@ -256,8 +256,8 @@ JSS_strerror(PRErrorCode errNum);
 **      return -1;
 */
 void
-JSS_throwMsgPrErrArg(JNIEnv *env, char *throwableClassName, char *message,
-    PRErrorCode errCode);
+JSS_throwMsgPrErrArg(JNIEnv *env, const char *throwableClassName,
+    const char *message, PRErrorCode errCode);
 
 #define JSS_throwMsgPrErr(e, cn, m) \
     JSS_throwMsgPrErrArg((e), (cn), (m), PR_GetError())
@@ -295,6 +295,25 @@ int JSS_ConvertNativeErrcodeToJava(int nativeErrcode);
 **  The new jbyteArray object or NULL on failure.
 */
 jbyteArray JSS_ToByteArray(JNIEnv *env, const void *data, int length);
+
+/************************************************************************
+** JSS_RefJString
+**
+** Converts the given jstring object to a char *; must be freed with
+** JSS_DerefJString().
+**
+** Returns
+**  A reference to the characters underlying the given string.
+*/
+const char *JSS_RefJString(JNIEnv *env, jstring str);
+
+/************************************************************************
+** JSS_DerefJString
+**
+** Returns the reference given by the JVM to a jstring's contents.
+**
+*/
+void JSS_DerefJString(JNIEnv *env, jstring str, const char *ref);
 
 PR_END_EXTERN_C
 


### PR DESCRIPTION
This simplifies the interaction between C and Java with regards to JNI's `jstring` representation of Java's `String` objects. 

In particular, we only ever access JString's via their UTF8 representations, so this wrapper assumes we're doing that. It also handles `NULL` strings, simplifying the logic to call these wrappers: always call them and condition around a `NULL` return value instead of a `NULL` input value. 

This also caught two types of bugs:
 - Where we forget to dereference at all.
 - Where we (incorrectly) conditionally dereference around whether or not we're acting on a copy. Common consensus seems to be to always dereference, even on copies.

Questions: 
 - Should we add error handling logic when the string fails to parse/reference? E.g., `jstring != NULL` but the return value is `NULL`? This influences whether or not the changes to `configureOCSP` are correct.
 - Should we make `Ref` return a `const char *` instead of a `char *`? This means that some references will have to cast to `(char *)` themselves. Perhaps we can update those places to use `const char *`...