### PR TITLE
Fix release procedure in jss.spec

### DIFF
--- a/jss.spec
+++ b/jss.spec
@@ -13,11 +13,10 @@ Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
 # To generate the source tarball:
 # $ git clone https://github.com/dogtagpki/jss.git
 # $ cd jss
-# $ git archive \
-#     --format=tar.gz \
-#     --prefix jss-VERSION/ \
-#     -o jss-VERSION.tar.gz \
-#     <version tag>
+# $ git tag v4.5.<z>
+# $ git push origin v4.5.<z>
+# Then go to https://github.com/dogtagpki/jss/releases and download the source
+# tarball.
 Source:         https://github.com/dogtagpki/%{name}/archive/v%{version}%{?_phase}/%{name}-%{version}%{?_phase}.tar.gz
 
 # To create a patch for all changes since a version tag:
@@ -51,10 +50,6 @@ BuildRequires:  slf4j-jdk14
 %endif
 BuildRequires:  apache-commons-lang
 BuildRequires:  apache-commons-codec
-
-%if 0%{?fedora} >= 25 || 0%{?rhel} > 7
-BuildRequires:  perl-interpreter
-%endif
 
 BuildRequires:  junit
 


### PR DESCRIPTION
As discovered with the v4.4.6 release, the tarball creation process as
described in the spec file was wrong and/or generated a different
tarball than linked to by the Source URL. Update the procedure to match
the URL.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`