### PR TITLE
JNI for j_buffer - 2:0

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -87,6 +87,10 @@ macro(jss_tests)
         COMMAND "org.mozilla.jss.tests.TestRawSSL" "${RESULTS_NSSDB_OUTPUT_DIR}"
         DEPENDS "Setup_DBs"
     )
+    jss_test_java(
+        NAME "JSS_Test_Buffer"
+        COMMAND "org.mozilla.jss.tests.TestBuffer"
+    )
     if ((${Java_VERSION_MAJOR} EQUAL 1) AND (${Java_VERSION_MINOR} LESS 9))
         jss_test_java(
             NAME "Test_PKCS11Constants.java_for_Sun_compatibility"

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -357,6 +357,16 @@ Java_org_mozilla_jss_nss_SSL_ResetHandshake;
 Java_org_mozilla_jss_nss_SSL_ForceHandshake;
 Java_org_mozilla_jss_nss_SSL_ConfigSecureServer;
 Java_org_mozilla_jss_nss_SSL_ConfigServerSessionIDCache;
+
+Java_org_mozilla_jss_nss_Buffer_Create;
+Java_org_mozilla_jss_nss_Buffer_Capacity;
+Java_org_mozilla_jss_nss_Buffer_CanRead;
+Java_org_mozilla_jss_nss_Buffer_CanWrite;
+Java_org_mozilla_jss_nss_Buffer_Read;
+Java_org_mozilla_jss_nss_Buffer_Write;
+Java_org_mozilla_jss_nss_Buffer_Get;
+Java_org_mozilla_jss_nss_Buffer_Put;
+Java_org_mozilla_jss_nss_Buffer_Free;
     local:
         *;
 };

--- a/org/mozilla/jss/nss/Buffer.c
+++ b/org/mozilla/jss/nss/Buffer.c
@@ -1,0 +1,155 @@
+#include <nspr.h>
+#include <limits.h>
+#include <stdint.h>
+#include <jni.h>
+
+#include "jssutil.h"
+#include "BufferProxy.h"
+#include "buffer.h"
+
+#include "_jni/org_mozilla_jss_nss_Buffer.h"
+
+JNIEXPORT jobject JNICALL
+Java_org_mozilla_jss_nss_Buffer_Create(JNIEnv *env, jclass clazz, jlong length)
+{
+    j_buffer *buf = NULL;
+
+    PR_ASSERT(env != NULL && length > 0);
+
+    buf = jb_alloc((size_t) length);
+    PR_ASSERT(buf != NULL);
+
+    return JSS_PR_wrapJBuffer(env, &buf);
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_mozilla_jss_nss_Buffer_Capacity(JNIEnv *env, jclass clazz, jobject buf)
+{
+    j_buffer *real_buf = NULL;
+
+    PR_ASSERT(env != NULL && buf != NULL);
+
+    if (JSS_PR_unwrapJBuffer(env, buf, &real_buf) != PR_SUCCESS) {
+        return 0;
+    }
+
+    return jb_capacity(real_buf);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_mozilla_jss_nss_Buffer_CanRead(JNIEnv *env, jclass clazz, jobject buf)
+{
+    j_buffer *real_buf = NULL;
+
+    PR_ASSERT(env != NULL && buf != NULL);
+
+    if (JSS_PR_unwrapJBuffer(env, buf, &real_buf) != PR_SUCCESS) {
+        return false;
+    }
+
+    return jb_can_read(real_buf);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_mozilla_jss_nss_Buffer_CanWrite(JNIEnv *env, jclass clazz, jobject buf)
+{
+    j_buffer *real_buf = NULL;
+
+    PR_ASSERT(env != NULL && buf != NULL);
+
+    if (JSS_PR_unwrapJBuffer(env, buf, &real_buf) != PR_SUCCESS) {
+        return false;
+    }
+
+    return jb_can_write(real_buf);
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_org_mozilla_jss_nss_Buffer_Read(JNIEnv *env, jclass clazz, jobject buf,
+    jlong length)
+{
+    j_buffer *real_buf = NULL;
+    size_t read_amount = 0;
+    uint8_t *tmp = NULL;
+    jbyteArray result = NULL;
+
+    PR_ASSERT(env != NULL && buf != NULL && length > 0);
+
+    if (JSS_PR_unwrapJBuffer(env, buf, &real_buf) != PR_SUCCESS) {
+        return NULL;
+    }
+
+    tmp = calloc(length, sizeof(uint8_t));
+    read_amount = jb_read(real_buf, tmp, (size_t) length);
+    result = JSS_ToByteArray(env, tmp, read_amount);
+    free(tmp);
+
+    return result;
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_mozilla_jss_nss_Buffer_Write(JNIEnv *env, jclass clazz, jobject buf, jbyteArray input)
+{
+    j_buffer *real_buf = NULL;
+    size_t input_length = 0;
+    uint8_t *real_input = NULL;
+    long write_amount = -1;
+
+    PR_ASSERT(env != NULL && buf != NULL);
+
+    if (JSS_PR_unwrapJBuffer(env, buf, &real_buf) != PR_SUCCESS) {
+        return write_amount;
+    }
+
+    if (!JSS_FromByteArray(env, input, &real_input, &input_length)) {
+        return write_amount;
+    }
+
+    write_amount = jb_write(real_buf, real_input, input_length);
+    free(real_input);
+
+    return write_amount;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_Buffer_Get(JNIEnv *env, jclass clazz, jobject buf)
+{
+    j_buffer *real_buf = NULL;
+
+    PR_ASSERT(env != NULL && buf != NULL);
+
+    if (JSS_PR_unwrapJBuffer(env, buf, &real_buf) != PR_SUCCESS) {
+        return -1;
+    }
+
+    return jb_get(real_buf);
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_Buffer_Put(JNIEnv *env, jclass clazz, jobject buf, jbyte input)
+{
+    j_buffer *real_buf = NULL;
+
+    PR_ASSERT(env != NULL && buf != NULL);
+
+    if (JSS_PR_unwrapJBuffer(env, buf, &real_buf) != PR_SUCCESS) {
+        return -1;
+    }
+
+    return jb_put(real_buf, (uint8_t) input);
+}
+
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_nss_Buffer_Free(JNIEnv *env, jclass clazz, jobject buf)
+{
+    j_buffer *real_buf = NULL;
+
+    PR_ASSERT(env != NULL && buf != NULL);
+
+    if (JSS_PR_unwrapJBuffer(env, buf, &real_buf) != PR_SUCCESS ||
+            real_buf == NULL) {
+        return;
+    }
+
+    jb_free(real_buf);
+}

--- a/org/mozilla/jss/nss/Buffer.java
+++ b/org/mozilla/jss/nss/Buffer.java
@@ -1,17 +1,66 @@
 package org.mozilla.jss.nss;
 
 public class Buffer {
+    /**
+     * Create a new j_buffer object with the specified number of bytes.
+     *
+     * See also: jb_alloc in org/mozilla/jss/ssl/javax/buffer.h
+     */
     public static native BufferProxy Create(long length);
 
+    /**
+     * Check the total capacity of a buffer object.
+     *
+     * See also: jb_capacity in org/mozilla/jss/ssl/javax/buffer.h
+     */
     public static native long Capacity(BufferProxy buf);
+
+    /**
+     * Check whether or not the buffer can be read from (i.e., is non-empty).
+     *
+     * See also: jb_can_read in org/mozilla/jss/ssl/javax/buffer.h
+     */
     public static native boolean CanRead(BufferProxy buf);
+
+    /**
+     * Check whether or not the buffer can be written to (i.e., is not full).
+     *
+     * See also: jb_can_write in org/mozilla/jss/ssl/javax/buffer.h
+     */
     public static native boolean CanWrite(BufferProxy buf);
 
+    /**
+     * Read the specified number of bytes from the buffer.
+     *
+     * See also: jb_read in org/mozilla/jss/ssl/javax/buffer.h
+     */
     public static native byte[] Read(BufferProxy buf, long length);
+
+    /**
+     * Write the specified bytes to the buffer.
+     *
+     * See also: jb_write in org/mozilla/jss/ssl/javax/buffer.h
+     */
     public static native long Write(BufferProxy buf, byte[] input);
 
+    /**
+     * Get a single character from the buffer.
+     *
+     * See also: jb_get in org/mozilla/jss/ssl/javax/buffer.h
+     */
     public static native int Get(BufferProxy buf);
+
+    /**
+     * Put a single character into the buffer.
+     *
+     * See also: jb_put in org/mozilla/jss/ssl/javax/buffer.h
+     */
     public static native int Put(BufferProxy buf, byte input);
 
+    /**
+     * Destroy a buffer object, freeing its resources.
+     *
+     * See also: jb_free in org/mozilla/jss/ssl/javax/buffer.h
+     */
     public static native void Free(BufferProxy buf);
 }

--- a/org/mozilla/jss/nss/Buffer.java
+++ b/org/mozilla/jss/nss/Buffer.java
@@ -1,0 +1,17 @@
+package org.mozilla.jss.nss;
+
+public class Buffer {
+    public static native BufferProxy Create(long length);
+
+    public static native long Capacity(BufferProxy buf);
+    public static native boolean CanRead(BufferProxy buf);
+    public static native boolean CanWrite(BufferProxy buf);
+
+    public static native byte[] Read(BufferProxy buf, long length);
+    public static native long Write(BufferProxy buf, byte[] input);
+
+    public static native int Get(BufferProxy buf);
+    public static native int Put(BufferProxy buf, byte input);
+
+    public static native void Free(BufferProxy buf);
+}

--- a/org/mozilla/jss/nss/BufferProxy.c
+++ b/org/mozilla/jss/nss/BufferProxy.c
@@ -1,0 +1,51 @@
+#include <nspr.h>
+#include <jni.h>
+
+#include "java_ids.h"
+#include "jssutil.h"
+#include "BufferProxy.h"
+
+jobject
+JSS_PR_wrapJBuffer(JNIEnv *env, j_buffer **buffer)
+{
+    jbyteArray pointer = NULL;
+    jclass proxyClass;
+    jmethodID constructor;
+    jobject bufferObj = NULL;
+
+    PR_ASSERT(env != NULL && buffer != NULL && *buffer != NULL);
+
+    /* convert pointer to byte array */
+    pointer = JSS_ptrToByteArray(env, *buffer);
+
+    /*
+     * Lookup the class and constructor
+     */
+    proxyClass = (*env)->FindClass(env, BUFFER_PROXY_CLASS_NAME);
+    if(proxyClass == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+    constructor = (*env)->GetMethodID(env, proxyClass,
+                            PLAIN_CONSTRUCTOR,
+                            BUFFER_PROXY_CONSTRUCTOR_SIG);
+    if(constructor == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+
+    /* call the constructor */
+    bufferObj = (*env)->NewObject(env, proxyClass, constructor, pointer);
+
+finish:
+    *buffer = NULL;
+
+    PR_ASSERT(bufferObj || (*env)->ExceptionOccurred(env));
+    return bufferObj;
+}
+
+PRStatus
+JSS_PR_unwrapJBuffer(JNIEnv *env, jobject buffer_proxy, j_buffer **buffer)
+{
+    return JSS_getPtrFromProxy(env, buffer_proxy, (void**)buffer);
+}

--- a/org/mozilla/jss/nss/BufferProxy.h
+++ b/org/mozilla/jss/nss/BufferProxy.h
@@ -3,5 +3,8 @@
 
 #pragma once
 
+/* Wrap a j_buffer object into a BufferProxy, freeing the buffer on error. */
 jobject JSS_PR_wrapJBuffer(JNIEnv *env, j_buffer **buffer);
+
+/* Extract a j_buffer pointer from an instance of a BufferProxy. */
 PRStatus JSS_PR_unwrapJBuffer(JNIEnv *env, jobject buffer_proxy, j_buffer **buffer);

--- a/org/mozilla/jss/nss/BufferProxy.h
+++ b/org/mozilla/jss/nss/BufferProxy.h
@@ -1,0 +1,7 @@
+#include <jni.h>
+#include "buffer.h"
+
+#pragma once
+
+jobject JSS_PR_wrapJBuffer(JNIEnv *env, j_buffer **buffer);
+PRStatus JSS_PR_unwrapJBuffer(JNIEnv *env, jobject buffer_proxy, j_buffer **buffer);

--- a/org/mozilla/jss/nss/BufferProxy.java
+++ b/org/mozilla/jss/nss/BufferProxy.java
@@ -1,0 +1,13 @@
+package org.mozilla.jss.nss;
+
+public class BufferProxy extends org.mozilla.jss.util.NativeProxy {
+    public BufferProxy(byte[] pointer) {
+        super(pointer);
+    }
+
+    protected native void releaseNativeResources();
+
+    protected void finalize() throws Throwable {
+        super.finalize();
+    }
+}

--- a/org/mozilla/jss/tests/TestBuffer.java
+++ b/org/mozilla/jss/tests/TestBuffer.java
@@ -1,0 +1,83 @@
+package org.mozilla.jss.tests;
+
+import org.mozilla.jss.nss.Buffer;
+import org.mozilla.jss.nss.BufferProxy;
+
+public class TestBuffer {
+    public static void TestCreateFree() {
+        BufferProxy buf = Buffer.Create(100);
+        assert(buf != null);
+        Buffer.Free(buf);
+    }
+
+    public static void TestReadWrite() {
+        BufferProxy buf = Buffer.Create(10);
+        byte[] data = { 0x01, 0x00, 0x02, 0x03 };
+        assert(buf != null);
+
+        assert(Buffer.Write(buf, data) == 4);
+
+        byte[] out_data = Buffer.Read(buf, 4);
+        assert(out_data.length == 4);
+        assert(out_data[0] == data[0]);
+        assert(out_data[1] == data[1]);
+        assert(out_data[2] == data[2]);
+        assert(out_data[3] == data[3]);
+
+        Buffer.Free(buf);
+    }
+
+    public static void TestCapacities() {
+        BufferProxy buf = Buffer.Create(6);
+        byte[] data = {0x00, 0x01, 0x02};
+
+        assert(buf != null);
+        assert(Buffer.Capacity(buf) == 6);
+        assert(!Buffer.CanRead(buf));
+        assert(Buffer.CanWrite(buf));
+
+        assert(Buffer.Write(buf, data) == data.length);
+        assert(Buffer.CanRead(buf));
+        assert(Buffer.CanWrite(buf));
+
+        assert(Buffer.Write(buf, data) == data.length);
+        assert(Buffer.CanRead(buf));
+        assert(!Buffer.CanWrite(buf));
+
+        Buffer.Free(buf);
+    }
+
+    public static void TestPutGet() {
+        BufferProxy buf = Buffer.Create(2);
+        assert(buf != null);
+
+        assert(Buffer.Put(buf, (byte) 0x00) == 0x00);
+        assert(Buffer.Get(buf) == 0x00);
+        assert(Buffer.Get(buf) == -1);
+
+        assert(Buffer.Put(buf, (byte) 0x01) == 0x01);
+        assert(Buffer.Put(buf, (byte) 0x02) == 0x02);
+        assert(Buffer.Put(buf, (byte) 0x03) == -1);
+        assert(Buffer.Get(buf) == 0x01);
+        assert(Buffer.Get(buf) == 0x02);
+        assert(Buffer.Get(buf) == -1);
+
+        Buffer.Free(buf);
+    }
+
+    public static void main(String[] args) {
+        System.loadLibrary("jss4");
+
+        System.out.println("Calling TestCreateFree()...");
+        TestCreateFree();
+
+        System.out.println("Calling TestReadWrite()...");
+        TestReadWrite();
+
+        System.out.println("Calling TestCapacities()...");
+        TestCapacities();
+
+        System.out.println("Calling TestPutGet()...");
+        TestPutGet();
+    }
+}

--- a/org/mozilla/jss/util/java_ids.h
+++ b/org/mozilla/jss/util/java_ids.h
@@ -392,6 +392,12 @@ PR_BEGIN_EXTERN_C
 #define SECURITY_STATUS_CLASS_NAME "org/mozilla/jss/nss/SecurityStatusResult"
 #define SECURITY_STATUS_CONSTRUCTOR_SIG "(I[BII[B[B)V"
 
+/*
+ * BufferProxy
+ */
+#define BUFFER_PROXY_CLASS_NAME "org/mozilla/jss/nss/BufferProxy"
+#define BUFFER_PROXY_CONSTRUCTOR_SIG "([B)V"
+
 PR_END_EXTERN_C
 
 #endif


### PR DESCRIPTION
Dependencies:

 - ~#138 - for JNI enhancements.~
 - ~#103 - for the buffer implementation.~
 - ~#93 - for buffer-prfd and associated `j_buffer` improvements.~
 - ~#122 - for accessing NSPR's `PRFileDesc` objects in Java.~

(Note that #93 and #122 aren't strictly necessary for this PR, but are for the next PR in the series).

This PR adds support for calling into `j_buffer` objects from Java. The next PR in this series (`2:1`) will let us construct `BufferPRFD` objects in Java.

Then `3:0` will combine `2:1` with `1:1` and let us reproduce the [test case](https://github.com/cipherboy/jss/blob/buffer-prfd/org/mozilla/jss/tests/TestBufferPRFD.c) for a Buffer PRFileDesc (i.e., do a single-threaded async SSL handshake) in Java, and `4:0` will begin implementing a `SSLEngine`. 