### PR TITLE
JSSEngine, an SSLEngine implementation

### DIFF
--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -374,6 +374,16 @@ public final class JSSProvider extends java.security.Provider {
         put("Alg.Alias.TrustManagerFactory.PKIX", "NssX509");
         put("Alg.Alias.TrustManagerFactory.X509", "NssX509");
         put("Alg.Alias.TrustManagerFactory.X.509", "NssX509");
+
+        /////////////////////////////////////////////////////////////
+        // TLS
+        /////////////////////////////////////////////////////////////
+        put("SSLContext.Default", "org.mozilla.jss.provider.javax.net.JSSContextSpi");
+        put("SSLContext.SSL", "org.mozilla.jss.provider.javax.net.JSSContextSpi");
+        put("SSLContext.TLS", "org.mozilla.jss.provider.javax.net.JSSContextSpi");
+        put("SSLContext.TLSv1.1", "org.mozilla.jss.provider.javax.net.JSSContextSpi$TLSv11");
+        put("SSLContext.TLSv1.2", "org.mozilla.jss.provider.javax.net.JSSContextSpi$TLSv12");
+        put("SSLContext.TLSv1.3", "org.mozilla.jss.provider.javax.net.JSSContextSpi$TLSv13");
     }
 
     public String toString() {

--- a/org/mozilla/jss/provider/javax/net/JSSContextSpi.java
+++ b/org/mozilla/jss/provider/javax/net/JSSContextSpi.java
@@ -1,0 +1,116 @@
+package org.mozilla.jss.provider.javax.net;
+
+import java.security.*;
+import java.util.ArrayList;
+
+import javax.net.ssl.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
+import org.mozilla.jss.provider.javax.crypto.JSSTrustManager;
+import org.mozilla.jss.pkcs11.PK11Cert;
+import org.mozilla.jss.pkcs11.PK11PrivKey;
+import org.mozilla.jss.ssl.javax.JSSEngine;
+import org.mozilla.jss.ssl.javax.JSSEngineReferenceImpl;
+import org.mozilla.jss.ssl.SSLVersion;
+
+public class JSSContextSpi extends SSLContextSpi {
+    public static Logger logger = LoggerFactory.getLogger(JSSContextSpi.class);
+
+    JSSKeyManager key_manager;
+    X509TrustManager[] trust_managers;
+
+    SSLVersion protocol_version;
+
+    public void engineInit(KeyManager[] kms, TrustManager[] tms, SecureRandom sr) throws KeyManagementException {
+        logger.debug("JSSContextSpi.engineInit(" + kms + ", " + tms + ", " + sr + ")");
+
+        if (kms != null) {
+            for (KeyManager km : kms) {
+                if (km instanceof JSSKeyManager) {
+                    key_manager = (JSSKeyManager) km;
+                    break;
+                }
+            }
+        }
+
+        if (tms != null) {
+            ArrayList<X509TrustManager> xtms = new ArrayList<X509TrustManager>();
+            for (TrustManager tm : tms) {
+                if (tm instanceof X509TrustManager) {
+                    xtms.add((X509TrustManager) tm);
+                }
+            }
+
+            trust_managers = xtms.toArray(new X509TrustManager[xtms.size()]);
+        }
+    }
+
+    public SSLEngine engineCreateSSLEngine() {
+        logger.debug("JSSContextSpi.engineCreateSSLEngine()");
+
+        JSSEngine ret = new JSSEngineReferenceImpl();
+        initializeEngine(ret);
+
+        return ret;
+    }
+
+    public SSLEngine engineCreateSSLEngine(String host, int port) {
+        logger.debug("JSSContextSpi.engineCreateSSLEngine(" + host + ", " + port + ")");
+
+        JSSEngine ret = new JSSEngineReferenceImpl(host, port);
+        initializeEngine(ret);
+
+        return ret;
+    }
+
+    private void initializeEngine(JSSEngine eng) {
+        eng.setKeyManager(key_manager);
+        eng.setTrustManagers(trust_managers);
+
+        if (protocol_version != null) {
+            eng.setEnabledProtocols(protocol_version, protocol_version);
+        }
+    }
+
+    public SSLSessionContext engineGetClientSessionContext() {
+        logger.debug("JSSContextSpi.engineGetClientSessionContext() - not implemented");
+        return null;
+    }
+
+    public SSLSessionContext engineGetServerSessionContext() {
+        logger.debug("JSSContextSpi.engineGetServerSessionContext() - not implemented");
+        return null;
+    }
+
+    public SSLServerSocketFactory engineGetServerSocketFactory() {
+        logger.debug("JSSContextSpi.engineGetServerSocketFactory() - not implemented");
+        return null;
+    }
+
+    public SSLSocketFactory engineGetSocketFactory() {
+        logger.debug("JSSContextSpi.engineGetSocketFactory() - not implemented");
+        return null;
+    }
+
+    public class TLSv11 extends JSSContextSpi {
+        public TLSv11() {
+            protocol_version = SSLVersion.TLS_1_1;
+        }
+    }
+
+    public class TLSv12 extends JSSContextSpi {
+        public TLSv12() {
+            protocol_version = SSLVersion.TLS_1_2;
+        }
+    }
+
+    public class TLSv13 extends JSSContextSpi {
+        public TLSv13() {
+            protocol_version = SSLVersion.TLS_1_3;
+        }
+    }
+}

--- a/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -1,0 +1,783 @@
+package org.mozilla.jss.ssl.javax;
+
+import java.util.*;
+import javax.net.ssl.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.mozilla.jss.crypto.Policy;
+import org.mozilla.jss.nss.*;
+import org.mozilla.jss.pkcs11.*;
+import org.mozilla.jss.provider.javax.crypto.*;
+import org.mozilla.jss.ssl.*;
+
+/**
+ * JSS's SSLEngine base class for alternative implementations.
+ *
+ * This abstracts out many components for all JSS SSLEngine implementations,
+ * such as cipher suite support, SSLSession creation, and various other
+ * common functions. This allows alternative SSLEngine implementations to
+ * focus on two main things: wrap/unwrap and init.
+ *
+ * There are the following implementations:
+ *  - JSSEngineReferenceImpl - A reference implementation with extensive
+ *                             logging and debugging.
+ *
+ * Usually a JSSEngine isn't constructed directly, but instead accessed via
+ * the Provider mechanism, SSLContext. See JSSContextSpi for more information.
+ */
+public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
+    public static Logger logger = LoggerFactory.getLogger(JSSEngine.class);
+
+    /**
+     * Size of the underlying BUFFERs.
+     *
+     * Helps to be large enough to fit most common SSL packets during the
+     * initial handshake.
+     */
+    protected static int BUFFER_SIZE = 1 << 12;
+
+    /**
+     * Whether or not this SSLEngine is acting as the client end of the
+     * handshake.
+     */
+    protected boolean as_server;
+
+    /**
+     * Peer's hostname, used for certificate validation.
+     *
+     */
+    protected String hostname;
+
+    /**
+     * Certificate used by this JSSEngine instance.
+     *
+     * Selected and inferred from the KeyManagers passed, when not passed
+     * explicitly (either during construction or with a call to
+     * setKeyMaterials(...)).
+     */
+    protected PK11Cert cert;
+
+    /**
+     * Key corresponding to the local certificate.
+     */
+    protected PK11PrivKey key;
+
+    /**
+     * A list of all KeyManagers available to this JSSEngine instance.
+     *
+     * Note: currently only a single JSSKeyManager instance is exposed,
+     * and it can only handle finding a single certificate by nickname.
+     * In the future, more KeyManagers should be supported.
+     */
+    protected X509KeyManager[] key_managers;
+
+    /**
+     * A list of all TrustManagers available to this JSSEngine instance.
+     *
+     * The behavior of this list depends on how which TrustManagers are
+     * passed.
+     */
+    protected X509TrustManager[] trust_managers;
+
+    /**
+     * Whether or not we should fail to handshake if client authentication
+     * is not passed by the peer and we are a server; if we are a client,
+     * whether or not we offer our certificate to the server.
+     *
+     * See also the note for want_client_auth.
+     */
+    protected boolean need_client_auth;
+
+    /**
+     * Whether or not we should attempt to handshake with client
+     * authentication.
+     *
+     * Note that under a strict reading of the SSLEngine spec, this is
+     * mutually exclusive with need_client_auth: either want_client_auth
+     * or need_client_auth can be true, but not both. However, both can
+     * be false.
+     *
+     * Under NSS semantics however, we have control over two values: whether
+     * we offer/request client auth, and whether we should fail to handshake
+     * if we don't get client auth. This doesn't quite map onto the want/need
+     * semantics, but it is what we have available.
+     */
+    protected boolean want_client_auth;
+
+    /**
+     * What the official SSLEngineResult handshake status is, at the present
+     * time.
+     *
+     * Note that while we store the current handshake state in JSSEngine, we
+     * don't implement getHandshakeStatus(...), as different JSSEngine
+     * implementations could have different implementations for that method.
+     */
+    protected SSLEngineResult.HandshakeStatus handshake_state = SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+
+    /**
+     * A list of all ciphers enabled by this SSLEngine.
+     *
+     * This list is restricted to a list of ciphers that are supported and
+     * approved by local policy.
+     */
+    protected SSLCipher[] enabled_ciphers;
+
+    /**
+     * The minimum TLS protocol version we should attempt to handshake.
+     *
+     * This version is tempered by local policy, when applicable.
+     */
+    protected SSLVersion min_protocol;
+
+    /**
+     * The maximum TLS protocol version we should attempt to handshake.
+     *
+     * This version is tempered by local policy, when applicable.
+     */
+    protected SSLVersion max_protocol;
+
+    /**
+     * A JSSSession extends the SSLSession, providing useful information not
+     * otherwise contained in the SSLSession, but exposed by NSS.
+     */
+    protected JSSSession session;
+
+    /**
+     * Whether or not the outbound portion of this connection is closed.
+     */
+    protected boolean is_outbound_closed;
+
+    /**
+     * Whether or not the inbound portion of this connection is closed.
+     */
+    protected boolean is_inbound_closed;
+
+    /**
+     * Constructor for a JSSEngine, providing no hints for an internal
+     * session reuse strategy and no key.
+     *
+     * This should always be called from an implementation's corresponding
+     * constructor.
+     */
+    public JSSEngine() {
+        super();
+
+        session = new JSSSession(BUFFER_SIZE);
+    }
+
+    /**
+     * Constructor for a JSSEngine, providing hints for an internal session
+     * reuse strategy (the peer's hostname and port), but no local cert or key.
+     *
+     * This should always be called from an implementation's corresponding
+     * constructor.
+     */
+    public JSSEngine(String peerHost, int peerPort) {
+        super(peerHost, peerPort);
+
+        session = new JSSSession(BUFFER_SIZE);
+        session.setPeerHost(peerHost);
+        session.setPeerPort(peerPort);
+    }
+
+    /**
+     * Constructor for a JSSEngine, providing hints for an internal session
+     * reuse strategy (the peer's hostname and port), along with a chosen
+     * certificate and key to use.
+     *
+     * This should always be called from an implementation's corresponding
+     * constructor.
+     */
+    public JSSEngine(String peerHost, int peerPort,
+                     org.mozilla.jss.crypto.X509Certificate localCert,
+                     org.mozilla.jss.crypto.PrivateKey localKey) {
+        super(peerHost, peerPort);
+
+        cert = (PK11Cert) localCert;
+        key = (PK11PrivKey) localKey;
+
+        session = new JSSSession(BUFFER_SIZE);
+        session.setPeerHost(peerHost);
+        session.setPeerPort(peerPort);
+    }
+
+    /**
+     * Set the configuration from the given SSLParameters object onto this
+     * JSSEngine.
+     *
+     * Aligning with the parent implementation, this calls:
+     *  - setEnabledCipherSuites when getCipherSuites is non-null,
+     *  - setEnabledProtocols when getProtocols is non-null, and
+     *  - setWantClientAuth and setNeedClientAuth.
+     *
+     * This doesn't yet understand from the parent implementation, the
+     * following calls:
+     * - getServerNames for the local server certificate selection, and
+     * - getSNIMatchers for configuring SNI selection criteria
+     *
+     * Unlike the parent, this also understands:
+     *  - setCertFromAlias when getAlias is non-null,
+     * - setHostname when getHostname is non-null.
+     *
+     * Note: this implementation overrides the one in SSLEngine so that we
+     * create a JSSParameters object from the passed SSLParameters (if it is
+     * not already an instance of JSSParameters), simplifying the other
+     * function calls and reducing duplicate parsing.
+     */
+    public void setSSLParameters(SSLParameters params) {
+        JSSParameters parsed;
+
+        // Try to cast the passed parameter into a JSSParameters. This has
+        // additional fields we usually need for construction of a NSS-backed
+        // SSLEngine. Otherwise, parse the values into JSS-specific fields.
+        // If we didn't create the JSSParameters here, both calls
+        // (setEnabledCipherSuites, setEnabledProtocols) would construct their
+        // own JSSParameters.
+        if (params instanceof JSSParameters) {
+            parsed = (JSSParameters) params;
+        } else {
+            parsed = new JSSParameters(params);
+        }
+
+        // Per semantics from parent class.
+        if (parsed.getSSLCiphers() != null) {
+            setEnabledCipherSuites(parsed.getSSLCiphers());
+        }
+
+        // Per semantics from parent class.
+        if (parsed.getSSLVersionRange() != null) {
+            setEnabledProtocols(parsed.getSSLVersionRange());
+        }
+
+        // Differing from the semantics of the parent class, we always set
+        // these from the values in the parsed JSSParameters. This is because
+        // NSS has a different set of expectations.
+        setWantClientAuth(parsed.getWantClientAuth());
+        setNeedClientAuth(parsed.getNeedClientAuth());
+
+        // In the event we haven't explicitly set cert and key, try and infer
+        // them from the alias specified... We assume that when the SSLEngine
+        // has a certificate already, we want to use them, even if parsed has
+        // a null certificate.
+        if (parsed.getAlias() != null && key_managers != null && key_managers.length > 0 && cert == null && key == null) {
+            setCertFromAlias(parsed.getAlias());
+        }
+
+        // When we have a value for the peer hostname, we should try and use
+        // it.
+        if (parsed.getHostname() != null) {
+            setHostname(parsed.getHostname());
+        }
+    }
+
+    /**
+     * Set the hostname used to validate the peer's certificate.
+     *
+     * This is usually passed to NSS via a call to NSS's ill-named
+     * SSL_SetURL(...), which really takes a hostname.
+     *
+     * Note: if this isn't called (and no peerHost was specified via a
+     * constructor), NSS will accept any host name provided by the server!
+     * Only useful for validating the server certificate; not used when
+     * validating the peer's certificate.
+     */
+    public void setHostname(String name) {
+        // Note, this is the only way to set the hostname used for validation.
+        //
+        // In the event setHostname is never explicitly called, we should try
+        // and fall back to the value passed in the constructor.
+        hostname = name;
+    }
+
+    /**
+     * Choose a certificate to give to the peer from the specified alias,
+     * assuming KeyManagers have already been specified and at least one is
+     * a JSSKeyManager.
+     *
+     * When alias is null, this clears all previous certs and keys.
+     *
+     * If no KeyManagers have been specified, raises an
+     * IllegalArgumentException stating as much.
+     *
+     */
+    public void setCertFromAlias(String alias) throws IllegalArgumentException {
+        if (alias == null) {
+            // Per calling, semantics, get rid of any existing cert/key we
+            // might have.
+            cert = null;
+            key = null;
+            return;
+        }
+
+        if (key_managers == null || key_managers.length == 0) {
+            String msg = "Missing or null KeyManagers; refusing to search ";
+            msg += "for cert";
+            throw new IllegalArgumentException(msg);
+        }
+
+        for (X509KeyManager key_manager : key_managers) {
+            if (key_manager == null) {
+                // Skip this key_manager. This case could occur when
+                // setKeyManagers(...) is passed an array containing the value
+                // null, but otherwise shouldn't happen.
+                continue;
+            }
+
+            if (!(key_manager instanceof JSSKeyManager)) {
+                // We're explicitly looking for a JSSKeyManager; skip this if
+                // it doesn't match.
+                continue;
+            }
+
+            JSSKeyManager jkm = (JSSKeyManager) key_manager;
+
+            // While the return type of CryptoManager.findCertByNickname is
+            // technically org.mozilla.jss.crypto.X509Certificate, in practice
+            // they are always PK11Cert instances. We're going to need an
+            // instance of PK11Cert anyways, in order to correctly pass it to
+            // the native layer.
+            cert = (PK11Cert) jkm.getCertificate(alias);
+            key = (PK11PrivKey) jkm.getPrivateKey(alias);
+
+            if (cert != null && key != null) {
+                // Found a cert and key matching our alias; exit.
+                break;
+            }
+        }
+
+        if (cert == null && key == null) {
+            String msg = "JSSEngine.setCertFromAlias: Unable to find ";
+            msg += "certificate and key for specified alias!";
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
+    /**
+     * Sets the list of enabled cipher suites from a list of JCA-approved
+     * String names.
+     *
+     * Note: this method is slower than creating a JSSParameters configuration
+     * object and calling setSSLParameters(...) with it. This call must
+     * construct its own JSSParameters instance internally and translate
+     * between JCA String names and SSLCipher instances.
+     */
+    public void setEnabledCipherSuites(String[] suites) throws IllegalArgumentException {
+        JSSParameters parser = new JSSParameters();
+        parser.setCipherSuites(suites);
+
+        if (parser.getSSLCiphers() == null) {
+            enabled_ciphers = null;
+            return;
+        }
+
+        setEnabledCipherSuites(parser.getSSLCiphers());
+    }
+
+    /**
+     * Sets the list of enabled cipher suites from a a list of SSLCipher enum
+     * instances.
+     */
+    public void setEnabledCipherSuites(SSLCipher[] suites) {
+        if (suites == null || suites.length == 0) {
+            logger.warn("JSSEngine.setEnabledCipherSuites(...) given a null list of cipher suites.");
+            return;
+        }
+
+        enabled_ciphers = suites.clone();
+    }
+
+    /**
+     * Queries the list of cipher suites enabled by default, if a
+     * corresponding setEnabledCIpherSuites call hasn't yet been made.
+     */
+    private SSLCipher[] queryEnabledCipherSuites() {
+        logger.debug("JSSEngine: queryEnabledCipherSuites()");
+        ArrayList<SSLCipher> enabledCiphers = new ArrayList<SSLCipher>();
+
+        for (SSLCipher cipher : SSLCipher.values()) {
+            try {
+                if (SSL.CipherPrefGetDefault(cipher.getID())) {
+                    logger.debug("Enabled: " + cipher.name() + " (" + cipher.getID() + ")");
+                    enabledCiphers.add(cipher);
+                }
+            } catch (Exception e) {
+                // Do nothing -- this shouldn't happen as SSLCipher should be
+                // synced with NSS. However, we'll just log this exception as
+                // a warning. At worst we fail to report that a cipher suite is
+                // enabled.
+                logger.warn("Unable to get the value of cipher: " + cipher.name() + " (" + cipher.getID() + "): " + e.getMessage());
+            }
+        }
+
+        return enabledCiphers.toArray(new SSLCipher[0]);
+    }
+
+    /**
+     * Lists cipher suites currently enabled on this JSSEngine instance.
+     */
+    public String[] getEnabledCipherSuites() {
+        logger.debug("JSSEngine: getEnabledCipherSuites()");
+
+        // This only happens in the event that setEnabledCipherSuites(...)
+        // isn't called. In which case, we'll need to explicitly query the
+        // list of default cipher suites.
+        if (enabled_ciphers == null) {
+            enabled_ciphers = queryEnabledCipherSuites();
+        }
+
+        // Use JSSParameters to do the heavy lifting of converting our list
+        // of cipher suites to an array of Strings.
+        JSSParameters parser = new JSSParameters();
+        parser.setCipherSuites(enabled_ciphers);
+        return parser.getCipherSuites();
+    }
+
+    /**
+     * Lists all cipher suites supported by JSS/NSS.
+     *
+     * Note that this list isn't just all values in SSLCipher: it is only
+     * those which are supported and allowed by local policy.
+     */
+    public String[] getSupportedCipherSuites() {
+        logger.debug("JSSEngine: getSupportedCipherSuites()");
+        ArrayList<String> result = new ArrayList<String>();
+
+        for (SSLCipher c : SSLCipher.values()) {
+            if (c.isSupported()) {
+                logger.debug("JSSEngine: getSupportedCipherSuites() - Supported: " + c);
+                result.add(c.name());
+            }
+        }
+
+        return result.toArray(new String[result.size()]);
+    }
+
+    /**
+     * Set the range of SSL protocols enabled by this SSLEngine instance, from
+     * a list of JCA-standardized protocol String names.
+     *
+     * Note that this enables all protocols in the range of min(protocols) to
+     * max(protocols), inclusive due to the underlying call to NSS's
+     * SSL_VersionRangeSet(...).
+     *
+     * It is also recommend to construct your own JSSParameters object first
+     * and pass it to setSSLParameters(...), rather than calling this method
+     * directly.
+     */
+    public void setEnabledProtocols(String[] protocols) throws IllegalArgumentException {
+        logger.debug("JSSEngine: setEnabledProtocols(");
+        for (String protocol : protocols) {
+            logger.debug("\t" + protocol + ",");
+        }
+        logger.debug(")");
+
+        JSSParameters parser = new JSSParameters();
+        parser.setProtocols(protocols);
+
+        SSLVersionRange vrange = parser.getSSLVersionRange();
+        setEnabledProtocols(vrange);
+    }
+
+    /**
+     * Sets the range of enabled SSL Protocols from a minimum and maximum
+     * SSLVersion value.
+     */
+    public void setEnabledProtocols(SSLVersion min, SSLVersion max) throws IllegalArgumentException {
+        logger.debug("JSSEngine: setEnabledProtocols()");
+        if ((min_protocol == null && max_protocol != null) || (min_protocol != null && max_protocol == null)) {
+            throw new IllegalArgumentException("Expected min and max to either both be null or both be not-null; not mixed: (" + min + ", " + max + ")");
+        }
+        min_protocol = min;
+        max_protocol = max;
+    }
+
+    /**
+     * Sets the range of enabled SSL Protocols from a SSLVersionRange object.
+     */
+    public void setEnabledProtocols(SSLVersionRange vrange) {
+        logger.debug("JSSEngine: setEnabledProtocols()");
+        if (vrange == null) {
+            min_protocol = null;
+            max_protocol = null;
+            return;
+        }
+
+        min_protocol = vrange.getMinVersion();
+        max_protocol = vrange.getMaxVersion();
+    }
+
+    /**
+     * Queries the list of protocols enabled by default.
+     *
+     * Only used when setEnabledProtocols(...) hasn't yet been called.
+     */
+    private SSLVersionRange queryEnabledProtocols() {
+        logger.debug("JSSEngine: queryEnabledProtocols()");
+
+        SSLVersionRange vrange;
+        try {
+            vrange = SSL.VersionRangeGetDefault();
+        } catch (Exception e) {
+            // This shouldn't happen unless the PRFDProxy is null.
+            throw new RuntimeException("JSSEngine.queryEnabledProtocols() Unexpected failure: " + e.getMessage(), e);
+        }
+
+        if (vrange == null) {
+            // Again; this shouldn't happen as the vrange should always
+            // be created by VersionRangeGet(...).
+            throw new RuntimeException("JSSEngine.queryEnabledProtocols() - null protocol range");
+        }
+
+        return vrange;
+    }
+
+    /**
+     * Gets the list of enabled SSL protocol versions on this particular
+     * JSSEngine instance, as a list of JCA-standardized strings.
+     */
+    public String[] getEnabledProtocols() {
+        logger.debug("JSSEngine: getEnabledProtocols()");
+
+        if (min_protocol == null || max_protocol == null) {
+            SSLVersionRange vrange = queryEnabledProtocols();
+            min_protocol = vrange.getMinVersion();
+            max_protocol = vrange.getMaxVersion();
+        }
+
+        // Use JSSParameters to do the heavy lifting of converting the
+        // SSLVersionRange to a list of JDK-conforming Strings.
+        JSSParameters parser = new JSSParameters();
+        parser.setProtocols(min_protocol, max_protocol);
+        return parser.getProtocols();
+    }
+
+    /**
+     * Gets the list of SSL protocols supported, as a list of JCA-standardized
+     * strings.
+     */
+    public String[] getSupportedProtocols() {
+        logger.debug("JSSEngine: getSupportedProtocols()");
+        ArrayList<String> result = new ArrayList<String>();
+
+        for (SSLVersion v : Policy.TLS_VERSION_RANGE.getAllInRange()) {
+            logger.debug("JSSEngine: getSupportedProtocol - Supported: " + v);
+            result.add(v.jdkAlias());
+        }
+
+        return result.toArray(new String[result.size()]);
+    }
+
+    /**
+     * Set public and protected key material; useful when doing client auth or
+     * if this wasn't provided to the constructor.
+     *
+     * Can also be used to remove key material; however note that both
+     * arguments must match: either both certificate and key are null or
+     * both are not-null.
+     */
+    public void setKeyMaterials(PK11Cert our_cert, PK11PrivKey our_key) throws IllegalArgumentException {
+        logger.debug("JSSEngine: setKeyMaterials()");
+
+        if ((our_cert == null && our_key != null) || (our_cert != null && our_key == null)) {
+            throw new IllegalArgumentException("JSSEngine.setKeyMaterials(): Either both cert and key must be null or both must be not-null");
+        }
+
+        cert = our_cert;
+        key = our_key;
+    }
+
+    /**
+     * Set the internal KeyManager, when present, replacing all previous
+     * KeyManagers.
+     *
+     * It is suggested that at least one key manager be a JSSKeyManager
+     * instance if a key and certificate must be provided for this end of
+     * the connection.
+     */
+    public void setKeyManager(X509KeyManager km) {
+        if (km == null) {
+            logger.debug("JSSEngine: setKeyManager(null)");
+            return;
+        }
+
+        logger.debug("JSSEngine: setKeyManager(" + km.getClass().getName() + ")");
+        key_managers = new X509KeyManager[] { km };
+    }
+
+    /**
+     * Set the internal list of KeyManagers.
+     *
+     * It is suggested that at least one key manager be a JSSKeyManager
+     * instance if a key and certificate must be provided for this end of
+     * the connection.
+     */
+    public void setKeyManagers(X509KeyManager[] xkms) {
+        if (xkms == null) {
+            logger.debug("JSSEngine: setKeyManagers([null])");
+            return;
+        }
+
+        logger.debug("JSSEngine: setKeyManagers(");
+        for (X509KeyManager km : xkms) {
+           logger.debug(" - " + km.getClass().getName());
+        }
+        logger.debug(")");
+
+        key_managers = xkms;
+    }
+
+    /**
+     * Set the internal TrustManager, when present, replacing all previous
+     * TrustManagers.
+     */
+    public void setTrustManager(JSSTrustManager tm) {
+        if (tm == null) {
+            logger.debug("JSSEngine: setTrustManager(null)");
+            return;
+        }
+
+        logger.debug("JSSEngine: setTrustManager(" + tm.getClass().getName() + ")");
+        trust_managers = new X509TrustManager[] { tm };
+    }
+
+    /**
+     * Set the internal list of TrustManagers.
+     */
+    public void setTrustManagers(X509TrustManager[] xtms) {
+        if (xtms == null) {
+            logger.debug("JSSEngine: setKeyManagers([null])");
+            return;
+        }
+
+        logger.debug("JSSEngine: setTrustManagers(");
+        for (X509TrustManager tm : xtms) {
+           logger.debug(" - " + tm.getClass().getName());
+        }
+        logger.debug(")");
+
+        trust_managers = xtms;
+    }
+
+    /**
+     * Gets the JSSSession object which reflects the status of this
+     * JSS Engine's session.
+     */
+    public JSSSession getSession() {
+        logger.debug("JSSEngine: getSession()");
+        return session;
+    }
+
+    /**
+     * Whether or not to enable this SSLEngine instance to create new
+     * sessions.
+     *
+     * The default value is true. When passed the value false, this will
+     * throw a RuntimeException, stating that all JSS Engines do not support
+     * restricting to only resuming existing sessions.
+     */
+    public void setEnableSessionCreation(boolean flag) {
+        logger.debug("JSSEngine: setEnableSessionCreation(" + flag + ") - not implemented");
+        if (!flag) {
+            String msg = "JSSEngine does not support restricting to only resuming existing sessions.";
+            throw new RuntimeException(msg);
+        }
+    }
+
+    /**
+     * Whether or not new sessions can be created by this SSLEngine instance.
+     *
+     * This always returns true.
+     */
+    public boolean getEnableSessionCreation() {
+        logger.debug("JSSEngine: getEnableSessionCreation() - not implemented");
+        return true;
+    }
+
+    /**
+     * Set whether or not to handshake as a client.
+     */
+    public void setUseClientMode(boolean mode) throws IllegalArgumentException {
+        logger.debug("JSSEngine.setUseClientMode(" + mode + ")");
+        as_server = !mode;
+    }
+
+    /**
+     * Set whether or not client authentication is required for the TLS
+     * handshake to succeed.
+     */
+    public void setNeedClientAuth(boolean need) {
+        logger.debug("JSSEngine.setNeedClientAuth(" + need + ")");
+        need_client_auth = need;
+    }
+
+    /**
+     * Set whether or not we should attempt client authentication.
+     */
+    public void setWantClientAuth(boolean want) {
+        logger.debug("JSSEngine.setWantClientAuth(" + want + ")");
+        want_client_auth = want;
+    }
+
+    /**
+     * Query whether this JSSEngine is a client (true) or a server (false).
+     */
+    public boolean getUseClientMode() {
+        return !as_server;
+    }
+
+    /**
+     * Query whether or not we must have client authentication for the TLS
+     * handshake to succeed.
+     */
+    public boolean getNeedClientAuth() {
+        return need_client_auth;
+    }
+
+    /**
+     * Query whether or not we request client authentication.
+     */
+    public boolean getWantClientAuth() {
+        return want_client_auth;
+    }
+
+    /**
+     * Query whether or not the inbound side of this connection is closed.
+     */
+    public boolean isInboundDone() {
+        logger.debug("JSSEngine.isInboundDone()? " + is_inbound_closed);
+        return is_inbound_closed;
+    }
+
+    /**
+     * Query whether or not the outbound side of this connection is closed.
+     */
+    public boolean isOutboundDone() {
+        logger.debug("JSSEngine.isOutboundDone()? " + is_outbound_closed);
+        return is_outbound_closed;
+    }
+
+    /**
+     * Gets the current security status of this JSSEngine instance.
+     *
+     * This is abstract to allow implementations to implement this (and step
+     * their handshake mechanism) as they wish.
+     */
+    public abstract SecurityStatusResult getStatus();
+
+    /**
+     * Calls cleanup only if both inbound and outbound data streams are
+     * closed.
+     *
+     * This prevents accidental cleanup in the case of a partially open
+     * connection.
+     */
+    public abstract void tryCleanup();
+
+    /**
+     * Performs cleanup of internal data, closing both inbound and outbound
+     * data streams if still open.
+     */
+    public abstract void cleanup();
+}

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -1,0 +1,1167 @@
+package org.mozilla.jss.ssl.javax;
+
+import java.lang.*;
+import java.util.*;
+
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.channels.WritableByteChannel;
+import java.nio.channels.Channels;
+
+import java.nio.ByteBuffer;
+
+import javax.net.ssl.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.mozilla.jss.nss.*;
+import org.mozilla.jss.pkcs11.*;
+import org.mozilla.jss.provider.javax.crypto.*;
+import org.mozilla.jss.ssl.*;
+
+import org.mozilla.jss.crypto.Policy;
+import org.mozilla.jss.crypto.PrivateKey;
+import org.mozilla.jss.crypto.X509Certificate;
+
+/**
+ * The reference JSSEngine implementation.
+ *
+ * This JSSEngine implementation is a reference for future JSSEngine
+ * implementations, providing a pure-Java overview of what should happen at
+ * each step of the init, wrap, and unwrap calls.
+ *
+ * This implementation allows for extended debug logging, but also debug
+ * packet logging. The latter writes out packets sent via wrap(...) and
+ * received from unwrap(...) to a port on localhost. This allows one to easily
+ * attach Wireshark or tcpdump and inspect the TLS packets, even if errors
+ * occur during the test suite (where packets aren't sent over the wire by
+ * default). This maintains the client/server relationship, and are logged
+ * as being from the appropriate side of the TLS connection.
+ */
+public class JSSEngineReferenceImpl extends JSSEngine {
+    private String peer_info;
+
+    private boolean closed_fd;
+    private BufferProxy read_buf;
+    private BufferProxy write_buf;
+    private SSLFDProxy ssl_fd;
+
+    private int unknown_state_count;
+    private boolean step_handshake;
+
+    private SSLException ssl_exception;
+    private boolean seen_exception;
+
+    private int debug_port;
+    private ServerSocket ss_socket;
+    private Socket s_socket;
+    private Socket c_socket;
+    private OutputStream s_ostream;
+    private OutputStream c_ostream;
+
+    private String name;
+    private String prefix = "";
+
+    public JSSEngineReferenceImpl() {
+        super();
+
+        peer_info = "";
+
+        debug("JSSEngine: constructor()");
+    }
+
+    public JSSEngineReferenceImpl(String peerHost, int peerPort) {
+        super(peerHost, peerPort);
+
+        peer_info = peerHost + ":" + peerPort;
+
+        debug("JSSEngine: constructor(" + peerHost + ", " + peerPort + ")");
+    }
+
+    public JSSEngineReferenceImpl(String peerHost, int peerPort,
+                     org.mozilla.jss.crypto.X509Certificate localCert,
+                     org.mozilla.jss.crypto.PrivateKey localKey) {
+        super(peerHost, peerPort, localCert, localKey);
+
+        peer_info = peerHost + ":" + peerPort;
+        prefix = prefix + "[" + peer_info + "] ";
+
+        debug("JSSEngine: constructor(" + peerHost + ", " + peerPort + ", " + localCert + ", " + localKey + ")");
+    }
+
+    private String errorText(int error) {
+        // Convert the given error into a pretty string representation with
+        // as much information as is currently available.
+
+        String error_name = PR.ErrorToName(error);
+        String error_text = PR.GetErrorText();
+
+        if (error == 0) {
+            return "NO ERROR";
+        } else if (error_name.isEmpty()) {
+            return "UNKNOWN (" + error + ")";
+        } else if (error_text.isEmpty()) {
+            return error_name + " (" + error + ")";
+        } else {
+            return error_name + " (" + error + "): " + error_text;
+        }
+    }
+
+    private void debug(String msg) {
+        logger.debug(prefix + msg);
+    }
+
+    private void info(String msg) {
+        logger.info(prefix + msg);
+    }
+
+    private void warn(String msg) {
+        logger.warn(prefix + msg);
+    }
+
+    public void setName(String name) {
+        this.name = name;
+        prefix = "[" + this.name + "] " + prefix;
+    }
+
+    private void init() {
+        debug("JSSEngine: init()");
+
+        // Initialize our JSSEngine when we begin to handshake; otherwise,
+        // calls to Set<Option>(...) won't be processed if we call it too
+        // early; some of these need to be applied at initialization.
+
+        // Ensure we don't leak ssl_fd if we're called multiple times.
+        if (ssl_fd != null && !closed_fd) {
+            is_inbound_closed = true;
+            is_outbound_closed = true;
+            cleanup();
+        }
+
+        ssl_fd = null;
+
+        // Create buffers for interacting with NSS.
+        createBuffers();
+        createBufferFD();
+
+        // Initialize the appropriate end of this connection.
+        if (as_server) {
+            initServer();
+        } else {
+            initClient();
+        }
+
+        // Apply the requested cipher suites and protocols.
+        applyProtocols();
+        applyCiphers();
+
+        // Apply hostname information (via setURL).
+        applyHosts();
+
+        // Apply TrustManager(s) information for validating the peer's
+        // certificate.
+        applyTrustManagers();
+
+        // Finally, set up any debug logging necessary.
+        createLoggingSocket();
+    }
+
+    private void createBuffers() {
+        debug("JSSEngine: createBuffers()");
+
+        // If the buffers exist, destroy them and recreate.
+        if (read_buf != null) {
+            Buffer.Free(read_buf);
+        }
+        read_buf = Buffer.Create(BUFFER_SIZE);
+
+        if (write_buf != null) {
+            Buffer.Free(write_buf);
+        }
+        write_buf = Buffer.Create(BUFFER_SIZE);
+    }
+
+    private void createBufferFD() {
+        debug("JSSEngine: createBufferFD()");
+
+        // Create the basis for the ssl_fd from the pair of buffers.
+        PRFDProxy fd;
+        if (peer_info != null && peer_info.length() != 0) {
+            fd = PR.NewBufferPRFD(read_buf, write_buf, peer_info.getBytes());
+        } else {
+            fd = PR.NewBufferPRFD(read_buf, write_buf, null);
+        }
+
+        if (fd == null) {
+            throw new RuntimeException("JSSEngine.init(): Error creating buffer-backed PRFileDesc.");
+        }
+
+        // Initialize ssl_fd from the model Buffer-backed PRFileDesc.
+        ssl_fd = SSL.ImportFD(null, fd);
+        closed_fd = false;
+
+        // Turn on SSL Alert Logging for the ssl_fd object.
+        int ret = SSL.EnableAlertLogging(ssl_fd);
+        if (ret == SSL.SECFailure) {
+            throw new RuntimeException("JSSEngine.init(): Unable to enable SSL Alert Logging on this SSLFDProxy instance.");
+        }
+    }
+
+    private void initClient() {
+        debug("JSSEngine: initClient()");
+
+        // Update handshake status; client initiates connection, so we
+        // need to wrap first.
+        handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+
+        if (cert != null && key != null) {
+            debug("JSSEngine.initClient(): Enabling client auth: " + cert);
+            ssl_fd.SetClientCert(cert);
+            if (SSL.AttachClientCertCallback(ssl_fd) != SSL.SECSuccess) {
+                throw new RuntimeException("JSSEngine.init(): Unable to attach client certificate auth callback.");
+            }
+        }
+
+        step_handshake = true;
+    }
+
+    private void initServer() {
+        debug("JSSEngine: initServer()");
+
+        // The only time cert and key are required are when we're creating a
+        // server SSLEngine.
+        if (cert == null || key == null) {
+            throw new IllegalArgumentException("JSSEngine: must be initialized with server certificate and key!");
+        }
+
+        debug("JSSEngine.initServer(): " + cert);
+        debug("JSSEngine.initServer(): " + key);
+
+        // Configure SSL server with the given certificate and its private
+        // key.
+        if (SSL.ConfigServerCert(ssl_fd, cert, key) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to initialize server with cert and key: " + errorText(PR.GetError()));
+        }
+        session.setLocalCertificates(new PK11Cert[]{ cert } );
+
+        // Create a small session cache.
+        //
+        // TODO: Make this configurable.
+        if (SSL.ConfigServerSessionIDCache(1, 100, 100, null) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to configure server session cache: " + errorText(PR.GetError()));
+        }
+
+        // Update handshake status; client initiates connection, so wait
+        // for unwrap on the server end.
+        handshake_state = SSLEngineResult.HandshakeStatus.NEED_UNWRAP;
+
+        // Only specify these on the server side as they affect what we
+        // want from the remote peer in NSS. In the server case, this is
+        // client auth, but if we were to set these on the client, it would
+        // affect server auth.
+        if (SSL.OptionSet(ssl_fd, SSL.REQUEST_CERTIFICATE, want_client_auth || need_client_auth ? 1 : 0) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to configure SSL_REQUEST_CERTIFICATE option: " + errorText(PR.GetError()));
+        }
+
+        if (SSL.OptionSet(ssl_fd, SSL.REQUIRE_CERTIFICATE, need_client_auth ? 1 : 0) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to configure SSL_REQUIRE_CERTIFICATE option: " + errorText(PR.GetError()));
+        }
+
+        step_handshake = true;
+    }
+
+    private void applyCiphers() {
+        debug("JSSEngine: applyCiphers()");
+        // Enabled the ciphersuites specified by setEnabledCipherSuites(...).
+        // When this isn't called, enabled_ciphers will be null, so we'll just
+        // use whatever is enabled by default.
+        if (enabled_ciphers == null) {
+            return;
+        }
+
+        // We need to disable the suite if it isn't present in the list of
+        // suites above. Be lazy about it for the time being and disable all
+        // cipher suites first.
+        for (SSLCipher suite : SSLCipher.values()) {
+            if (SSL.CipherPrefSet(ssl_fd, suite.getID(), false) == SSL.SECFailure) {
+                // warn("Unable to set cipher suite preference for " + suite.name() + ": " + errorText(PR.GetError()));
+            }
+        }
+
+        // Only enable these particular suites. When a cipher suite can't be
+        // enabled it is most likely due to local policy. Log it. Also log
+        // which ciphers were successfully enabled for debugging purposes.
+        for (SSLCipher suite : enabled_ciphers) {
+            if (suite == null) {
+                continue;
+            }
+
+            if (SSL.CipherPrefSet(ssl_fd, suite.getID(), true) == SSL.SECFailure) {
+                warn("Unable to enable cipher suite " + suite + ": " + errorText(PR.GetError()));
+            } else {
+                debug("Enabled cipher suite " + suite + ": " + errorText(PR.GetError()));
+            }
+        }
+    }
+
+    private void applyProtocols() {
+        debug("JSSEngine: applyProtocols() min_protocol=" + min_protocol + " max_protocol=" + max_protocol);
+        // Enable the protocols only when both a maximum and minimum protocol
+        // version are specified.
+        if (min_protocol == null || max_protocol == null) {
+            debug("JSSEngine: applyProtocols() - missing min_protocol or max_protocol; using defaults");
+            return;
+        }
+
+        // We should bound this range by crypto-policies in the future to
+        // match the current behavior.
+        SSLVersionRange vrange = new SSLVersionRange(min_protocol, max_protocol);
+        if (SSL.VersionRangeSet(ssl_fd, vrange) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to set version range: " + errorText(PR.GetError()));
+        }
+    }
+
+    private void applyHosts() {
+        debug("JSSEngine: applyHosts()");
+
+        // This is most useful for the client end of the connection; this
+        // specifies what to match the server's certificate against.
+        if (hostname != null) {
+            if (SSL.SetURL(ssl_fd, hostname) == SSL.SECFailure) {
+                throw new RuntimeException("Unable to configure server hostname: " + errorText(PR.GetError()));
+            }
+        }
+    }
+
+    private void applyTrustManagers() {
+        debug("JSSEngine: applyTrustManagers()");
+
+        // If none have been specified, exit early.
+        if (trust_managers == null || trust_managers.length == 0) {
+            debug("JSSEngine: no TrustManagers to apply.");
+            return;
+        }
+
+        // Check if we have a single JSSNativeTrustManager.
+        if (trust_managers.length == 1 && trust_managers[0] instanceof JSSNativeTrustManager) {
+            // This is a dummy TrustManager. It signifies that we should call
+            // SSL.ConfigJSSDefaultCertAuthCallback(...) on this SSL
+            // PRFileDesc pointer, letting us utilize the same certificate
+            // validation logic that SSLSocket had.
+            debug("JSSEngine: applyTrustManagers() - adding Native TrustManager");
+            if (SSL.ConfigJSSDefaultCertAuthCallback(ssl_fd) == SSL.SECFailure) {
+                throw new RuntimeException("Unable to configure JSSNativeTrustManager on this JSSengine: " + errorText(PR.GetError()));
+            }
+        }
+    }
+
+    private void createLoggingSocket() {
+        if (debug_port == 0) {
+            return;
+        }
+
+        try {
+            ss_socket = new ServerSocket(debug_port);
+            ss_socket.setReuseAddress(true);
+            ss_socket.setReceiveBufferSize(BUFFER_SIZE);
+
+            c_socket = new Socket(ss_socket.getInetAddress(), ss_socket.getLocalPort());
+            c_socket.setReuseAddress(true);
+            c_socket.setReceiveBufferSize(BUFFER_SIZE);
+            c_socket.setSendBufferSize(BUFFER_SIZE);
+
+            s_socket = ss_socket.accept();
+            s_socket.setReuseAddress(true);
+            s_socket.setReceiveBufferSize(BUFFER_SIZE);
+            s_socket.setSendBufferSize(BUFFER_SIZE);
+
+            s_ostream = s_socket.getOutputStream();
+
+            c_ostream = c_socket.getOutputStream();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to enable debug socket logging! " + e.getMessage(), e);
+        }
+    }
+
+    public void beginHandshake() {
+        debug("JSSEngine: beginHandshake()");
+
+        // We assume beginHandshake(...) is the entry point for initializing
+        // the buffer. In particular, wrap(...) / unwrap(...) *MUST* call
+        // beginHandshake(...) if ssl_fd == null.
+
+        // ssl_fd == null <-> we've not initialized anything yet.
+        if (ssl_fd == null) {
+            init();
+        }
+
+        // Always, reset the handshake status, using the existing
+        // socket and configuration (which might've been just created).
+        if (SSL.ResetHandshake(ssl_fd, as_server) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to begin handshake: " + errorText(PR.GetError()));
+        }
+    }
+
+    public void closeInbound() {
+        debug("JSSEngine: closeInbound()");
+
+        PR.Shutdown(ssl_fd, PR.SHUTDOWN_RCV);
+        is_inbound_closed = true;
+    }
+
+    public void closeOutbound() {
+        debug("JSSEngine: closeOutbound()");
+
+        PR.Shutdown(ssl_fd, PR.SHUTDOWN_SEND);
+        is_outbound_closed = true;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public Runnable getDelegatedTask() {
+        debug("JSSEngine: getDelegatedTask()");
+
+        // We fake being a non-blocking SSLEngine. In particular, we never
+        // export tasks as delegated tasks (e.g., OCSP checking), so this
+        // method will always return null.
+
+        return null;
+    }
+
+    public SSLEngineResult.HandshakeStatus getHandshakeStatus() {
+        debug("JSSEngine: getHandshakeStatus()");
+
+        // Always update the handshake state; this ensures that we catch
+        // looping due to missing data and flip our expected direction.
+        updateHandshakeState();
+
+        return handshake_state;
+    }
+
+    public SecurityStatusResult getStatus() {
+        if (ssl_fd == null) {
+            return null;
+        }
+
+        return SSL.SecurityStatus(ssl_fd);
+    }
+
+    /**
+     * Enable writing of encrypted TLS traffic to the specified port in a
+     * client-server relationship (mirroring the actual role of this
+     * SSLEngine) to enable debugging with Wireshark.
+     */
+    public void enableSafeDebugLogging(int port) {
+        debug_port = port;
+    }
+
+    private int computeSize(ByteBuffer[] buffers, int offset, int length) throws IllegalArgumentException {
+        debug("JSSEngine: computeSize()");
+        int result = 0;
+
+        if (buffers == null || buffers.length == 0) {
+            debug("JSSEngine.compueSize(): no buffers - result=" + result);
+            return result;
+        }
+
+        // Semantics of arguments:
+        //
+        // - buffers is where we're reading/writing application data.
+        // - offset is the index of the first buffer we read/write to.
+        // - length is the total number of buffers we read/write to.
+        //
+        // We use a relative index and an absolute index to handle these
+        // constraints.
+        for (int rel_index = 0; rel_index < length; rel_index++) {
+            int index = offset + rel_index;
+            if (index >= buffers.length) {
+                throw new IllegalArgumentException("offset (" + offset + ") or length (" + length + ") exceeds contract based on number of buffers (" + buffers.length + ")");
+            }
+
+            if (rel_index == 0 && buffers[index] == null) {
+                // If our first buffer is null, assume the rest are and skip
+                // everything else. This commonly happens when null is passed
+                // as the src parameter to wrap or when null is passed as the
+                // dst parameter to unwrap.
+                debug("JSSEngine.compueSize(): null first buffer - result=" + result);
+                return result;
+            }
+
+            if (buffers[index] == null) {
+                throw new IllegalArgumentException("Buffer at index " + index + " is null.");
+            }
+
+            result += buffers[index].remaining();
+        }
+
+        debug("JSSEngine.compueSize(): result=" + result);
+
+        return result;
+    }
+
+    private int putData(byte[] data, ByteBuffer[] buffers, int offset, int length) {
+        debug("JSSEngine: putData()");
+        // Handle the rather unreasonable task of moving data into the buffers.
+        // We assume the buffer parameters have already been checked by
+        // computeSize(...); that is, offset/length contracts hold and that
+        // each buffer in the range is non-null.
+        //
+        // We also assume that data.length does not exceed the total number
+        // of bytes the buffers can hold; this is what computeSize(...)'s
+        // return value should ensure. This directly means that the inner
+        // while loop won't exceed the bounds of offset+length.
+
+        int buffer_index = offset;
+        int data_index = 0;
+
+        if (data == null || buffers == null) {
+            return data_index;
+        }
+
+        for (data_index = 0; data_index < data.length; data_index++) {
+            // Ensure we have have a buffer with capacity.
+            while ((buffers[buffer_index] == null || buffers[buffer_index].remaining() <= 0) &&
+                    (buffer_index < offset + length)) {
+                buffer_index += 1;
+            }
+            if (buffer_index >= offset + length) {
+                break;
+            }
+
+            // TODO: use bulk copy
+            buffers[buffer_index].put(data[data_index]);
+        }
+
+        return data_index;
+    }
+
+    private void updateSession() {
+        try {
+            PK11Cert[] peer_chain = SSL.PeerCertificateChain(ssl_fd);
+            session.setPeerCertificates(peer_chain);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private SSLException checkSSLAlerts() {
+        debug("JSSEngine: Checking inbound and outbound SSL Alerts. Have " + ssl_fd.inboundAlerts.size() + " inbound and " + ssl_fd.outboundAlerts.size() + " outbound alerts.");
+
+        // Prefer inbound alerts to outbound alerts.
+        while (ssl_fd.inboundOffset < ssl_fd.inboundAlerts.size()) {
+            SSLAlertEvent event = ssl_fd.inboundAlerts.get(ssl_fd.inboundOffset);
+            ssl_fd.inboundOffset += 1;
+
+            if (event.getLevelEnum() == SSLAlertLevel.WARNING && event.getDescriptionEnum() == SSLAlertDescription.CLOSE_NOTIFY) {
+                warn("Got inbound CLOSE_NOTIFY alert");
+                closeInbound();
+            }
+
+            debug("JSSEngine: Got inbound alert: " + event);
+
+            SSLException exception = event.toException();
+            if (exception != null) {
+                return exception;
+            }
+        }
+
+        while (ssl_fd.outboundOffset < ssl_fd.outboundAlerts.size()) {
+            SSLAlertEvent event = ssl_fd.outboundAlerts.get(ssl_fd.outboundOffset);
+            ssl_fd.outboundOffset += 1;
+
+            if (event.getLevelEnum() == SSLAlertLevel.WARNING && event.getDescriptionEnum() == SSLAlertDescription.CLOSE_NOTIFY) {
+                warn("Sent outbound CLOSE_NOTIFY alert.");
+                closeOutbound();
+            }
+
+            debug("JSSEngine: Got outbound alert: " + event);
+
+            SSLException exception = event.toException();
+            if (exception != null) {
+                return exception;
+            }
+        }
+
+        return null;
+    }
+
+    private void updateHandshakeState() {
+        debug("JSSEngine: updateHandshakeState()");
+
+        // If we've previously seen an exception, we should just return
+        // here; there's already an alert on the wire, so there's no point
+        // in checking for new ones and/or stepping the handshake: it has
+        // already failed.
+        if (seen_exception) {
+            return;
+        }
+
+        // If we're already done, we should check for SSL ALerts.
+        if (!step_handshake && handshake_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
+            debug("JSSEngine.updateHandshakeState() - not handshaking");
+            unknown_state_count = 0;
+
+            ssl_exception = checkSSLAlerts();
+            seen_exception = (ssl_exception != null);
+            return;
+        }
+
+        // If we've previously finished handshaking, then move to
+        // NOT_HANDSHAKING. Now is also a good time to check for any
+        // alerts.
+        if (!step_handshake && handshake_state == SSLEngineResult.HandshakeStatus.FINISHED) {
+            debug("JSSEngine.updateHandshakeState() - FINISHED to NOT_HANDSHAKING");
+            handshake_state = SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+            unknown_state_count = 0;
+
+            ssl_exception = checkSSLAlerts();
+            seen_exception = (ssl_exception != null);
+            return;
+        }
+
+        // Before we step the handshake, check our current security status.
+        // This informs us of our possible return codes.
+        SecurityStatusResult preHandshakeStatus = getStatus();
+
+        // Since we're not obviously done handshaking, and the last time we
+        // were called, we were still handshaking, step the handshake.
+        debug("JSSEngine.updateHandshakeState() - forcing handshake");
+        if (SSL.ForceHandshake(ssl_fd) == SSL.SECFailure) {
+            int error_value = PR.GetError();
+
+            if (error_value != PRErrors.WOULD_BLOCK_ERROR) {
+                debug("JSSEngine.updateHandshakeState() - FATAL " + getStatus());
+
+                ssl_exception = new SSLHandshakeException("Error duing SSL.ForceHandshake() :: " + errorText(error_value));
+                seen_exception = true;
+
+                handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+                return;
+            }
+        }
+
+        // Check if we've just finished handshaking.
+        SecurityStatusResult handshakeStatus = getStatus();
+        debug("JSSSEngine.updateHandshakeState() - pre: " + preHandshakeStatus);
+        debug("JSSSEngine.updateHandshakeState() - post: " + handshakeStatus);
+        debug("JSSEngine.updateHandshakeState() - read_buf.read=" + Buffer.ReadCapacity(read_buf) + " read_buf.write=" + Buffer.WriteCapacity(read_buf) + " write_buf.read=" + Buffer.ReadCapacity(write_buf) + " write_buf.write=" + Buffer.WriteCapacity(write_buf));
+
+        // Set NEED_WRAP when we have data to send to the client.
+        if (Buffer.ReadCapacity(write_buf) > 0 && handshake_state != SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+            // Can't write; to read, we need to call wrap to provide more
+            // data to write.
+            debug("JSSEngine.updateHandshakeState() - can write " + Buffer.ReadCapacity(write_buf) + " bytes, NEED_WRAP to process");
+            handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+            unknown_state_count = 0;
+            return;
+        }
+
+        // Delay the check to see if the handshake finished until after we
+        // send the CLIENT FINISHED message and recieved the SERVER FINISHED
+        // message if we're a client. Otherwise, wait to send SERVER FINISHED
+        // message. This is because NSS thinks the handshake has finished
+        // (according to SecurityStatusResult since it has sent the massage)
+        // but we haven't yet gotten around to doing so if we're in a WRAP()
+        // call.
+        if (handshakeStatus.on >= 1 && Buffer.ReadCapacity(write_buf) == 0) {
+            debug("JSSEngine.updateHandshakeState() - handshakeStatus.on is " + handshakeStatus.on + ", so we've just finished handshaking");
+            updateSession();
+            step_handshake = false;
+            handshake_state = SSLEngineResult.HandshakeStatus.FINISHED;
+            unknown_state_count = 0;
+            return;
+        }
+
+        if (Buffer.ReadCapacity(read_buf) == 0 && handshake_state != SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+            // Set NEED_UNWRAP when we have no data to read from the client.
+            debug("JSSEngine.updateHandshakeState() - can read " + Buffer.ReadCapacity(read_buf) + " bytes, NEED_UNWRAP to give us more");
+            handshake_state = SSLEngineResult.HandshakeStatus.NEED_UNWRAP;
+            unknown_state_count = 0;
+            return;
+        }
+
+        unknown_state_count += 1;
+        if (unknown_state_count >= 4) {
+            if (handshake_state == SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+                handshake_state = SSLEngineResult.HandshakeStatus.NEED_UNWRAP;
+            } else {
+                handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+            }
+            unknown_state_count = 1;
+        }
+    }
+
+    private boolean isHandshakeFinished() {
+        debug("JSSEngine: isHandshakeFinished()");
+        return (handshake_state == SSLEngineResult.HandshakeStatus.FINISHED ||
+                (ssl_fd != null && handshake_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING));
+    }
+
+    private void logUnwrap(ByteBuffer src) {
+        if (debug_port <= 0 || src == null || src.remaining() == 0) {
+            return;
+        }
+
+        OutputStream stream = c_ostream;
+
+        if (!as_server) {
+            // An unwrap from the client means we write data to the outbound
+            // side of the server socket.
+            stream = s_ostream;
+        }
+
+        WritableByteChannel channel = Channels.newChannel(stream);
+
+        int pos = src.position();
+        try {
+            debug("JSSEngine: logUnwrap() - writing " + src.remaining() + " bytes.");
+            channel.write(src);
+            stream.flush();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to log contents of unwrap's src to debug socket: " + e.getMessage(), e);
+        } finally {
+            src.position(pos);
+        }
+    }
+
+    public SSLEngineResult unwrap(ByteBuffer src, ByteBuffer[] dsts, int offset, int length) throws IllegalArgumentException, SSLException {
+        debug("JSSEngine: unwrap(ssl_fd=" + ssl_fd + ")");
+
+        // In this method, we're taking the network wire contents of src and
+        // passing them as the read side of our buffer. If there's any data
+        // for us to read from the remote peer (via ssl_fd), we place it in
+        // the various dsts.
+        //
+        // However, we also need to detect if the handshake is still ongoing;
+        // if so, we can't send data (from src) until then.
+
+        if (ssl_fd == null) {
+            beginHandshake();
+        }
+
+        logUnwrap(src);
+
+        // wire_data is the number of bytes from src we've written into
+        // read_buf. This is bounded above by src.capcity but also the
+        // free space left in read_buf to write to. Allows us to size the
+        // temporary byte array appropriately.
+        int wire_data = (int) Buffer.WriteCapacity(read_buf);
+        if (src == null) {
+            wire_data = 0;
+        } else {
+            // We need to know how many bytes have been written into src: this
+            // is via src.remaining().
+            wire_data = Math.min(wire_data, src.remaining());
+        }
+
+        // Order of operations:
+        //  1. Read data from srcs
+        //  2. Update handshake status
+        //  3. Write data to dsts
+        //
+        // Since srcs is coming from the data, it could affect our ability to
+        // handshake. It could also affect our ability to write data to dsts,
+        // as src could provide new data to decrypt. When no new data from src
+        // is present, we could have residual steps in handshake(), in which
+        // case no data would be written to dsts. Lastly, even if no new data
+        // from srcs, could still have residual data in read_buf, so we should
+        // attempt to read from the ssl_fd.
+
+        // When we have data from src, write it to read_buf.
+        if (wire_data > 0) {
+            byte[] wire_buffer = new byte[wire_data];
+            src.get(wire_buffer);
+            int written = (int) Buffer.Write(read_buf, wire_buffer);
+
+            // For safety: ensure everything we thought we could write was
+            // actually written. Otherwise, we've done something wrong.
+            wire_data = Math.min(wire_data, written);
+
+            // TODO: Determine if we should write the trail of wire_buffer
+            // back to the front of src... Seems like unnecessary work.
+            debug("JSSEngine.unwrap(): Wrote " + wire_data + " bytes to read_buf.");
+        }
+
+        // In the above, we should always try to read and write data. Check to
+        // see if we need to step our handshake process or not.
+        updateHandshakeState();
+
+        // Actual amount of data written to the buffer.
+        int app_data = 0;
+
+        // Maximum theoretical amount of data we could've written to the
+        // destination. This is bounded by the lower of both the size of
+        // our dsts and the maximum BUFFER_SIZE. Worst case, we'll be forced
+        // to call unwrap(...) multiple times.
+        int max_app_data = Math.min(computeSize(dsts, offset, length), BUFFER_SIZE);
+
+        // When we have app data to write over the network, go ahead and do
+        // so. This involves reading from ssl_fd and writing to dsts. We don't
+        // currently have a good proxy metric for "can read from a ssl_fd",
+        // so always attempt it. In particular, even if the handshake isn't
+        // finished, we still need to call PR.Read(...) or PR.Write(...) in
+        // order to tell if an inbound alert was received.
+        if (max_app_data > 0) {
+            byte[] app_buffer = PR.Read(ssl_fd, max_app_data);
+            debug("JSSEngine.unwrap() - " + app_buffer + " error=" + errorText(PR.GetError()));
+            if (app_buffer != null) {
+                app_data = putData(app_buffer, dsts, offset, length);
+            } else {
+                int error = PR.GetError();
+                if (error != 0 && error != PRErrors.WOULD_BLOCK_ERROR) {
+                    ssl_exception = new SSLException("Unexpected return from PR.Read(): " + errorText(error));
+                    seen_exception = true;
+                }
+            }
+
+            if (seen_exception == false && ssl_exception == null) {
+                ssl_exception = checkSSLAlerts();
+                seen_exception = (ssl_exception != null);
+            }
+        }
+
+        // Before we return, check if an exception occurred and throw it if
+        // one did.
+        if (ssl_exception != null) {
+            info("JSSEngine.unwrap() - Got SSLException: " + ssl_exception);
+            SSLException excpt = ssl_exception;
+            ssl_exception = null;
+            handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+            tryCleanup();
+            throw excpt;
+        }
+
+        SSLEngineResult.Status handshake_status = SSLEngineResult.Status.OK;
+
+
+        if (is_inbound_closed && is_outbound_closed) {
+            debug("Socket is currently closed.");
+            handshake_status = SSLEngineResult.Status.CLOSED;
+        }
+
+        // Need a way to introspect the open/closed state of the TLS
+        // connection.
+
+        debug("JSSEngine.unwrap() - Finished");
+        debug(" - Status: " + handshake_status);
+        debug(" - Handshake State: " + handshake_state);
+        debug(" - wire_data: " + wire_data);
+        debug(" - app_data: " + app_data);
+
+        tryCleanup();
+        return new SSLEngineResult(handshake_status, handshake_state, wire_data, app_data);
+    }
+
+    public int writeData(ByteBuffer[] srcs, int offset, int length) {
+        debug("JSSEngine: writeData()");
+        // This is the tough end of reading/writing. There's two potential
+        // places buffering could occur:
+        //
+        //  - Inside the NSS library (unclear if this happens).
+        //  - write_buf
+        //
+        // So when we call PR.Write(ssl_fd, data), it isn't guaranteed that
+        // we can write all of data to ssl_fd (unlike with all our other read
+        // or write operations where we have a clear bound). In the event that
+        // our Write call is truncated, we have to put data back into the
+        // buffer from whence it was read.
+        //
+        // However, we do use Buffer.WriteCapacity(write_buf) as a proxy
+        // metric for how much we can write without having to place data back
+        // in a src buffer.
+        int data_length = 0;
+
+        int index = offset;
+        int max_index = offset + length;
+
+        while (index < max_index) {
+            // If we don't have any remaining bytes in this buffer, skip it.
+            if (srcs[index].remaining() <= 0) {
+                index += 1;
+                continue;
+            }
+            debug("JSSEngine.writeData(): index=" + index + " max_index=" + max_index);
+
+            // We expect (i.e., need to construct a buffer) to write up to
+            // this much. Note that this is non-zero since we're taking the
+            // max here and we guarantee with the previous statement that
+            // srcs[index].remaining() > 0.
+            int expected_write = srcs[index].remaining();
+            debug("JSSEngine.writeData(): expected_write=" + expected_write + " write_cap=" + Buffer.WriteCapacity(write_buf) + " read_cap=" + Buffer.ReadCapacity(read_buf));
+
+            // Get data from our current srcs[index] buffer.
+            byte[] app_data = new byte[expected_write];
+            srcs[index].get(app_data);
+
+            // Actual amount written.
+            int this_write = PR.Write(ssl_fd, app_data);
+            debug("JSSEngine.writeData(): this_write=" + this_write);
+            if (this_write < 0) {
+                int error = PR.GetError();
+                if (error == PRErrors.SOCKET_SHUTDOWN_ERROR) {
+                    warn("NSPR reports outbound socket is shutdown.");
+                    is_outbound_closed = true;
+                } else if (error != PRErrors.WOULD_BLOCK_ERROR) {
+                    throw new RuntimeException("Unable to write to internal ssl_fd: " + errorText(PR.GetError()));
+                }
+
+                break;
+            }
+
+            data_length += this_write;
+
+            if (this_write == 0) {
+                // Revert our position to the previous position and break: we
+                // are out of space to write into our SSL FD.
+                int pos = srcs[index].position();
+                int delta = expected_write - this_write;
+                srcs[index].position(pos - delta);
+
+                // Also check for SSLExceptions while we're here.
+                break;
+            }
+        }
+
+        debug("JSSEngine.writeData(): data_length=" + data_length);
+
+        return data_length;
+    }
+
+    private void logWrap(ByteBuffer dst) {
+        if (debug_port <= 0 || dst == null || dst.remaining() == 0) {
+            return;
+        }
+
+        OutputStream stream = s_ostream;
+
+        if (!as_server) {
+            // A wrap from the client means we write data to the outbound
+            // side of the client socket.
+            stream = c_ostream;
+        }
+
+        WritableByteChannel channel = Channels.newChannel(stream);
+
+        int pos = dst.position();
+        try {
+            dst.flip();
+            debug("JSSEngine: logWrap() - writing " + dst.remaining() + " bytes.");
+            channel.write(dst);
+            stream.flush();
+            dst.flip();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to log contents of wrap's dst to debug socket: " + e.getMessage(), e);
+        } finally {
+            dst.position(pos);
+        }
+    }
+
+    public SSLEngineResult wrap(ByteBuffer[] srcs, int offset, int length, ByteBuffer dst) throws IllegalArgumentException, SSLException {
+        debug("JSSEngine: wrap(ssl_fd=" + ssl_fd + ")");
+        // In this method, we're taking the application data from the various
+        // srcs and writing it to the remote peer (via ssl_fd). If there's any
+        // data for us to send to the remote peer, we place it in dst.
+        //
+        // However, we also need to detect if the handshake is still ongoing;
+        // if so, we can't send data (from src) until then.
+
+        if (ssl_fd == null) {
+            beginHandshake();
+        }
+
+        // Order of operations:
+        //  1. Step the handshake
+        //  2. Write data from srcs to ssl_fd
+        //  3. Write data from write_buf to dst
+        //
+        // This isn't technically locally optimal: it could be that write_buf
+        // is full while we're handshaking so step 1 could be a no-op, but
+        // we could read from write_buf and step the handshake then. However,
+        // on our next call to wrap() would also step the handshake, which
+        // two in a row would almost certainly result in one being a no-op.
+        // Both steps 1 and 2 could write data to dsts. At best 2 will fail if
+        // write_buf is full, however, we'd again end up calling wrap() again
+        // anyways.
+
+        // In the above order of operations, we should always try to read and
+        // write data. Check to see if we need to step our handshake process
+        // or not.
+        updateHandshakeState();
+
+        if (ssl_exception == null && seen_exception) {
+            if (handshake_state != SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
+                // In the event that:
+                //
+                //      1. We saw an exception in the past
+                //          --> (seen_exception is true),
+                //      2. We've already thrown it from wrap or unwrap,
+                //          --> (ssl_exception is null),
+                //      3. We were previously handshaking
+                //          --> (handshake_state is a handshaking state),
+                //
+                // we need to make sure wrap is called again to ensure the
+                // alert is actually written to the wire. So here we are,
+                // in wrap and the above hold true; we can mark the handshake
+                // status as "FINISHED" (because well, it is over due to the
+                // alert). That leaves the return state to be anything other
+                // than OK to indicate the error.
+                handshake_state = SSLEngineResult.HandshakeStatus.FINISHED;
+            }
+        }
+
+        // Actual amount of data read from srcs (and written to ssl_fd). This
+        // is determined by the PR.Write(...) call on ssl_fd.
+        int app_data = 0;
+
+        // Maximum theoretical amount of data we could've read from srcs.
+        // While this isn't strictly bounded above by BUFFER_SIZE (as it is
+        // being written to ssl_fd instead of to read_buf or write_buf), we're
+        // better off limiting ourselves to a reasonable limit.
+        int max_app_data = Math.min(computeSize(srcs, offset, length), BUFFER_SIZE);
+
+        // Try writing data from srcs to the other end of the connection. Note
+        // that we always attempt this, even if the handshake isn't yet marked
+        // as finished. This is because we need the call to PR.Write(...) to
+        // tell if an alert is getting sent.
+        if (max_app_data > 0) {
+            debug("JSSEngine.wrap(): writing from srcs to buffer...");
+            app_data = writeData(srcs, offset, length);
+
+            if (seen_exception == false && ssl_exception == null) {
+                ssl_exception = checkSSLAlerts();
+                seen_exception = (ssl_exception != null);
+            }
+        } else {
+            debug("JSSEngine.wrap(): not writing from srcs to buffer: max_app_data=" + max_app_data + " handshake_finished=" + isHandshakeFinished());
+        }
+
+        // wire_data is the number of bytes written to dst. This is bounded
+        // above by two fields: the number of bytes we can read from
+        // write_buf, and the size of dst, if present.
+        int wire_data = (int) Buffer.ReadCapacity(write_buf);
+        if (dst == null) {
+            wire_data = 0;
+        } else {
+            // We want to know how much free space there is in dst for us to
+            // write to. This is given by dst.remaining().
+            wire_data = Math.min(wire_data, dst.remaining());
+        }
+
+        // Try reading data from write_buf to dst
+        if (wire_data > 0) {
+            byte[] wire_buffer = Buffer.Read(write_buf, wire_data);
+            dst.put(wire_buffer);
+            debug("JSSEngine.wrap() - Wrote " + wire_buffer.length + " bytes to dst.");
+        }
+
+        logWrap(dst);
+
+        // Before we return, check if an exception occurred and throw it if
+        // one did.
+        if (ssl_exception != null) {
+            info("JSSEngine.wrap() - Got SSLException: " + ssl_exception);
+            SSLException excpt = ssl_exception;
+            ssl_exception = null;
+            cleanup();
+            throw excpt;
+        }
+
+        // Need a way to introspect the open/closed state of the TLS
+        // connection.
+
+        SSLEngineResult.Status handshake_status = SSLEngineResult.Status.OK;
+
+        if (ssl_exception == null && seen_exception) {
+            debug("Seen and processed exception; closing inbound and outbound because this was the last wrap(...)");
+            closeInbound();
+            closeOutbound();
+        }
+
+        if (is_inbound_closed && is_outbound_closed) {
+            debug("Socket is currently closed.");
+            handshake_status = SSLEngineResult.Status.CLOSED;
+        }
+
+        debug("JSSEngine.wrap() - Finished");
+        debug(" - Status: " + handshake_status);
+        debug(" - Handshake State: " + handshake_state);
+        debug(" - wire_data: " + wire_data);
+        debug(" - app_data: " + app_data);
+
+        tryCleanup();
+        return new SSLEngineResult(handshake_status, handshake_state, app_data, wire_data);
+    }
+
+    /**
+     * Calls cleanup only if both inbound and outbound data streams are
+     * closed.
+     *
+     * This prevents accidental cleanup in the case of a partially open
+     * connection.
+     */
+    public void tryCleanup() {
+        debug("JSSEngine: tryCleanup()");
+        if (is_inbound_closed && is_outbound_closed) {
+            // throw new RuntimeException("Probably shouldn't be here!");
+            cleanup();
+        }
+    }
+
+    /**
+     * Performs cleanup of internal data, closing both inbound and outbound
+     * data streams if still open.
+     */
+    public void cleanup() {
+        debug("JSSEngine: cleanup()");
+
+        if (!is_inbound_closed) {
+            debug("JSSEngine: cleanup() - closing opened inbound socket");
+            closeInbound();
+        }
+
+        if (!is_outbound_closed) {
+            debug("JSSEngine: cleanup() - closing opened outbound socket");
+            closeOutbound();
+        }
+
+        // First cleanup any debugging ports, if any.
+        cleanupLoggingSocket();
+
+        // Then clean up the NSS state.
+        cleanupSSLFD();
+    }
+
+    private void cleanupLoggingSocket() {
+        if (debug_port > 0) {
+            try {
+                s_socket.close();
+            } catch (Exception e) {}
+
+            try {
+                c_socket.close();
+            } catch (Exception e) {}
+
+            try {
+                ss_socket.close();
+            } catch (Exception e) {}
+        }
+    }
+
+    private void cleanupSSLFD() {
+        if (!closed_fd) {
+            try {
+                PR.Close(ssl_fd);
+            } catch (Exception e) {
+            } finally {
+                closed_fd = true;
+            }
+        }
+
+        Buffer.Free(read_buf);
+        Buffer.Free(write_buf);
+    }
+}

--- a/org/mozilla/jss/ssl/javax/JSSSession.java
+++ b/org/mozilla/jss/ssl/javax/JSSSession.java
@@ -1,0 +1,158 @@
+package org.mozilla.jss.ssl.javax;
+
+import java.security.cert.Certificate;
+import javax.security.cert.X509Certificate;
+import java.security.Principal;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+public class JSSSession implements SSLSession {
+    private int application_buffer_size;
+    private String cipher_suite;
+    private long creation_time;
+    private byte[] session_id;
+    private long last_access_time;
+    private Certificate[] local_certificates;
+    private Principal local_principal;
+    private int packet_buffer_size;
+    private X509Certificate[] peer_chain;
+    private Certificate[] peer_certificates;
+    private String peer_host;
+    private int peer_port;
+    private Principal peer_principal;
+    private String protocol;
+
+    JSSSession(int buffer_size) {
+        creation_time = System.currentTimeMillis();
+        application_buffer_size = buffer_size;
+        packet_buffer_size = buffer_size;
+        setLastAccessedTime();
+    }
+
+    public byte[] getId() {
+        return session_id;
+    }
+
+    protected void setId(byte[] new_id) {
+        session_id = new_id;
+        setLastAccessedTime();
+    }
+
+    public SSLSessionContext getSessionContext() {
+        return null;
+    }
+
+    public long getCreationTime() {
+        return creation_time;
+    }
+
+    public long getLastAccessedTime() {
+        return last_access_time;
+    }
+
+    protected void setLastAccessedTime() {
+        last_access_time = System.currentTimeMillis();
+    }
+
+    public void invalidate() {}
+    public boolean isValid() { return true; }
+    public void putValue(String name, Object value) {}
+    public Object getValue(String name) { return null; }
+    public void removeValue(String name) {}
+    public String[] getValueNames() { return null; }
+
+    public Certificate[] getPeerCertificates() {
+        return peer_certificates;
+    }
+
+    protected void setPeerCertificates(Certificate[] new_certs) {
+        peer_certificates = new_certs;
+        setLastAccessedTime();
+    }
+
+    public Certificate[] getLocalCertificates() {
+        return local_certificates;
+    }
+
+    protected void setLocalCertificates(Certificate[] new_certs) {
+        local_certificates = new_certs;
+        setLastAccessedTime();
+    }
+
+    public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
+        if (peer_chain == null) {
+            String msg = "Peer reported no certificate chain or handshake has not yet completed.";
+            throw new SSLPeerUnverifiedException(msg);
+        }
+
+        return peer_chain;
+    }
+
+    protected void setPeerCertificateChain(X509Certificate[] new_chain) {
+        peer_chain = new_chain;
+        setLastAccessedTime();
+    }
+
+    public Principal getPeerPrincipal() {
+        return peer_principal;
+    }
+
+    protected void setPeerPrincipal(Principal new_principal) {
+        peer_principal = new_principal;
+        setLastAccessedTime();
+    }
+
+    public Principal getLocalPrincipal() {
+        return local_principal;
+    }
+
+    protected void setLocalPrincipal(Principal new_principal) {
+        local_principal = new_principal;
+        setLastAccessedTime();
+    }
+
+    public String getCipherSuite() {
+        return cipher_suite;
+    }
+
+    protected void setCipherSuite(String new_suite) {
+        cipher_suite = new_suite;
+        setLastAccessedTime();
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    protected void setProtocol(String new_protocol) {
+        protocol = new_protocol;
+        setLastAccessedTime();
+    }
+
+    public String getPeerHost() {
+        return peer_host;
+    }
+
+    public void setPeerHost(String new_host) {
+        peer_host = new_host;
+        setLastAccessedTime();
+    }
+
+    public int getPeerPort() {
+        return peer_port;
+    }
+
+    public void setPeerPort(int new_port) {
+        peer_port = new_port;
+        setLastAccessedTime();
+    }
+
+    public int getPacketBufferSize() {
+        return packet_buffer_size;
+    }
+
+    public int getApplicationBufferSize() {
+        return application_buffer_size;
+    }
+}

--- a/org/mozilla/jss/tests/TestSSLEngine.java
+++ b/org/mozilla/jss/tests/TestSSLEngine.java
@@ -1,0 +1,619 @@
+package org.mozilla.jss.tests;
+
+import java.lang.*;
+import java.nio.*;
+import java.net.*;
+import java.util.*;
+import java.security.*;
+import javax.net.ssl.*;
+
+import org.mozilla.jss.*;
+import org.mozilla.jss.nss.*;
+import org.mozilla.jss.ssl.*;
+import org.mozilla.jss.ssl.javax.*;
+import org.mozilla.jss.provider.javax.crypto.*;
+
+public class TestSSLEngine {
+    public static void initialize(String[] args) throws Exception {
+        InitializationValues ivs = new InitializationValues(args[0]);
+        CryptoManager.initialize(ivs);
+        CryptoManager cm = CryptoManager.getInstance();
+        cm.setPasswordCallback(new FilePasswordCallback(args[1]));
+    }
+
+    public static void testProvided() throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLS", "Mozilla-JSS");
+        System.err.println(ctx.getProvider());
+
+        SSLEngine raw_eng = ctx.createSSLEngine();
+        assert(raw_eng instanceof JSSEngine);
+    }
+
+    public static JSSParameters createParameters() throws Exception {
+        JSSParameters params = new JSSParameters();
+
+        params.setHostname("localhost");
+
+        return params;
+    }
+
+    public static JSSParameters createParameters(String alias) throws Exception {
+        JSSParameters params = new JSSParameters();
+
+        params.setAlias(alias);
+        params.setHostname("localhost");
+
+        return params;
+    }
+
+    public static KeyManager[] getKMs() throws Exception {
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NssX509");
+        return kmf.getKeyManagers();
+    }
+
+    public static TrustManager[] getTMs() throws Exception {
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("NssX509");
+        TrustManager[] tms = tmf.getTrustManagers();
+        for (TrustManager tm : tms) {
+            if (tm instanceof JSSTrustManager) {
+                // JSS test suite doesn't enable extended key usages, so
+                // configure the TrustManager to allow them.
+                JSSTrustManager jtm = (JSSTrustManager) tm;
+                jtm.configureAllowMissingExtendedKeyUsage(true);
+            }
+        }
+
+        return tms;
+    }
+
+    public static void testHandshake(SSLEngine client_eng, SSLEngine server_eng) throws Exception {
+        // Ensure we exit in case of a bug... :-)
+        int counter = 0;
+        int max_steps = 20;
+        int max_data = Math.max(client_eng.getSession().getApplicationBufferSize(), server_eng.getSession().getApplicationBufferSize());
+        max_data = Math.max(max_data, 1 << 20);
+
+        boolean client_done = false;
+        boolean server_done = false;
+
+        client_eng.beginHandshake();
+        server_eng.beginHandshake();
+
+        ArrayList<ByteBuffer> c2s_buffers = new ArrayList<ByteBuffer>();
+        ArrayList<ByteBuffer> s2c_buffers = new ArrayList<ByteBuffer>();
+        for (counter = 0; counter < max_steps; counter++) {
+            SSLEngineResult.HandshakeStatus client_state = client_eng.getHandshakeStatus();
+            SSLEngineResult.HandshakeStatus server_state = server_eng.getHandshakeStatus();
+            System.err.println("client_done=" + client_done + " | client_eng.getHandshakeStatus()=" + client_state + " | c2s_buffers.size=" + c2s_buffers.size());
+            System.err.println("server_done=" + server_done + " | server_eng.getHandshakeStatus()=" + server_state + " | s2c_buffers.size=" + s2c_buffers.size());
+
+            System.err.println("\n\n=====BEGIN CLIENT=====");
+
+            if (!client_done && client_state == SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+                ByteBuffer src = ByteBuffer.allocate(0);
+                ByteBuffer dst = ByteBuffer.allocate(max_data);
+
+                SSLEngineResult r = client_eng.wrap(src, dst);
+                if (r.getStatus() != SSLEngineResult.Status.OK) {
+                    throw new RuntimeException("Unknown result from client_eng.wrap(): " + r.getStatus());
+                }
+
+                dst.flip();
+                if (dst.hasRemaining()) {
+                    // Since we flipped our buffer, we can use hasRemaining()
+                    // to check if there's data we should unwrap on the client
+                    // side. There is, so add it to the candidates.
+                    c2s_buffers.add(dst);
+                }
+            } else if (!client_done && client_state == SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+                while (s2c_buffers.size() > 0) {
+                    ByteBuffer src = s2c_buffers.remove(0);
+                    ByteBuffer dst = ByteBuffer.allocate(max_data);
+
+                    SSLEngineResult r = client_eng.unwrap(src, dst);
+                    if (r.getStatus() != SSLEngineResult.Status.OK) {
+                        throw new RuntimeException("Unknown result from client_eng.unwrap(): " + r.getStatus());
+                    }
+
+                    dst.flip();
+                    assert(!dst.hasRemaining());
+                    if (src.hasRemaining()) {
+                        // Since we have bytes left after reading it, put it
+                        // back on the front of the stack.
+                        s2c_buffers.add(0, src);
+
+                        // After only partially reading a buffer, it is
+                        // unlikely that we'll be able to continue, so break.
+                        break;
+                    } else if (r.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+                        break;
+                    }
+                }
+            } else if (counter > 1 && !client_done && (client_state == SSLEngineResult.HandshakeStatus.FINISHED || client_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING)) {
+                System.err.println("Client: " + server_eng.getHandshakeStatus());
+                client_done = true;
+            } else if (!client_done && client_state == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+                /* Per SSLEngineSimpleDemo from Oracle. */
+                Runnable runnable;
+                while ((runnable = client_eng.getDelegatedTask()) != null) {
+                    System.err.println("Client: running delegated task");
+                    runnable.run();
+                }
+
+                client_state = client_eng.getHandshakeStatus();
+                assert(client_state != SSLEngineResult.HandshakeStatus.NEED_TASK);
+            } else if (!client_done) {
+                throw new RuntimeException("Unknown status for client_eng: " + client_state);
+            } else if (client_done && s2c_buffers.size() > 0) {
+                System.err.println("Client: processing remaining buffers.");
+                while (s2c_buffers.size() > 0) {
+                    ByteBuffer src = s2c_buffers.remove(0);
+                    ByteBuffer dst = ByteBuffer.allocate(max_data);
+
+                    SSLEngineResult r = client_eng.unwrap(src, dst);
+                    if (r.getStatus() != SSLEngineResult.Status.OK) {
+                        throw new RuntimeException("Unknown result from client_eng.unwrap(): " + r.getStatus());
+                    }
+
+                    dst.flip();
+                    assert(!dst.hasRemaining());
+                    if (src.hasRemaining()) {
+                        // Since we have bytes left after reading it, put it
+                        // back on the front of the stack.
+                        s2c_buffers.add(0, src);
+
+                        // After only partially reading a buffer, it is
+                        // unlikely that we'll be able to continue, so break.
+                        break;
+                    } else if (r.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+                        break;
+                    }
+                }
+            }
+
+            System.err.println("=====END CLIENT=====\n\n");
+            System.err.println("\n\n=====BEGIN SERVER=====");
+
+            if (!server_done && server_state == SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+                ByteBuffer src = ByteBuffer.allocate(0);
+                ByteBuffer dst = ByteBuffer.allocate(max_data);
+
+                SSLEngineResult r = server_eng.wrap(src, dst);
+                if (r.getStatus() != SSLEngineResult.Status.OK) {
+                    throw new RuntimeException("Unknown result from server_eng.wrap(): " + r.getStatus());
+                }
+
+                dst.flip();
+                if (dst.hasRemaining()) {
+                    // Since we flipped our buffer, we can use hasRemaining()
+                    // to check if there's data we should unwrap on the client
+                    // side. There is, so add it to the candidates.
+                    s2c_buffers.add(dst);
+                }
+            } else if (!server_done && server_state == SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+                while (c2s_buffers.size() > 0) {
+                    ByteBuffer src = c2s_buffers.remove(0);
+                    ByteBuffer dst = ByteBuffer.allocate(max_data);
+
+                    SSLEngineResult r = server_eng.unwrap(src, dst);
+                    if (r.getStatus() != SSLEngineResult.Status.OK) {
+                        throw new RuntimeException("Unknown result from server_eng.unwrap(): " + r.getStatus());
+                    }
+
+                    dst.flip();
+                    assert(!dst.hasRemaining());
+                    if (src.hasRemaining()) {
+                        // Since we have bytes left after reading it, put it
+                        // back on the front of the stack.
+                        c2s_buffers.add(0, src);
+
+                        // After only partially reading a buffer, it is
+                        // unlikely that we'll be able to continue, so break.
+                        break;
+                    } else if (r.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+                        break;
+                    }
+                }
+            } else if (counter > 1 && !server_done && (server_state == SSLEngineResult.HandshakeStatus.FINISHED || server_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING)) {
+                System.err.println("Server: " + server_eng.getHandshakeStatus());
+                server_done = true;
+            } else if (!server_done && server_state == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+                /* Per SSLEngineSimpleDemo from Oracle. */
+                Runnable runnable;
+                while ((runnable = server_eng.getDelegatedTask()) != null) {
+                    System.err.println("Server: running delegated task");
+                    runnable.run();
+                }
+
+                server_state = client_eng.getHandshakeStatus();
+                assert(server_state != SSLEngineResult.HandshakeStatus.NEED_TASK);
+            } else if (!server_done) {
+                throw new RuntimeException("Unknown status for server handshake status: " + server_state);
+            } else if (server_done && c2s_buffers.size() > 0) {
+                System.err.println("Server: processing remaining buffers.");
+                while (c2s_buffers.size() > 0) {
+                    ByteBuffer src = c2s_buffers.remove(0);
+                    ByteBuffer dst = ByteBuffer.allocate(max_data);;
+
+                    SSLEngineResult r = server_eng.unwrap(src, dst);
+                    if (r.getStatus() != SSLEngineResult.Status.OK) {
+                        throw new RuntimeException("Unknown result from server_eng.unwrap(): " + r.getStatus());
+                    }
+
+                    dst.flip();
+                    assert(!dst.hasRemaining());
+                    if (src.hasRemaining()) {
+                        // Since we have bytes left after reading it, put it
+                        // back on the front of the stack.
+                        c2s_buffers.add(0, src);
+
+                        // After only partially reading a buffer, it is
+                        // unlikely that we'll be able to continue, so break.
+                        break;
+                    } else if (r.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+                        break;
+                    }
+                }
+            }
+            System.err.println("=====END SERVER=====\n\n");
+
+            if (client_done && server_done) {
+                assert(s2c_buffers.size() == 0);
+                assert(c2s_buffers.size() == 0);
+                break;
+            }
+        }
+
+        if (counter == max_steps) {
+            throw new RuntimeException("Unable to complete a handshake in " + max_steps + " steps; assuming we were stuck in an infinite loop: c2s_buffers.size=" + c2s_buffers.size() + " s2c_buffers.size=" + s2c_buffers.size());
+        }
+    }
+
+    public static void sendTestData(SSLEngine send, SSLEngine recv, ByteBuffer mesg, ByteBuffer inter, ByteBuffer dest) throws Exception {
+        int start_pos = mesg.position();
+        int mesg_size = mesg.remaining();
+        int counter = 0;
+        int max_counter = 10;
+
+        SSLEngineResult r;
+
+        for (counter = 0; counter < max_counter; counter++) {
+            r = send.wrap(mesg, inter);
+            inter.flip();
+
+            System.err.println("Bytes of plaintext message: " + mesg_size);
+
+            if (r.getStatus() != SSLEngineResult.Status.OK) {
+                throw new RuntimeException("Unknown result from send.wrap(): " + r.getStatus());
+            } else if (mesg.hasRemaining()) {
+                // Need to be called again to add more data.
+                inter.flip();
+                continue;
+            } else if (inter.hasRemaining()) {
+                break;
+            }
+        }
+
+        if (counter == max_counter) {
+            throw new RuntimeException("Reasonably expected to get encrypted data during wrap.");
+        }
+
+        System.err.println("Bytes of ciphertext message: " + inter.remaining());
+        assert(inter.remaining() >= mesg_size);
+        assert(dest.remaining() > inter.remaining());
+
+        for (counter = 0; counter < max_counter; counter++) {
+            r = recv.unwrap(inter, dest);
+            dest.flip();
+
+            if (r.getStatus() != SSLEngineResult.Status.OK) {
+                throw new RuntimeException("Unknown result from send.wrap(): " + r.getStatus());
+            } else if (!dest.hasRemaining()) {
+                throw new RuntimeException("Reasonably expected to get decrypted data during unwrap. Have: " + dest.remaining());
+            } else if (dest.remaining() < mesg_size) {
+                // Flip it back so we can append more data again.
+                System.err.println("Expecting to get " + (mesg_size - dest.remaining()) + " more bytes... Calling unwrap again.");
+                dest.flip();
+                continue;
+            } else if (dest.remaining() >= mesg_size) {
+                break;
+            }
+        }
+
+        if (counter == max_counter) {
+            throw new RuntimeException("Reasonably expected to get all decrypted data during unwrap but only got " + dest.remaining());
+        }
+
+        System.err.println("Bytes of decrypted message: " + dest.remaining());
+
+        mesg.position(start_pos);
+        byte[] orig = new byte[mesg.remaining()];
+        byte[] copy = new byte[dest.remaining()];
+
+        mesg.get(orig);
+        dest.get(copy);
+
+        if (!Arrays.equals(orig, copy)) {
+            throw new RuntimeException("Expected data received to equal that sent!");
+        }
+    }
+
+    public static void testPostHandshakeTransfer(SSLEngine client_eng, SSLEngine server_eng) throws Exception {
+        assert(client_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING);
+        assert(server_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING);
+
+        int max_data = Math.max(client_eng.getSession().getApplicationBufferSize(), server_eng.getSession().getApplicationBufferSize());
+        max_data = Math.max(max_data, 1 << 25);
+
+
+        System.err.println("Testing post-handshake transfer...");
+
+        ByteBuffer client_msg = ByteBuffer.wrap("Cooking MCs".getBytes());
+        ByteBuffer c2s_buffer = ByteBuffer.allocate(max_data);
+        ByteBuffer server_unwrap = ByteBuffer.allocate(max_data);
+        sendTestData(client_eng, server_eng, client_msg, c2s_buffer, server_unwrap);
+
+        ByteBuffer server_msg = ByteBuffer.wrap("like a pound of bacon.".getBytes());
+        ByteBuffer s2c_buffer = ByteBuffer.allocate(max_data);
+        ByteBuffer client_unwrap = ByteBuffer.allocate(max_data);
+        sendTestData(server_eng, client_eng, server_msg, s2c_buffer, client_unwrap);
+
+        System.err.println("Done testing post-handshake transfer! Success!");
+    }
+
+    public static void sendCloseData(SSLEngine send, SSLEngine recv) throws Exception {
+        int counter = 0;
+        int max_tries = 20;
+        int max_data = Math.max(send.getSession().getApplicationBufferSize(), recv.getSession().getApplicationBufferSize());
+        max_data = Math.max(max_data, 1 << 20);
+
+        ByteBuffer src = ByteBuffer.allocate(max_data);
+        ByteBuffer transfer = ByteBuffer.allocate(max_data);
+        ByteBuffer read = ByteBuffer.allocate(max_data);
+
+        SSLEngineResult r = null;
+
+        for (counter = 0; counter < max_tries; counter++) {
+            r = send.wrap(src, transfer);
+            transfer.flip();
+
+            if (r.getStatus() != SSLEngineResult.Status.OK && r.getStatus() != SSLEngineResult.Status.CLOSED) {
+                throw new RuntimeException("Unknown result from send.wrap(): " + r.getStatus());
+            } else if (transfer.hasRemaining()) {
+                break;
+            }
+        }
+
+        if (counter == max_tries) {
+            throw new RuntimeException("Reasonably expected to send CLOSE_NOTIFY alert to other party.");
+        }
+
+        r = recv.unwrap(transfer, read);
+        read.flip();
+
+        if (r.getStatus() != SSLEngineResult.Status.OK && r.getStatus() != SSLEngineResult.Status.CLOSED) {
+            throw new RuntimeException("Unknown result from recv.unwrap(): " + r.getStatus());
+        } else if (read.hasRemaining()) {
+            throw new RuntimeException("Expected not to recieve any data but got " + read.remaining() + " bytes during unwrap.");
+        }
+    }
+
+    public static void testClose(SSLEngine client_eng, SSLEngine server_eng) throws Exception {
+        assert(client_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING || client_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.FINISHED);
+        assert(server_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING || server_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.FINISHED);
+        if (client_eng instanceof JSSEngine) {
+            assert(((JSSEngine) client_eng).getStatus().on >= 1);
+        }
+
+        if (server_eng instanceof JSSEngine) {
+            assert(((JSSEngine) server_eng).getStatus().on >= 1);
+        }
+
+        assert(client_eng.isInboundDone() == false);
+        assert(client_eng.isOutboundDone() == false);
+        assert(server_eng.isInboundDone() == false);
+        assert(server_eng.isOutboundDone() == false);
+
+        System.err.println("Testing client close...");
+
+        client_eng.closeOutbound();
+        sendCloseData(client_eng, server_eng);
+        assert(client_eng.isOutboundDone() == true);
+        assert(server_eng.isInboundDone() == true);
+        assert(server_eng.isOutboundDone() == false);
+        assert(client_eng.isInboundDone() == false);
+
+        System.err.println("Testing server close...");
+
+        server_eng.closeOutbound();
+        sendCloseData(server_eng, client_eng);
+
+        // Everything should be done now...
+        assert(server_eng.isOutboundDone() == true);
+        assert(client_eng.isInboundDone() == true);
+
+        System.err.println("Passed close test!");
+    }
+
+    public static void testBasicHandshake(SSLEngine client_eng, SSLEngine server_eng) throws Exception {
+        testHandshake(client_eng, server_eng);
+        testPostHandshakeTransfer(client_eng, server_eng);
+        testClose(client_eng, server_eng);
+    }
+
+    public static void configureSSLEngine(SSLEngine eng, String protocol, String cipher_suite) throws Exception {
+        eng.setEnabledProtocols(new String[] { protocol });
+        eng.setEnabledCipherSuites(new String[] { cipher_suite });
+    }
+
+    public static boolean skipProtocolCipherSuite(String protocol, String cipher_suite, String client_alias, String server_alias) {
+        SSLVersion v = SSLVersion.findByAlias(protocol);
+        SSLCipher cs = SSLCipher.valueOf(cipher_suite);
+
+        boolean works_with_version = cs.supportsTLSVersion(v);
+        boolean is_rsa = client_alias.contains("RSA") && cs.requiresRSACert();
+        boolean is_ecdsa = client_alias.contains("ECDSA") && cs.requiresECDSACert();
+        boolean supported = cs.isSupported();
+        boolean null_cipher = cipher_suite.contains("NULL");
+        boolean right_cert_type = is_rsa || is_ecdsa;
+
+        // The JSS test suite currently doesn't generate certificates
+        // compatible with ECDH_RSA cipher suites.
+        boolean is_ecdh_rsa = cipher_suite.contains("ECDH_RSA");
+
+        return (!works_with_version || !supported || !right_cert_type || null_cipher || is_ecdh_rsa);
+    }
+
+    public static void testAllHandshakes(SSLContext ctx, String client_alias, String server_alias, boolean client_auth) throws Exception {
+        SSLEngine dummy = ctx.createSSLEngine();
+        assert(dummy != null);
+
+        for (String protocol : dummy.getSupportedProtocols()) {
+            for (String cipher_suite : dummy.getSupportedCipherSuites()) {
+                if (skipProtocolCipherSuite(protocol, cipher_suite, client_alias, server_alias)) {
+                    continue;
+                }
+
+                System.err.println("Testing: " + protocol + " with " + cipher_suite);
+
+                String context = protocol + "/" + cipher_suite;
+
+                JSSEngine client_eng = (JSSEngine) ctx.createSSLEngine();
+                client_eng.setSSLParameters(createParameters(client_alias));
+                client_eng.setUseClientMode(true);
+
+                if (client_eng instanceof JSSEngineReferenceImpl) {
+                    ((JSSEngineReferenceImpl) client_eng).setName("JSS Client " + context);
+                }
+
+                JSSEngine server_eng = (JSSEngine) ctx.createSSLEngine();
+                server_eng.setSSLParameters(createParameters(server_alias));
+                server_eng.setUseClientMode(false);
+
+                if (server_eng instanceof JSSEngineReferenceImpl) {
+                    ((JSSEngineReferenceImpl) server_eng).setName("JSS Server " + context);
+                    ((JSSEngineReferenceImpl) server_eng).enableSafeDebugLogging(7377);
+                }
+
+                if (client_auth) {
+                    server_eng.setNeedClientAuth(true);
+                }
+
+                configureSSLEngine(client_eng, protocol, cipher_suite);
+                configureSSLEngine(server_eng, protocol, cipher_suite);
+
+                try {
+                    testBasicHandshake(client_eng, server_eng);
+                } catch (Exception e) {
+                    client_eng.cleanup();
+                    server_eng.cleanup();
+                    throw e;
+                }
+            }
+        }
+    }
+
+    public static void testJSSEToJSSHandshakes(SSLContext jss_context, String server_alias) throws Exception {
+        // We set this up as a JSS Server with JSSE client, forgoing client
+        // authentication. Begin by setting up the JSSE context, complete with
+        // supported protocols.
+        SSLContext jsse_context = SSLContext.getInstance("TLS", "SunJSSE");
+        jsse_context.init(getKMs(), getTMs(), null);
+        SSLEngine jsse_dummy = jsse_context.createSSLEngine();
+
+        String[] jsse_protocols = jsse_dummy.getSupportedProtocols();
+        Arrays.sort(jsse_protocols);
+
+        String[] jsse_suites = jsse_dummy.getSupportedCipherSuites();
+        Arrays.sort(jsse_suites);
+
+        SSLEngine dummy = jss_context.createSSLEngine();
+        for (String protocol : dummy.getSupportedProtocols()) {
+            for (String cipher_suite : dummy.getSupportedCipherSuites()) {
+                if (skipProtocolCipherSuite(protocol, cipher_suite, "", server_alias)) {
+                    continue;
+                }
+
+                if (Arrays.binarySearch(jsse_protocols, protocol) < 0) {
+                    System.err.println("JSSE doesn't support protocol: " + protocol);
+                    continue;
+                }
+
+                if (Arrays.binarySearch(jsse_suites, cipher_suite) < 0) {
+                    System.err.println("JSSE doesn't support this cipher suite: " + cipher_suite);
+                    continue;
+                }
+
+                System.err.println("Testing JSSE client with JSS server: " + protocol + " with " + cipher_suite);
+
+                SSLEngine client_eng = jsse_context.createSSLEngine();
+                client_eng.setSSLParameters(createParameters());
+                client_eng.setUseClientMode(true);
+
+                JSSEngine server_eng = (JSSEngine) jss_context.createSSLEngine();
+                server_eng.setSSLParameters(createParameters(server_alias));
+                server_eng.setUseClientMode(false);
+
+                if (server_eng instanceof JSSEngineReferenceImpl) {
+                    ((JSSEngineReferenceImpl) server_eng).enableSafeDebugLogging(7374);
+                }
+
+                configureSSLEngine(client_eng, protocol, cipher_suite);
+                configureSSLEngine(server_eng, protocol, cipher_suite);
+
+                try {
+                    testBasicHandshake(client_eng, server_eng);
+                } catch (Exception e) {
+                    server_eng.cleanup();
+                    throw e;
+                }
+            }
+        }
+    }
+
+    public static void testBasicClientServer(String[] args) throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLS", "Mozilla-JSS");
+        ctx.init(getKMs(), getTMs(), null);
+
+        String client_alias = args[2];
+        String server_alias = args[3];
+
+        testAllHandshakes(ctx, client_alias, server_alias, false);
+        testAllHandshakes(ctx, client_alias, server_alias, true);
+        testJSSEToJSSHandshakes(ctx, server_alias);
+    }
+
+    public static void testNativeClientServer(String[] args) throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLS", "Mozilla-JSS");
+        ctx.init(getKMs(), new TrustManager[] { new JSSNativeTrustManager() }, null);
+
+        String client_alias = args[2];
+        String server_alias = args[3];
+
+        testAllHandshakes(ctx, client_alias, server_alias, false);
+        testAllHandshakes(ctx, client_alias, server_alias, true);
+        testJSSEToJSSHandshakes(ctx, server_alias);
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Args:
+        //  - nssdb
+        //  - nssdb password
+        //  - client cert
+        //  - server cert
+
+        System.out.println("Initializing CryptoManager...");
+        initialize(args);
+
+        assert(SSLVersion.TLS_1_2.matchesAlias("TLSv1.2"));
+
+        System.out.println("Testing provided instance...");
+        testProvided();
+
+        System.out.println("Testing basic handshake with TMs from provider...");
+        testBasicClientServer(args);
+
+        System.out.println("Testing basic handshake with native TM...");
+        testNativeClientServer(args);
+    }
+}


### PR DESCRIPTION
This PR adds necessary features to implement a SSLEngine in JSS. It is placed under `org.mozilla.jss.ssl.javax.JSSEngine`, and exposed via the Mozilla-JSS Provider interface. 

Checklist:
 - [ ] Finish tests, updating this as necessary to fix bugs.
     - [x] Basic handshake tests.
     - [ ] Test re-handshaking an existing session.
     - [x] Matrix of RSA/ECC/(none) with different protocol versions, TLS Cipher Suites, &c. 
     - [x] Cross-test with SunJSSE. 
 - [x] Override default cipher suites, use Crypto Policies when present.
 - [x] Determine how to interact with [`SSLParameters`](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLParameters.html) objects. (See #198)
 - [x] Determine how to interact with [`KeyManager`](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/KeyManager.html) and how we access it. 
    - [x] "Native" [JSS KeyManager](https://dogtagpki.github.io/jss/master/javadocs/org/mozilla/jss/provider/javax/crypto/JSSKeyManager.html) and selecting a certificate by alias.
 - [ ] Determine how to interact with [`TrustManager`](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/TrustManager.html) and how we access it.
    - [x] "Native" [JSS Native TrustManager](https://dogtagpki.github.io/jss/master/javadocs/org/mozilla/jss/provider/javax/crypto/JSSNativeTrustManager.html).
    - [ ] Additional (non-Native, including JSSTrustManager) TrustManager support.
 - [x] Move `JSSContext` into the provider.
 - [x] Determine how to interact with client certificates.
    - [x] Server side (check client cert)
    - [x] Client side (send client cert)
 - [x] Determine how to raise TLS handshake errors correctly.
 - [x] Expose additional protocol data in JSSSession (pushed into #432 and #434).
 - [x] Protocol-specific JSSContexts. 

---

OK, this is ready for review. The checklist above is as complete as I'd like it for this initial merge. Note that performance **isn't** a concern for this particular implementation, right now. We'll get there. This is mostly to make sure we have the scaffolding and have _something_ in place to test against TomcatJSS and PKI before we get too excited about making things feature-complete. 

I'm going for clarity here with this. If you have any question, however small, ask it in a comment and I'll try and address it. 