### PR TITLE
Align upstream and downstream spec files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ generate_rpm_sources() {
             echo "Generating $TARBALL from $SOURCE_TAG tag"
         fi
 
-        pushd "$SCR_DIR"
+        pushd "$SRC_DIR"
         git \
             archive \
             --format=tar.gz \

--- a/jss.spec.in
+++ b/jss.spec.in
@@ -12,11 +12,10 @@ Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
 # To generate the source tarball:
 # $ git clone https://github.com/dogtagpki/jss.git
 # $ cd jss
-# $ git archive \
-#     --format=tar.gz \
-#     --prefix jss-VERSION/ \
-#     -o jss-VERSION.tar.gz \
-#     <version tag>
+# $ git tag v4.4.<z>
+# $ git push origin v4.4.<z>
+# Then go to https://github.com/dogtagpki/jss/releases and download the source
+# tarball.
 Source:         https://github.com/dogtagpki/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 # To create a patch for all changes since a version tag:
@@ -72,9 +71,11 @@ This package contains the API documentation for JSS.
 
 # Prior to version 4.4.5, the source code were stored under "jss-<version>/jss"
 # path in the source tarball. Starting from version 4.4.5, the files will be
-# stored under "jss-<version>" path. However, since the spec file is still using
-# the old path, the unpacked source code has to be moved to the old path with
-# the following commands.
+# stored under "jss-<version>" path. However, since the build system is still
+# using the old path (introduced via sandboxing), the unpacked source code has
+# to be moved to the old path with the following commands. Otherwise, even
+# though we're linking against system libraries, the build will complain about
+# a missing sandbox.
 
 cd ..
 mv %{name}-%{version} jss


### PR DESCRIPTION
In JSS version 4.4.5, changes to the spec file were made that brought
upstream and downstream spec files out of alignment, because v4.4.5
chose to follow the .spec and build.sh changes to later v4.5.x releases.
This fixes the build.sh script to generate source tarballs like
downstream expects and updates the spec file accordingly.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`