### PR TITLE
Remove needless dependency on hamcrest

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,13 @@ This project has the following dependencies:
  - [JavaEE JAXB](https://github.com/eclipse-ee4j/jaxb-ri)
  - [SLF4J](https://www.slf4j.org/)
  - [JUnit 4](https://junit.org/junit4/)
-    - [Hamcrest](http://hamcrest.org/)
 
 To install these dependencies on Fedora, execute the following:
 
     sudo dnf install apache-commons-codec apache-commons-lang gcc-c++ \
                      java-devel jpackage-utils slf4j zlib-devel \
                      glassfish-jaxb-api nss-tools nss-devel cmake \
-                     hamcrest junit
+                     junit
 
 To install these dependencies on Debian, execute the following:
 
@@ -48,7 +47,7 @@ To install these dependencies on Debian, execute the following:
                          libcommons-lang-java libnss3-dev libslf4j-java \
                          openjdk-8-jdk pkg-config zlib1g-dev \
                          libjaxb-api-java libnss3-tools cmake zip unzip \
-                         libhamcrest-java junit4
+                         junit4
 
 
 Building

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -39,16 +39,15 @@ additional packages:
  - [SLF4J's JDK14 package](https://www.slf4j.org/api/org/slf4j/impl/JDK14LoggerAdapter.html)
  - [NSS's pk12util](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Reference/NSS_tools_:_pk12util)
  - [JUnit 4](https://junit.org/junit4/)
-    - [Hamcrest](http://hamcrest.org/)
 
 To install these dependencies on Fedora, execute the following:
 
-    sudo dnf install nss nss-tools slf4j-jdk14 hamcrest junit
+    sudo dnf install nss nss-tools slf4j-jdk14 junit
 
 To install these dependencies on Debian, execute the following:
 
     sudo apt-get install libnss3 libnss3-tools libslf4j-java \
-                         libhamcrest-java junit4
+                         junit4
 
 ## Run-time Dependencies
 

--- a/jss.spec
+++ b/jss.spec
@@ -57,7 +57,6 @@ BuildRequires:  perl-interpreter
 %endif
 
 BuildRequires:  junit
-BuildRequires:  hamcrest
 
 Requires:       nss >= 3.30
 Requires:       java-headless

--- a/tools/Dockerfiles/debian_jdk11
+++ b/tools/Dockerfiles/debian_jdk11
@@ -8,7 +8,7 @@ RUN true \
                               openjdk-11-jdk pkg-config quilt g++ mercurial \
                               zlib1g-dev libslf4j-java liblog4j2-java \
                               libcommons-lang-java libjaxb-api-java cmake \
-                              zip unzip libhamcrest-java junit4 \
+                              zip unzip junit4 \
         && mkdir -p /home/sandbox \
         && apt-get autoremove -y \
         && apt-get clean -y \

--- a/tools/Dockerfiles/fedora_29_jdk11
+++ b/tools/Dockerfiles/fedora_29_jdk11
@@ -8,7 +8,7 @@ RUN true \
                           apache-commons-codec apache-commons-lang gcc-c++ \
                           java-11-openjdk-devel jpackage-utils slf4j nss \
                           zlib-devel nss-devel nspr-devel perl slf4j-jdk14 \
-                          hamcrest junit \
+                          junit \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \
         && rm -rf /usr/share/doc /usr/share/doc-base \

--- a/tools/Dockerfiles/fedora_rawhide
+++ b/tools/Dockerfiles/fedora_rawhide
@@ -8,7 +8,7 @@ RUN true \
                           apache-commons-codec apache-commons-lang gcc-c++ \
                           java-11-openjdk-devel jpackage-utils slf4j nss \
                           zlib-devel nss-devel nspr-devel perl slf4j-jdk14 \
-                          hamcrest junit \
+                          junit \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \
         && rm -rf /usr/share/doc /usr/share/doc-base \

--- a/tools/Dockerfiles/ubuntu_jdk8
+++ b/tools/Dockerfiles/ubuntu_jdk8
@@ -8,7 +8,7 @@ RUN true \
                               openjdk-8-jdk pkg-config quilt g++ mercurial \
                               zlib1g-dev libslf4j-java liblog4j2-java \
                               libcommons-lang-java libjaxb-api-java cmake \
-                              zip unzip libhamcrest-java junit4 \
+                              zip unzip junit4 \
         && mkdir -p /home/sandbox \
         && apt-get autoremove -y \
         && apt-get clean -y \


### PR DESCRIPTION
jUnit pulls in `hamcrest-core` for us, which is all we need. This should fix Rawhide builds, since `hamcrest` fails to install.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`