### PR TITLE
JNI for BufferPRFD - 2:1

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -91,6 +91,10 @@ macro(jss_tests)
         NAME "JSS_Test_Buffer"
         COMMAND "org.mozilla.jss.tests.TestBuffer"
     )
+    jss_test_java(
+        NAME "JSS_Test_BufferPRFD"
+        COMMAND "org.mozilla.jss.tests.TestBufferPRFD"
+    )
     if ((${Java_VERSION_MAJOR} EQUAL 1) AND (${Java_VERSION_MINOR} LESS 9))
         jss_test_java(
             NAME "Test_PKCS11Constants.java_for_Sun_compatibility"

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -345,6 +345,7 @@ Java_org_mozilla_jss_nss_PR_Read;
 Java_org_mozilla_jss_nss_PR_Send;
 Java_org_mozilla_jss_nss_PR_Recv;
 Java_org_mozilla_jss_nss_PR_NewTCPSocket;
+Java_org_mozilla_jss_nss_PR_NewBufferPRFD;
 Java_org_mozilla_jss_nss_PR_Shutdown;
 Java_org_mozilla_jss_nss_PR_GetError;
 Java_org_mozilla_jss_nss_PR_GetErrorText;

--- a/org/mozilla/jss/nss/PR.java
+++ b/org/mozilla/jss/nss/PR.java
@@ -23,6 +23,15 @@ public class PR {
     public static native PRFDProxy NewTCPSocket();
 
     /**
+     * Create a new j_buffer backed PRFileDesc, mimicing a TCP socket with
+     * the specified peer_info.
+     *
+     * See also: newBufferPRFileDesc in org/mozilla/jss/ssl/javax/BufferPRFD.h
+     */
+    public static native PRFDProxy NewBufferPRFD(BufferProxy read_buf,
+                                                 BufferProxy write_buf,
+                                                 byte[] peer_info);
+    /**
      * Close an existing PRFDProxy.
      *
      * See also: PR_Close in /usr/include/nspr4/prio.h

--- a/org/mozilla/jss/tests/TestBufferPRFD.java
+++ b/org/mozilla/jss/tests/TestBufferPRFD.java
@@ -1,0 +1,48 @@
+package org.mozilla.jss.tests;
+
+import org.mozilla.jss.nss.Buffer;
+import org.mozilla.jss.nss.BufferProxy;
+import org.mozilla.jss.nss.PR;
+import org.mozilla.jss.nss.PRFDProxy;
+
+public class TestBufferPRFD {
+    public static void TestCreateClose() {
+        byte[] info = {0x01, 0x02, 0x03, 0x04};
+        BufferProxy left_read = Buffer.Create(10);
+        BufferProxy right_read = Buffer.Create(10);
+
+        assert(left_read != null);
+        assert(right_read != null);
+
+        PRFDProxy left = PR.NewBufferPRFD(left_read, right_read, info);
+        PRFDProxy right = PR.NewBufferPRFD(right_read, left_read, info);
+
+        assert(left != null);
+        assert(right != null);
+
+        System.err.println(PR.Write(left, info));
+        assert(PR.Send(left, info, 0, 0) == 4);
+        assert(PR.Send(left, info, 0, 0) == 4);
+        assert(PR.Send(left, info, 0, 0) == 2);
+
+        byte[] result = PR.Recv(right, 10, 0, 0);
+        assert(result.length == 10);
+
+        for (int i = 0; i < 10; i++) {
+            assert(result[i] == info[i % info.length]);
+        }
+
+        assert(PR.Close(left) == 0);
+        assert(PR.Close(right) == 0);
+
+        Buffer.Free(left_read);
+        Buffer.Free(right_read);
+    }
+
+    public static void main(String[] args) {
+        System.loadLibrary("jss4");
+
+        System.out.println("Calling TestCreateClose()...");
+        TestCreateClose();
+    }
+}


### PR DESCRIPTION
As a continuation of #145...

This adds support (and tests!) creating a BufferPRFD from Java. This will ultimately be used as the core of a new SSLEngine, encrypting data to/from the buffer. Adds a test case to ensure send/recv on a BufferPRFD work as expected. 

Questions:
 - [ ] Should we clear the contents of the buffer after use, as this will likely be used in sensitive code?

Answers: 

 - The buffer should only have wire contents in it; these will all be encrypted data which is no more than what an attacker would get. So it is fine to not clean these. 