### PR TITLE
JNI Enhancements: JSS_FromByteArray

### DIFF
--- a/org/mozilla/jss/CryptoManager.c
+++ b/org/mozilla/jss/CryptoManager.c
@@ -708,7 +708,7 @@ getPWFromCallback(PK11SlotInfo *slot, PRBool retry, void *arg)
 
         returnchars = PL_strdup(pwchars);
         JSS_wipeCharArray(pwchars);
-        (*env)->ReleaseByteArrayElements(env, pwArray, (jbyte*)pwchars, 0);
+        JSS_DerefByteArray(env, pwArray, pwchars, 0);
     } else {
         returnchars = NULL;
     }

--- a/org/mozilla/jss/PK11Finder.c
+++ b/org/mozilla/jss/PK11Finder.c
@@ -1024,10 +1024,8 @@ finish:
         }
         PR_Free(derCerts);
     }
-    if(packageBytes != NULL) {
-        (*env)->ReleaseByteArrayElements(env, packageArray, packageBytes,
-                                            JNI_ABORT); /* don't copy back */
-    }
+    /* don't copy back */
+    JSS_DerefByteArray(env, packageArray, packageBytes, JNI_ABORT);
     if(leafCert != NULL) {
         CERT_DestroyCertificate(leafCert);
     }
@@ -1324,10 +1322,7 @@ finish:
     if( cinfo != NULL) {
         SEC_PKCS7DestroyContentInfo(cinfo);
     }
-    if(pkcs7Bytes != NULL) {
-        PR_ASSERT(pkcs7ByteArray != NULL);
-        (*env)->ReleaseByteArrayElements(env, pkcs7ByteArray, pkcs7Bytes, 0);
-    }
+    JSS_DerefByteArray(env, pkcs7ByteArray, pkcs7Bytes, 0);
     if( info != NULL ) {
         destroyEncoderCallbackInfo(info);
     }

--- a/org/mozilla/jss/PK11Finder.c
+++ b/org/mozilla/jss/PK11Finder.c
@@ -816,12 +816,10 @@ Java_org_mozilla_jss_CryptoManager_importCertPackageNative
     /***************************************************
      * Convert package from byte array to jbyte*
      ***************************************************/
-    packageBytes = (*env)->GetByteArrayElements(env, packageArray, NULL);
-    if(packageBytes == NULL) {
-        PR_ASSERT( (*env)->ExceptionOccurred(env) );
+    if (!JSS_RefByteArray(env, packageArray, &packageBytes, &packageLen)) {
+        PR_ASSERT((*env)->ExceptionOccurred(env));
         goto finish;
     }
-    packageLen = (*env)->GetArrayLength(env, packageArray);
 
     /***************************************************
      * Decode package with NSS function

--- a/org/mozilla/jss/pkcs11/PK11MessageDigest.c
+++ b/org/mozilla/jss/pkcs11/PK11MessageDigest.c
@@ -132,9 +132,7 @@ Java_org_mozilla_jss_pkcs11_PK11MessageDigest_update
     }
 
 finish:
-    if(bytes) {
-        (*env)->ReleaseByteArrayElements(env, inbufBA, bytes, JNI_ABORT);
-    }
+    JSS_DerefByteArray(env, inbufBA, bytes, JNI_ABORT);
 }
 
 
@@ -174,8 +172,6 @@ Java_org_mozilla_jss_pkcs11_PK11MessageDigest_digest
     }
 
 finish:
-    if(bytes) {
-        (*env)->ReleaseByteArrayElements(env, outbuf, bytes, 0);
-    }
+    JSS_DerefByteArray(env, outbuf, bytes, 0);
     return outLen;
 }

--- a/org/mozilla/jss/pkcs11/PK11MessageDigest.c
+++ b/org/mozilla/jss/pkcs11/PK11MessageDigest.c
@@ -111,15 +111,15 @@ Java_org_mozilla_jss_pkcs11_PK11MessageDigest_update
 
     PK11Context *context = NULL;
     jbyte* bytes = NULL;
+    jsize length = 0;
 
     if( JSS_PK11_getCipherContext(env, proxyObj, &context) != PR_SUCCESS ) {
         /* exception was thrown */
         goto finish;
     }
 
-    PR_ASSERT( (*env)->GetArrayLength(env, inbufBA) >= offset+len );
-    bytes = (*env)->GetByteArrayElements(env, inbufBA, NULL);
-    if( bytes == NULL ) {
+    if (!JSS_RefByteArray(env, inbufBA, &bytes, &length) ||
+            length < offset+len) {
         ASSERT_OUTOFMEM(env);
         goto finish;
     }
@@ -148,6 +148,7 @@ Java_org_mozilla_jss_pkcs11_PK11MessageDigest_digest
 {
     PK11Context *context=NULL;
     jbyte *bytes=NULL;
+    jsize length = 0;
     SECStatus status;
     unsigned int outLen = 0;
 
@@ -156,9 +157,8 @@ Java_org_mozilla_jss_pkcs11_PK11MessageDigest_digest
         goto finish;
     }
 
-    PR_ASSERT( (*env)->GetArrayLength(env, outbuf) >= offset+len );
-    bytes = (*env)->GetByteArrayElements(env, outbuf, NULL);
-    if( bytes == NULL ) {
+    if (!JSS_RefByteArray(env, outbuf, &bytes, &length) ||
+            length < offset+len) {
         ASSERT_OUTOFMEM(env);
         goto finish;
     }

--- a/org/mozilla/jss/pkcs11/PK11SecureRandom.c
+++ b/org/mozilla/jss/pkcs11/PK11SecureRandom.c
@@ -72,7 +72,6 @@ Java_org_mozilla_jss_pkcs11_PK11SecureRandom_setSeed
      */
 
     jbyte*    jdata   = NULL;
-    jboolean  jIsCopy = JNI_FALSE;
     jsize     jlen    = 0;
 
 
@@ -113,18 +112,11 @@ Java_org_mozilla_jss_pkcs11_PK11SecureRandom_setSeed
 
     /*
      * Convert "JNI jbyteArray" into "JNI jbyte*" so
-     * that it can be cast into a "C unsigned char*"
+     * that it can be cast into a "C unsigned char*";
+     * also get its length.
      */
 
-    jdata = ( *env )->GetByteArrayElements( env, jseed, &jIsCopy );
-
-
-    /*
-     * Retrieve the length of the "JNI jbyteArray"
-     * so that it can be cast into a "C int"
-     */
-
-    jlen = ( *env )->GetArrayLength( env, jseed );
+    JSS_RefByteArray(env, jseed, &jdata, &jlen);
 
 
     /*
@@ -220,7 +212,6 @@ Java_org_mozilla_jss_pkcs11_PK11SecureRandom_nextBytes
      */
 
     jbyte*    jdata   = NULL;
-    jboolean  jIsCopy = JNI_FALSE;
     jsize     jlen    = 0;
 
 
@@ -249,18 +240,10 @@ Java_org_mozilla_jss_pkcs11_PK11SecureRandom_nextBytes
 
     /*
      * Convert "JNI jbyteArray" into "JNI jbyte*" so
-     * that it can be cast into a "C unsigned char*"
+     * that it can be cast into a "C unsigned char*";
+     * also get its length.
      */
-
-    jdata = ( *env )->GetByteArrayElements( env, jbytes, &jIsCopy );
-
-
-    /*
-     * Retrieve the length of the "JNI jbyteArray"
-     * so that it can be cast into a "C int"
-     */
-
-    jlen = ( *env )->GetArrayLength( env, jbytes );
+    JSS_RefByteArray(env, jbytes, &jdata, &jlen);
 
 
     /*

--- a/org/mozilla/jss/pkcs11/PK11SecureRandom.c
+++ b/org/mozilla/jss/pkcs11/PK11SecureRandom.c
@@ -146,9 +146,7 @@ finish:
      * free any resources associated with it
      */
 
-    if(  jIsCopy == JNI_TRUE ) {
-        ( *env )->ReleaseByteArrayElements( env, jseed, jdata, 0 );
-    }
+    JSS_DerefByteArray(env, jseed, jdata, 0);
 
 
     /*
@@ -283,9 +281,7 @@ finish:
      * free any resources associated with it
      */
 
-    if( jIsCopy == JNI_TRUE ) {
-        ( *env )->ReleaseByteArrayElements( env, jbytes, jdata, 0 );
-    }
+    JSS_DerefByteArray(env, jbytes, jdata, 0);
 
 
     /*

--- a/org/mozilla/jss/pkcs11/PK11Signature.c
+++ b/org/mozilla/jss/pkcs11/PK11Signature.c
@@ -186,9 +186,7 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineUpdateNative
     }
 
 finish:
-    if(bytes!=NULL) {
-        (*env)->ReleaseByteArrayElements(env, bArray, bytes, JNI_ABORT);
-    }
+    JSS_DerefByteArray(env, bArray, bytes, JNI_ABORT);
 }
 
 
@@ -295,12 +293,7 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineVerifyNative
 	}
 
 finish:
-	if(sigItem.data!=NULL) {
-		(*env)->ReleaseByteArrayElements(	env,
-											sigArray,
-											(jbyte*)sigItem.data,
-											JNI_ABORT);
-	}
+	JSS_DerefByteArray(env, sigArray, sigItem.data, JNI_ABORT);
 	return verified;
 }
 

--- a/org/mozilla/jss/pkcs11/PK11Signature.c
+++ b/org/mozilla/jss/pkcs11/PK11Signature.c
@@ -150,13 +150,10 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineUpdateNative
     PR_ASSERT(ctxt != NULL);
 
     /* Get the bytes to be updated */
-    bytes = (*env)->GetByteArrayElements(env, bArray, NULL);
-    if(bytes==NULL) {
+    if (!JSS_RefByteArray(env, bArray, &bytes, &numBytes)) {
         ASSERT_OUTOFMEM(env);
         goto finish;
     }
-    numBytes = (*env)->GetArrayLength(env, bArray);
-    PR_ASSERT(numBytes > 0);
 
     if( offset < 0 || offset >= numBytes || length < 0 ||
             (offset+length) > numBytes || (offset+length) < 0 )
@@ -272,13 +269,10 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineVerifyNative
 	/*
 	 * Convert signature to SECItem
 	 */
-	sigItem.data = (unsigned char*)
-						(*env)->GetByteArrayElements(env, sigArray, 0);
-	if(sigItem.data == NULL) {
+	if (!JSS_RefByteArray(env, sigArray, (jbyte **) &sigItem.data, (jsize *) &sigItem.len)) {
 		ASSERT_OUTOFMEM(env);
 		goto finish;
 	}
-	sigItem.len = (*env)->GetArrayLength(env, sigArray);
 
 	/*
 	 * Finish the verification operation

--- a/org/mozilla/jss/pkcs11/PK11Store.c
+++ b/org/mozilla/jss/pkcs11/PK11Store.c
@@ -574,15 +574,12 @@ Java_org_mozilla_jss_pkcs11_PK11Store_importPrivateKey
     /*
      * copy the java byte array into a local copy
      */
-    derPK.len = (*env)->GetArrayLength(env, keyArray);
-    if(derPK.len <= 0) {
-        JSS_throwMsg(env, INVALID_KEY_FORMAT_EXCEPTION, "Key array is empty");
-        goto finish;
-    }
-    derPK.data = (unsigned char*)
-            (*env)->GetByteArrayElements(env, keyArray, NULL);
-    if(derPK.data == NULL) {
-        ASSERT_OUTOFMEM(env);
+    if (!JSS_RefByteArray(env, keyArray, (jbyte **) &derPK.data, (jsize *) &derPK.len)) {
+        if (derPK.len == 0) {
+            JSS_throwMsg(env, INVALID_KEY_FORMAT_EXCEPTION, "Key array is empty");
+        } else {
+            ASSERT_OUTOFMEM(env);
+        }
         goto finish;
     }
 

--- a/org/mozilla/jss/pkcs11/PK11Store.c
+++ b/org/mozilla/jss/pkcs11/PK11Store.c
@@ -618,12 +618,8 @@ finish:
     if( (excep=(*env)->ExceptionOccurred(env)) ) {
         (*env)->ExceptionClear(env);
     }
-    if(derPK.data != NULL) {
-        (*env)->ReleaseByteArrayElements(   env,
-                                            keyArray,
-                                            (jbyte*) derPK.data,
-                                            JNI_ABORT           );
-    }
+    JSS_DerefByteArray(env, keyArray, derPK.data, JNI_ABORT);
+
     /* now re-throw the exception */
     if( excep ) {
         (*env)->Throw(env, excep);

--- a/org/mozilla/jss/pkcs11/PK11SymmetricKeyDeriver.c
+++ b/org/mozilla/jss/pkcs11/PK11SymmetricKeyDeriver.c
@@ -76,13 +76,11 @@ JNIEXPORT jobject JNICALL Java_org_mozilla_jss_pkcs11_PK11SymmetricKeyDeriver_na
     }
 
     if( param != NULL) {
-        paramValue = (*env)->GetByteArrayElements(env,param, NULL);
-        paramLength = (*env)->GetArrayLength(env,param);
+        JSS_RefByteArray(env, param, &paramValue, &paramLength);
     }
 
     if( iv != NULL) {
-        ivValue = (*env)->GetByteArrayElements(env,iv, NULL);
-        ivLength = (*env)->GetArrayLength(env,iv);
+        JSS_RefByteArray(env, iv, &ivValue, &ivLength);
     }
 
     /* Set up the params data for the PK11_Derive family */

--- a/org/mozilla/jss/pkcs11/PK11SymmetricKeyDeriver.c
+++ b/org/mozilla/jss/pkcs11/PK11SymmetricKeyDeriver.c
@@ -312,14 +312,8 @@ finish:
        slotForSecondaryKey = NULL;
     }
 
-    if(paramValue) {
-        (*env)->ReleaseByteArrayElements(env, param, (jbyte*)paramValue,
-                                                              JNI_ABORT);
-    }
-    if(ivValue) {
-        (*env)->ReleaseByteArrayElements(env, iv, (jbyte*)ivValue,
-                                                        JNI_ABORT);
-    }
+    JSS_DerefByteArray(env, param, paramValue, JNI_ABORT);
+    JSS_DerefByteArray(env, iv, ivValue, JNI_ABORT);
 
     if( keyObj == NULL) {
         JSS_throwMsgPrErr(env, TOKEN_EXCEPTION, "Unable to derive symmetric key! "

--- a/org/mozilla/jss/pkcs11/PK11Token.c
+++ b/org/mozilla/jss/pkcs11/PK11Token.c
@@ -529,21 +529,15 @@ finish:
     /*
 	 * Free native objects
 	 */
-    if(szSsopw) {
-		if(ssoIsCopy) {
-			JSS_wipeCharArray(szSsopw);
-		}
-		/* JNI_ABORT means don't copy back changes */
-		(*env)->ReleaseByteArrayElements(env, ssopw, (jbyte*)szSsopw,
-										JNI_ABORT);
+    if (szSsopw && ssoIsCopy) {
+        JSS_wipeCharArray(szSsopw);
     }
-    if(szUserpw) {
-		if(userIsCopy) {
-			JSS_wipeCharArray(szUserpw);
-		}
-		(*env)->ReleaseByteArrayElements(env, userpw, (jbyte*)szUserpw,
-										JNI_ABORT);
+    JSS_DerefByteArray(env, ssopw, szSsopw, JNI_ABORT);
+
+    if (szUserpw && userIsCopy) {
+        JSS_wipeCharArray(szUserpw);
     }
+    JSS_DerefByteArray(env, userpw, szUserpw, JNI_ABORT);
 
     return;
 }
@@ -640,21 +634,15 @@ JNIEXPORT void JNICALL Java_org_mozilla_jss_pkcs11_PK11Token_changePassword
 
 finish:
     /* Free native objects */
-    if(szOldPIN) {
-		if(oldIsCopy) {
-			JSS_wipeCharArray(szOldPIN);
-		}
-		/* JNI_ABORT means don't copy back changes */
-        (*env)->ReleaseByteArrayElements(env, oldPIN, (jbyte*)szOldPIN,
-										JNI_ABORT);
+    if(szOldPIN && oldIsCopy) {
+        JSS_wipeCharArray(szOldPIN);
     }
-    if(szNewPIN) {
-		if(newIsCopy) {
-			JSS_wipeCharArray(szNewPIN);
-		}
-        (*env)->ReleaseByteArrayElements(env, newPIN, (jbyte*)szNewPIN,
-										JNI_ABORT);
+    JSS_DerefByteArray(env, oldPIN, szOldPIN, JNI_ABORT);
+
+    if(szNewPIN && newIsCopy) {
+        JSS_wipeCharArray(szNewPIN);
     }
+    JSS_DerefByteArray(env, newPIN, szNewPIN, JNI_ABORT);
 
     return;
 }
@@ -717,14 +705,11 @@ passwordIsCorrect
 
 finish:
 	/* Free native objects */
-	if(pwBytes != NULL) {
-		if(isCopy) {
-			JSS_wipeCharArray(pwBytes);
-		}
-		/* JNI_ABORT means don't copy back changes */
-		(*env)->ReleaseByteArrayElements(env, password, (jbyte*)pwBytes,
-											JNI_ABORT);
+	if (pwBytes && isCopy) {
+		JSS_wipeCharArray(pwBytes);
 	}
+	/* JNI_ABORT means don't copy back changes */
+	JSS_DerefByteArray(env, password, pwBytes, JNI_ABORT);
 
 	return pwIsCorrect;
 }

--- a/org/mozilla/jss/ssl/SSLSocket.c
+++ b/org/mozilla/jss/ssl/SSLSocket.c
@@ -644,12 +644,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_socketConnect
     supportsIPV6 = (*env)->CallStaticBooleanMethod(env, socketBaseClass,
          supportsIPV6ID);
 
-    addrBAelems = (*env)->GetByteArrayElements(env, addrBA, NULL);
-    addrBALen = (*env)->GetArrayLength(env, addrBA);
-
-    PR_ASSERT(addrBALen != 0);
-
-    if( addrBAelems == NULL ) {
+    if (!JSS_RefByteArray(env, addrBA, &addrBAelems, &addrBALen)) {
         ASSERT_OUTOFMEM(env);
         goto finish;
     }
@@ -934,15 +929,13 @@ Java_org_mozilla_jss_ssl_SSLSocket_socketRead(JNIEnv *env, jobject self,
     PRIntervalTime ivtimeout;
     PRThread *me;
     jint nread = -1;
-    
-    size = (*env)->GetArrayLength(env, bufBA);
-    if( off < 0 || len < 0 || (off+len) > size) {
-        JSS_throw(env, INDEX_OUT_OF_BOUNDS_EXCEPTION);
+
+    if (!JSS_RefByteArray(env, bufBA, &buf, &size)) {
         goto finish;
     }
 
-    buf = (*env)->GetByteArrayElements(env, bufBA, NULL);
-    if( buf == NULL ) {
+    if (off < 0 || len < 0 || (off+len) > size) {
+        JSS_throw(env, INDEX_OUT_OF_BOUNDS_EXCEPTION);
         goto finish;
     }
 
@@ -1041,19 +1034,12 @@ Java_org_mozilla_jss_ssl_SSLSocket_socketWrite(JNIEnv *env, jobject self,
     PRThread *me;
     PRInt32 numwrit;
 
-    if( bufBA == NULL ) {
-        JSS_throw(env, NULL_POINTER_EXCEPTION);
+    if (!JSS_RefByteArray(env, bufBA, &buf, &size)) {
         goto finish;
     }
 
-    size = (*env)->GetArrayLength(env, bufBA);
-    if( off < 0 || len < 0 || (off+len) > size ) {
+    if (off < 0 || len < 0 || (off+len) > size) {
         JSS_throw(env, INDEX_OUT_OF_BOUNDS_EXCEPTION);
-        goto finish;
-    }
-
-    buf = (*env)->GetByteArrayElements(env, bufBA, NULL);
-    if( buf == NULL ) {
         goto finish;
     }
 

--- a/org/mozilla/jss/ssl/SSLSocket.c
+++ b/org/mozilla/jss/ssl/SSLSocket.c
@@ -707,10 +707,7 @@ finish:
     PR_ASSERT( sock==NULL || sock->jsockPriv==NULL);
 
     JSS_DerefJString(env, hostname, hostnameStr);
-
-    if( addrBAelems != NULL ) {
-        (*env)->ReleaseByteArrayElements(env, addrBA, addrBAelems, JNI_ABORT);
-    }
+    JSS_DerefByteArray(env, addrBA, addrBAelems, JNI_ABORT);
 }
 
 JNIEXPORT jobject JNICALL
@@ -1009,7 +1006,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_socketRead(JNIEnv *env, jobject self,
 
 finish:
     EXCEPTION_CHECK(env, sock)
-    (*env)->ReleaseByteArrayElements(env, bufBA, buf,
+    JSS_DerefByteArray(env, bufBA, buf,
         (nread>0) ? 0 /*copy and free*/ : JNI_ABORT /*free, no copy*/);
     return nread;
 }
@@ -1114,9 +1111,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_socketWrite(JNIEnv *env, jobject self,
     PR_ASSERT(numwrit == len);
 
 finish:
-    if( buf != NULL ) {
-        (*env)->ReleaseByteArrayElements(env, bufBA, buf, JNI_ABORT);
-    }
+    JSS_DerefByteArray(env, bufBA, buf, JNI_ABORT);
     EXCEPTION_CHECK(env, sock)
 }
 

--- a/org/mozilla/jss/ssl/common.c
+++ b/org/mozilla/jss/ssl/common.c
@@ -460,16 +460,13 @@ Java_org_mozilla_jss_ssl_SocketBase_socketBind
 
     memset( &addr, 0, sizeof( PRNetAddr ));
 
-    if( addrBA != NULL ) {
-        addrBAelems = (*env)->GetByteArrayElements(env, addrBA, NULL);
-        addrBALen = (*env)->GetArrayLength(env, addrBA);
-
-        if( addrBAelems == NULL ) {
+    if (addrBA != NULL) {
+        if (!JSS_RefByteArray(env, addrBA, &addrBAelems, &addrBALen)) {
             ASSERT_OUTOFMEM(env);
             goto finish;
         }
 
-        if(addrBALen != 4 && addrBALen != 16) {
+        if (addrBALen != 4 && addrBALen != 16) {
             JSS_throwMsgPrErr(env, BIND_EXCEPTION,
             "Invalid address in bind!");
              goto finish;

--- a/org/mozilla/jss/ssl/common.c
+++ b/org/mozilla/jss/ssl/common.c
@@ -514,9 +514,7 @@ Java_org_mozilla_jss_ssl_SocketBase_socketBind
     }       
 
 finish:
-    if( addrBAelems != NULL ) {
-        (*env)->ReleaseByteArrayElements(env, addrBA, addrBAelems, JNI_ABORT);
-    }
+    JSS_DerefByteArray(env, addrBA, addrBAelems, JNI_ABORT);
 }
 
 /*

--- a/org/mozilla/jss/ssl/javasock.c
+++ b/org/mozilla/jss/ssl/javasock.c
@@ -212,12 +212,11 @@ jsock_write(PRFileDesc *fd, const PRIOVec *iov, PRInt32 iov_size,
             ASSERT_OUTOFMEM(env);
             goto finish;
         }
-        bytes = (*env)->GetByteArrayElements(env, outbufArray, NULL);
-        if( bytes == NULL ) {
+        if (!JSS_RefByteArray(env, outbufArray, &bytes, NULL)) {
             ASSERT_OUTOFMEM(env);
             goto finish;
         }
-        for( iovi = 0, outbufLen = 0; iovi < iov_size; ++iovi) {
+        for (iovi = 0, outbufLen = 0; iovi < iov_size; ++iovi) {
             memcpy(bytes+outbufLen,iov[iovi].iov_base, iov[iovi].iov_len);
             outbufLen += iov[iovi].iov_len;
         }
@@ -355,8 +354,7 @@ getInetAddress(PRFileDesc *fd, PRNetAddr *addr, LocalOrPeer localOrPeer)
         PR_ASSERT( (addrBALen == 4) || (addrBALen == 16 ) );
 
         /* make sure you release them later */
-        addrBytes = (*env)->GetByteArrayElements(env, addrByteArray, NULL);
-        if( addrBytes == NULL ) {
+        if (!JSS_RefByteArray(env, addrByteArray, &addrBytes, NULL)) {
             ASSERT_OUTOFMEM(env);
             goto finish;
         }

--- a/org/mozilla/jss/ssl/javasock.c
+++ b/org/mozilla/jss/ssl/javasock.c
@@ -222,7 +222,7 @@ jsock_write(PRFileDesc *fd, const PRIOVec *iov, PRInt32 iov_size,
             outbufLen += iov[iovi].iov_len;
         }
         PR_ASSERT(outbufLen == (*env)->GetArrayLength(env, outbufArray));
-        (*env)->ReleaseByteArrayElements(env, outbufArray, bytes, 0);
+        JSS_DerefByteArray(env, outbufArray, bytes, 0);
     }
 
     /*
@@ -373,8 +373,7 @@ getInetAddress(PRFileDesc *fd, PRNetAddr *addr, LocalOrPeer localOrPeer)
             addr->inet.port = port;
         }
 
-        (*env)->ReleaseByteArrayElements(env, addrByteArray, addrBytes,
-            JNI_ABORT);
+        JSS_DerefByteArray(env, addrByteArray, addrBytes, JNI_ABORT);
     }
 
     status = PR_SUCCESS;
@@ -553,7 +552,7 @@ jsock_recv(PRFileDesc *fd, void *buf, PRInt32 amount,
 
         memcpy(buf, bytes, retval);
 
-        (*env)->ReleaseByteArrayElements(env, byteArray, bytes, JNI_ABORT);
+        JSS_DerefByteArray(env, byteArray, bytes, JNI_ABORT);
     }
 
 finish:

--- a/org/mozilla/jss/util/jssutil.c
+++ b/org/mozilla/jss/util/jssutil.c
@@ -365,7 +365,7 @@ JSS_OctetStringToByteArray(JNIEnv *env, SECItem *item)
     /* now insert the rest of the bytes */
     memcpy(bytes+1, item->data, size-1);
 
-    (*env)->ReleaseByteArrayElements(env, array, bytes, 0);
+    JSS_DerefByteArray(env, array, bytes, 0);
 
     return array;
 }
@@ -422,9 +422,7 @@ JSS_ByteArrayToOctetString(JNIEnv *env, jbyteArray byteArray, SECItem *item)
     status = PR_SUCCESS;
 
 finish:
-    if(bytes) {
-        (*env)->ReleaseByteArrayElements(env, byteArray, bytes, JNI_ABORT);
-    }
+    JSS_DerefByteArray(env, byteArray, bytes, JNI_ABORT);
     if(status != PR_SUCCESS) {
         SECITEM_FreeItem(item, PR_FALSE);
     }
@@ -660,11 +658,11 @@ done:
 ** JNI_COMMIT for copy without freeing, and JNI_ABORT for free-only.
 **
 */
-void JSS_DerefByteArray(JNIEnv *env, jbyteArray array, jbyte *data, jint mode) {
+void JSS_DerefByteArray(JNIEnv *env, jbyteArray array, void *data, jint mode) {
     if (env == NULL || array == NULL || data == NULL) {
         return;
     }
-    (*env)->ReleaseByteArrayElements(env, array, data, mode);
+    (*env)->ReleaseByteArrayElements(env, array, (jbyte *) data, mode);
 }
 
 /************************************************************************

--- a/org/mozilla/jss/util/jssutil.h
+++ b/org/mozilla/jss/util/jssutil.h
@@ -297,6 +297,29 @@ int JSS_ConvertNativeErrcodeToJava(int nativeErrcode);
 jbyteArray JSS_ToByteArray(JNIEnv *env, const void *data, int length);
 
 /************************************************************************
+** JSS_RefByteArray.
+**
+** References the contents of a Java ByteArray into *data, and optionally
+** records length information to *lenght. Must be dereferenced via calling
+** JSS_DerefByteArray.
+**
+** Returns
+**  bool - whether or not the operation succeeded.
+*/
+bool JSS_RefByteArray(JNIEnv *env, jbyteArray array, jbyte **data,
+    jsize *length);
+
+/************************************************************************
+** JSS_DerefByteArray.
+**
+** Dereferences the specified ByteArray and passed reference. mode is the
+** same as given to (*env)->ReleaseByteArrayElements: 0 for copy and free,
+** JNI_COMMIT for copy without freeing, and JNI_ABORT for free-only.
+**
+*/
+void JSS_DerefByteArray(JNIEnv *env, jbyteArray array, jbyte *data, jint mode);
+
+/************************************************************************
 ** JSS_RefJString
 **
 ** Converts the given jstring object to a char *; must be freed with

--- a/org/mozilla/jss/util/jssutil.h
+++ b/org/mozilla/jss/util/jssutil.h
@@ -319,7 +319,7 @@ bool JSS_RefByteArray(JNIEnv *env, jbyteArray array, jbyte **data,
 ** JNI_COMMIT for copy without freeing, and JNI_ABORT for free-only.
 **
 */
-void JSS_DerefByteArray(JNIEnv *env, jbyteArray array, jbyte *data, jint mode);
+void JSS_DerefByteArray(JNIEnv *env, jbyteArray array, void *data, jint mode);
 
 /************************************************************************
 ** JSS_FromByteArray.

--- a/org/mozilla/jss/util/jssutil.h
+++ b/org/mozilla/jss/util/jssutil.h
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include <stdbool.h>
+
 #ifndef JSS_NATIVE_UTIL_H
 #define JSS_NATIVE_UTIL_H
 
@@ -318,6 +320,19 @@ bool JSS_RefByteArray(JNIEnv *env, jbyteArray array, jbyte **data,
 **
 */
 void JSS_DerefByteArray(JNIEnv *env, jbyteArray array, jbyte *data, jint mode);
+
+/************************************************************************
+** JSS_FromByteArray.
+**
+** Converts the given chararacter array from a Java byte array into a array of
+** uint_t. When length is passed and is not NULL, *length is updated with the
+** length of the array.
+**
+** Returns
+**  bool - whether or not the operation succeeded.
+*/
+bool JSS_FromByteArray(JNIEnv *env, jbyteArray array, uint8_t **data,
+    size_t *length);
 
 /************************************************************************
 ** JSS_RefJString


### PR DESCRIPTION
Similar to #134, this changes how byte arrays are handled and using them in several places.

We already have a `JSS_ToByteArray` that we're using extensively, but `JSS_FromByteArray` does the opposite (`jbyteArray -> uint8_t *`). It also adds underlying `JSS_RefByteArray` and `JSS_DerefByteArray` helpers to access the raw byte array elements. 

Unlike `JSS_RefByteArray`, `JSS_FromByteArray` always makes a copy, so rather than returning it with `JSS_DerefByteArray`, free it with `free(...)`.

~Currently WIP because I need to:~
 - [x] Look at `JSS_RefByteArray` usages
 - [x] Decide whether or not we should care about returning the copy value. 