### PR TITLE
JNI SSL Handshake Test - 3:0

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -93,7 +93,8 @@ macro(jss_tests)
     )
     jss_test_java(
         NAME "JSS_Test_BufferPRFD"
-        COMMAND "org.mozilla.jss.tests.TestBufferPRFD"
+        COMMAND "org.mozilla.jss.tests.TestBufferPRFD" "${RESULTS_NSSDB_OUTPUT_DIR}" "${DB_PWD}"
+        DEPENDS "List_CA_certs"
     )
     if ((${Java_VERSION_MAJOR} EQUAL 1) AND (${Java_VERSION_MINOR} LESS 9))
         jss_test_java(

--- a/org/mozilla/jss/tests/TestBufferPRFD.java
+++ b/org/mozilla/jss/tests/TestBufferPRFD.java
@@ -1,11 +1,17 @@
 package org.mozilla.jss.tests;
 
-import org.mozilla.jss.nss.Buffer;
-import org.mozilla.jss.nss.BufferProxy;
-import org.mozilla.jss.nss.PR;
-import org.mozilla.jss.nss.PRFDProxy;
+import java.util.*;
+
+import org.mozilla.jss.*;
+import org.mozilla.jss.crypto.*;
+import org.mozilla.jss.pkcs11.*;
+import org.mozilla.jss.pkix.*;
+import org.mozilla.jss.nss.*;
+import org.mozilla.jss.util.*;
 
 public class TestBufferPRFD {
+    public static int PR_WOULD_BLOCK_ERROR = -5998;
+
     public static void TestCreateClose() {
         byte[] info = {0x01, 0x02, 0x03, 0x04};
         BufferProxy left_read = Buffer.Create(10);
@@ -39,10 +45,167 @@ public class TestBufferPRFD {
         Buffer.Free(right_read);
     }
 
-    public static void main(String[] args) {
+    public synchronized static PRFDProxy Setup_NSS_Client(PRFDProxy fd, String host) {
+        PRFDProxy model = SSL.ImportFD(null, PR.NewTCPSocket());
+        assert(model != null);
+
+        fd = SSL.ImportFD(model, fd);
+        assert(fd != null);
+        PR.Close(model);
+
+        assert(SSL.ResetHandshake(fd, false) == 0);
+        assert(SSL.SetURL(fd, host) == 0);
+
+        return fd;
+    }
+
+    public synchronized static PRFDProxy Setup_NSS_Server(PRFDProxy fd, String host,
+        PK11Cert cert, PK11PrivKey key)
+    {
+        PRFDProxy model = SSL.ImportFD(null, PR.NewTCPSocket());
+        assert(model != null);
+
+        fd = SSL.ImportFD(model, fd);
+        assert(fd != null);
+        PR.Close(model);
+
+        assert(SSL.ConfigSecureServer(fd, cert, key, 1) == 0);
+        assert(SSL.ConfigServerSessionIDCache(1, 100, 100, null) == 0);
+        assert(SSL.ResetHandshake(fd, true) == 0);
+        assert(SSL.SetURL(fd, host) == 0);
+
+        return fd;
+    }
+
+    public synchronized static boolean IsHandshakeFinished(PRFDProxy c_nspr, PRFDProxy s_nspr) {
+        SecurityStatusResult c_result = SSL.SecurityStatus(c_nspr);
+        SecurityStatusResult s_result = SSL.SecurityStatus(s_nspr);
+
+        assert(c_result != null && s_result != null);
+
+        return c_result.on == 1 && s_result.on == 1;
+    }
+
+    public synchronized static void TestSSLHandshake(String database, String password) throws Exception {
+        /* Constants */
+        String host = "localhost";
+        byte[] peer_info = host.getBytes();
+
+        /* Find SSL Certificate */
+        CryptoManager manager;
+        CryptoManager.initialize(database);
+        manager = CryptoManager.getInstance();
+        manager.setPasswordCallback(new Password(password.toCharArray()));
+        CryptoToken token = manager.getInternalKeyStorageToken();
+
+        PK11Cert server_cert = (PK11Cert) manager.findCertByNickname("Server_RSA");
+        PK11PrivKey server_key = (PK11PrivKey) manager.findPrivKeyByCert(server_cert);
+
+        assert(server_cert != null);
+        assert(server_cert instanceof PK11Cert);
+        assert(server_key != null);
+        assert(server_key instanceof PK11PrivKey);
+
+        /* Create Buffers and BufferPRFDs */
+        BufferProxy read_buf = Buffer.Create(1024);
+        BufferProxy write_buf = Buffer.Create(1024);
+
+        assert(read_buf != null);
+        assert(write_buf != null);
+
+        PRFDProxy c_nspr = PR.NewBufferPRFD(read_buf, write_buf, peer_info);
+        PRFDProxy s_nspr = PR.NewBufferPRFD(write_buf, read_buf, peer_info);
+
+        assert(c_nspr != null);
+        assert(s_nspr != null);
+
+        c_nspr = Setup_NSS_Client(c_nspr, host);
+        s_nspr = Setup_NSS_Server(s_nspr, host, server_cert, server_key);
+
+        assert(c_nspr != null);
+        assert(s_nspr != null);
+
+        assert(!IsHandshakeFinished(c_nspr, s_nspr));
+
+        /* Try a handshake */
+        while(!IsHandshakeFinished(c_nspr, s_nspr)) {
+            if (SSL.ForceHandshake(c_nspr) != 0) {
+                int error = PR.GetError();
+
+                if (error != PR_WOULD_BLOCK_ERROR) {
+                    System.out.println("Unexpected error: " + error);
+                    System.exit(1);
+                }
+            }
+            if (SSL.ForceHandshake(s_nspr) != 0) {
+                int error = PR.GetError();
+
+                if (error != PR_WOULD_BLOCK_ERROR) {
+                    System.out.println("Unexpected error: " + error);
+                    System.exit(1);
+                }
+            }
+        }
+        System.out.println("Handshake completed successfully!\n");
+        assert(IsHandshakeFinished(c_nspr, s_nspr));
+
+        /* Send data from client -> server */
+        byte[] client_message = "Cooking MCs".getBytes();
+
+        assert(PR.Write(c_nspr, client_message) == client_message.length);
+        byte[] server_received = PR.Read(s_nspr, client_message.length);
+        assert(server_received != null);
+
+        if (server_received.length != client_message.length) {
+            System.out.println("Expected a client message of length " + client_message.length + " but got one of " + server_received.length);
+            System.exit(1);
+        }
+
+        for (int i = 0; i < client_message.length && i < server_received.length; i++) {
+            if (client_message[i] != server_received[i]) {
+                System.out.println("Received byte " + server_received[i] + " on server but expected " + client_message[i]);
+                System.exit(1);
+            }
+        }
+
+        /* Send data from server -> client */
+        byte[] server_message = "like a pound of bacon".getBytes();
+
+        assert(PR.Write(s_nspr, server_message) == server_message.length);
+        byte[] client_received = PR.Read(c_nspr, server_message.length);
+        assert(client_received != null);
+
+        if (client_received.length != server_message.length) {
+            System.out.println("Expected a server message of length " + server_message.length + " but got one of " + client_received.length);
+            System.exit(1);
+        }
+
+        for (int i = 0; i < server_message.length && i < client_received.length; i++) {
+            if (server_message[i] != client_received[i]) {
+                System.out.println("Received byte " + client_received[i] + " on client but expected " + server_message[i]);
+                System.exit(1);
+            }
+        }
+
+        /* Close connections */
+        assert(PR.Shutdown(c_nspr, 2) == 0);
+        assert(PR.Shutdown(s_nspr, 2) == 0);
+
+        /* Clean up */
+        assert(PR.Close(c_nspr) == 0);
+        assert(PR.Close(s_nspr) == 0);
+
+        Buffer.Free(read_buf);
+        Buffer.Free(write_buf);
+    }
+
+    public static void main(String[] args) throws Exception {
         System.loadLibrary("jss4");
 
         System.out.println("Calling TestCreateClose()...");
         TestCreateClose();
+
+        System.out.println("Calling TestSSLHandshake()...");
+        TestSSLHandshake(args[0], args[1]);
     }
 }


### PR DESCRIPTION
This depends on all open JNI javax-labeled PRs:
- ~#146 for JNI access to the Buffer PRFileDesc.~
   - ~BufferPRFDs are described in #93 ~
   - ~Which use `j_buffer`s from #103.~
- ~#132 for access to NSS's SSL implementation.~
   - ~With `NSS_Init` from #132 (maybe not necessary).~
   - ~And JNI PRFD access from #130 (also included in #146).~

This PR will include the equivalent test as #93's `TestBufferPRFD.c`, which performs a single-threaded, asynchronous SSL connection, except using JNI and Java instead of the NSS C API. 

This PR is WIP because:
 - [x] The test still needs to be written.
 - [x] The entire stack of PRs needs to be reviewed and merged.
 - [x] This PR needs to be rebased. 