### PR TITLE
[WIP] PK11RSAPublicKey/PK11RSAPrivateKey - expose standard JDK interfaces

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11RSAPublicKey.java
+++ b/org/mozilla/jss/pkcs11/PK11RSAPublicKey.java
@@ -16,7 +16,7 @@ public class PK11RSAPublicKey extends PK11PubKey implements RSAPublicKey {
 
     public BigInteger getModulus() {
       try {
-        return new BigInteger(getModulusByteArray());
+        return new BigInteger(1, getModulusByteArray());
       } catch( NumberFormatException e) {
         return null;
       }
@@ -25,7 +25,7 @@ public class PK11RSAPublicKey extends PK11PubKey implements RSAPublicKey {
 
     public BigInteger getPublicExponent() {
       try {
-        return new BigInteger(getPublicExponentByteArray());
+        return new BigInteger(1, getPublicExponentByteArray());
       } catch( NumberFormatException e) {
         return null;
       }


### PR DESCRIPTION
Commit: Always return a positive integer

PK11RSAPublicKey's getModulus() and getPublicExponent() methods can
potentially return negative values, when both the modulus and exponent
should be strictly positive.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`