### PR TITLE
Remove 3s sleep from SetupDBs

### DIFF
--- a/org/mozilla/jss/tests/SetupDBs.java
+++ b/org/mozilla/jss/tests/SetupDBs.java
@@ -36,8 +36,6 @@ public class SetupDBs {
             new FilePasswordCallback( args[1] )
         );
         
-        Thread.sleep(3*1000);
-        
         System.exit(0);
       } catch(Exception e) {
         e.printStackTrace();


### PR DESCRIPTION
As far as I can tell, this 3s sleep is extraneous. This test creates the
NSS DB (instead of calling certutil -N) and provides an anchor point in
the test suite. Our alternatives are to use `certutil -N` instead of
SetupDBs, but we might as well keep this, just without the sleep.

It is possible the sleep was used, perhaps to ensure that the DB is
flushed to disk before the test suite continues, but this should be
handled by the JVM and shouldn't be considered as a side-effect of a
Sleep.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`