### PR TITLE
Return positive BigIntegers

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11PrivKey.java
+++ b/org/mozilla/jss/pkcs11/PK11PrivKey.java
@@ -111,9 +111,9 @@ public class PK11PrivKey extends org.mozilla.jss.pkcs11.PK11Key
         byte[][] pqgArray = getDSAParamsNative();
 
         return new DSAParameterSpec(
-            new BigInteger(pqgArray[0]),
-            new BigInteger(pqgArray[1]),
-            new BigInteger(pqgArray[2])
+            new BigInteger(1, pqgArray[0]),
+            new BigInteger(1, pqgArray[1]),
+            new BigInteger(1, pqgArray[2])
         );
     }
 

--- a/org/mozilla/jss/pkcs11/PK11RSAPublicKey.java
+++ b/org/mozilla/jss/pkcs11/PK11RSAPublicKey.java
@@ -16,7 +16,7 @@ public class PK11RSAPublicKey extends PK11PubKey implements RSAPublicKey {
 
     public BigInteger getModulus() {
       try {
-        return new BigInteger(getModulusByteArray());
+        return new BigInteger(1, getModulusByteArray());
       } catch( NumberFormatException e) {
         return null;
       }
@@ -25,7 +25,7 @@ public class PK11RSAPublicKey extends PK11PubKey implements RSAPublicKey {
 
     public BigInteger getPublicExponent() {
       try {
-        return new BigInteger(getPublicExponentByteArray());
+        return new BigInteger(1, getPublicExponentByteArray());
       } catch( NumberFormatException e) {
         return null;
       }

--- a/org/mozilla/jss/pkix/crmf/CertReqMsg.java
+++ b/org/mozilla/jss/pkix/crmf/CertReqMsg.java
@@ -313,12 +313,12 @@ public class CertReqMsg implements ASN1Value {
             System.out.println("No public key");
         }
         if( temp.hasIssuerUID() ) {
-            System.out.println("Issuer UID: "+new BigInteger(temp.getIssuerUID().getBits() ) );
+            System.out.println("Issuer UID: "+new BigInteger(1, temp.getIssuerUID().getBits() ) );
         }  else {
             System.out.println("no issuer uid");
         }
         if( temp.hasSubjectUID() ) {
-            System.out.println("Subject UID: "+new BigInteger(temp.getIssuerUID().getBits() ) );
+            System.out.println("Subject UID: "+new BigInteger(1, temp.getIssuerUID().getBits() ) );
         }  else {
             System.out.println("no subject uid");
         }

--- a/org/mozilla/jss/tests/CloseDBs.java
+++ b/org/mozilla/jss/tests/CloseDBs.java
@@ -49,7 +49,7 @@ public final class CloseDBs extends org.mozilla.jss.DatabaseCloser {
             System.out.println("Keys:");
             try {
                 for(i=0; i < keys.length; i++) {
-                    System.out.println(new BigInteger(keys[i].getEncoded()));
+                    System.out.println(new BigInteger(1, keys[i].getEncoded()));
                 }
             } catch (Exception ex) {
                 System.out.println(ex.getMessage());


### PR DESCRIPTION
Several of the usages of `BigInteger`s lead to the potential of negative
numbers, though only positive numbers should be returned.

`PK11RSAPublicKey`'s `getModulus()` and `getPublicExponent()` methods can
potentially return negative values, when both the modulus and exponent
should be strictly positive.

`PK11PrivKey`'s `getDSAParams()` could return negative values depending on
the PQG parameters.

The Key Identifiers printed by `tests.CloseDBs` should be positive (as
they're UIDs) but could be displayed as negative values; the same
happens in `crmf.CertReqMsg`.

This negation property is discussed [here](https://docs.oracle.com/javase/7/docs/api/java/math/BigInteger.html#BigInteger(int,%20byte[])).

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`