### PR TITLE
Use --with-timestamp and --with-commit-id for COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,5 +1,5 @@
 srpm:
-	./build.sh srpm
+	./build.sh srpm --with-timestamp --with-commit-id
 	if [[ "${outdir}" != "" ]]; then \
 	    mv ${HOME}/build/jss/SRPMS/* ${outdir}; \
 	fi


### PR DESCRIPTION
This lets us see which commit a user is at when using our various auto-built COPRs. This'd let us triage bugs better to know if something recent broke, or if a bug was fixed recently, etc. Thoughts?

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`