### PR TITLE
Branch to v4.6.x

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -2,7 +2,7 @@ macro(jss_config)
     # Set the current JSS release number. Arguments are:
     #   MAJOR MINOR PATCH BETA
     # When BETA is zero, it isn't a beta release.
-    jss_config_version(4 5 3 0)
+    jss_config_version(4 6 0 1)
 
     # Configure output directories
     jss_config_outputs()

--- a/jss.spec
+++ b/jss.spec
@@ -6,9 +6,9 @@ Summary:        Java Security Services (JSS)
 URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
-Version:        4.5.3
+Version:        4.6.0
 Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
-# global         _phase -a1
+%global         _phase -b1
 
 # To generate the source tarball:
 # $ git clone https://github.com/dogtagpki/jss.git


### PR DESCRIPTION
To make packaging easier, branch v4.5.x after the TomcatJSS fixes (in commit 91870d5b5898dcb1a82c3691449e50baa8fbd9ba). master branch becomes the new v4.6.x series; marking this as beta.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`