### PR TITLE
Release JSS v4.4.5

### DIFF
--- a/jss.spec.in
+++ b/jss.spec.in
@@ -6,13 +6,8 @@ Summary:        Java Security Services (JSS)
 URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
-%if 0%{?rhel}
-Version:        4.4.4
-Release:        5%{?_timestamp}%{?_commit_id}%{?dist}
-%else
 Version:        4.4.5
 Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
-%endif
 
 # To generate the source tarball:
 # $ git clone https://github.com/dogtagpki/jss.git

--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -1461,7 +1461,7 @@ public final class CryptoManager implements TokenSupplier
 
 
     public static final String
-    JAR_JSS_VERSION     = "JSS_VERSION = JSS_4_4_0_RTM";
+    JAR_JSS_VERSION     = "JSS_VERSION = JSS_4_4_5_RTM";
     public static final String
     JAR_JDK_VERSION     = "JDK_VERSION = N/A";
     public static final String

--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -19,7 +19,7 @@ public final class JSSProvider extends java.security.Provider {
     /* QUESTION: When do we change MINOR and PATCH to 4 and 0? */
     private static int JSS_MAJOR_VERSION  = 4;
     private static int JSS_MINOR_VERSION  = 4;
-    private static int JSS_PATCH_VERSION  = 0;
+    private static int JSS_PATCH_VERSION  = 5;
     private static double JSS_VERSION     = JSS_MAJOR_VERSION +
                                            (JSS_MINOR_VERSION * 100 +
                                             JSS_PATCH_VERSION)/10000.0;

--- a/org/mozilla/jss/util/jssver.h
+++ b/org/mozilla/jss/util/jssver.h
@@ -25,10 +25,10 @@
 /*                                                                  */
 /********************************************************************/
 
-#define JSS_VERSION  "4.4.0"
+#define JSS_VERSION  "4.4.5"
 #define JSS_VMAJOR   4
 #define JSS_VMINOR   4
-#define JSS_VPATCH   0
+#define JSS_VPATCH   5
 #define JSS_BETA     PR_FALSE
 
 #endif


### PR DESCRIPTION
This release includes various fixes for ANS.1 encoding/decoding,
increased TLS cipher support, various OCSP related enhanacements,
support for PKCS11Constants (under the org.mozilla.jss.pkcs11
namespace), and an update to the netscape/security classes.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`