### PR TITLE
Fix IRC channel name: #dogtag-pki

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ started, check out our [documentation](docs/contributing.md), or if you
 want to contact us, check out the following forums:
 
  - The [pki-devel mailing list](https://www.redhat.com/mailman/listinfo/pki-devel).
- - The `#dogtagpki` IRC channel on [Freenode](https://freenode.net/).
+ - The `#dogtag-pki` IRC channel on [Freenode](https://freenode.net/).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,6 +53,6 @@ If you wish to discuss contributing to JSS or an issue, there are a few
 forums of discussion:
 
  - The [pki-devel mailing list](https://www.redhat.com/mailman/listinfo/pki-devel).
- - The `#dogtagpki` IRC channel on [Freenode](https://freenode.net/).
+ - The `#dogtag-pki` IRC channel on [Freenode](https://freenode.net/).
 
 Thanks!


### PR DESCRIPTION
Credit to @emaldona.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`