### PR TITLE
Add KeyManager and TrustStore - 5:1

### DIFF
--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -237,6 +237,14 @@ public final class JSSProvider extends java.security.Provider {
             "org.mozilla.jss.provider.javax.crypto.JSSMacSpi$HmacSHA512");
         put("Alg.Alias.Mac.Hmac-SHA512", "HmacSHA512");
 
+
+        /////////////////////////////////////////////////////////////
+        // KeyManagerFactory
+        /////////////////////////////////////////////////////////////
+        put("KeyManagerFactory.NssX509",
+            "org.mozilla.jss.provider.javax.crypto.JSSKeyManagerFactory");
+        put("Alg.Alias.KeyManagerFactory.SunX509", "NssX509");
+        put("Alg.Alias.KeyManagerFactory.PKIX", "SunX509");
     }
 
     public String toString() {

--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -245,6 +245,17 @@ public final class JSSProvider extends java.security.Provider {
             "org.mozilla.jss.provider.javax.crypto.JSSKeyManagerFactory");
         put("Alg.Alias.KeyManagerFactory.SunX509", "NssX509");
         put("Alg.Alias.KeyManagerFactory.PKIX", "SunX509");
+
+
+        /////////////////////////////////////////////////////////////
+        // TrustManagerFactory
+        /////////////////////////////////////////////////////////////
+        put("TrustManagerFactory.NssX509",
+            "org.mozilla.jss.provider.javax.crypto.JSSTrustManagerFactory");
+        put("Alg.Alias.TrustManagerFactory.SunX509", "NssX509");
+        put("Alg.Alias.TrustManagerFactory.PKIX", "NssX509");
+        put("Alg.Alias.TrustManagerFactory.X509", "NssX509");
+        put("Alg.Alias.TrustManagerFactory.X.509", "NssX509");
     }
 
     public String toString() {

--- a/org/mozilla/jss/provider/javax/crypto/JSSKeyManager.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSKeyManager.java
@@ -1,0 +1,146 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.tomcat;
+
+import java.net.Socket;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.net.ssl.X509KeyManager;
+
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.crypto.ObjectNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import sun.security.x509.X509CertImpl;
+
+public class JSSKeyManager implements X509KeyManager {
+
+    final static Logger logger = LoggerFactory.getLogger(JSSKeyManager.class);
+
+    @Override
+    public String chooseClientAlias(String[] keyTypes, Principal[] issuers, Socket socket) {
+        logger.debug("JSSKeyManager: chooseClientAlias()");
+
+        logger.debug("JSSKeyManager: key types:");
+        for (String keyType : keyTypes) {
+            logger.debug("JSSKeyManager: - " + keyType);
+        }
+
+        logger.debug("JSSKeyManager: issuers:");
+        for (Principal issuer : issuers) {
+            logger.debug("JSSKeyManager: - " + issuer.getName());
+        }
+
+        return null;  // not implemented
+    }
+
+    @Override
+    public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+        logger.debug("JSSKeyManager: chooseServerAlias()");
+        logger.debug("JSSKeyManager: key type: " + keyType);
+
+        logger.debug("JSSKeyManager: issuers:");
+        for (Principal issuer : issuers) {
+            logger.debug("JSSKeyManager: - " + issuer.getName());
+        }
+
+        return null;  // not implemented
+    }
+
+    @Override
+    public X509Certificate[] getCertificateChain(String alias) {
+
+        logger.debug("JSSKeyManager: getCertificateChain(" + alias + ")");
+
+        try {
+            CryptoManager cm = CryptoManager.getInstance();
+            org.mozilla.jss.crypto.X509Certificate cert = cm.findCertByNickname(alias);
+
+            org.mozilla.jss.crypto.X509Certificate[] chain = cm.buildCertificateChain(cert);
+            logger.debug("JSSKeyManager: cert chain:");
+
+            Collection<X509Certificate> list = new ArrayList<>();
+            for (org.mozilla.jss.crypto.X509Certificate c : chain) {
+                logger.debug("JSSKeyManager: - " + c.getSubjectDN());
+                list.add(new X509CertImpl(c.getEncoded()));
+            }
+
+            return list.toArray(new X509Certificate[list.size()]);
+
+        } catch (Throwable e) {
+            logger.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String[] getClientAliases(String keyType, Principal[] issuers) {
+        logger.debug("JSSKeyManager: getClientAliases()");
+        logger.debug("JSSKeyManager: key type: " + keyType);
+
+        logger.debug("JSSKeyManager: issuers:");
+        for (Principal issuer : issuers) {
+            logger.debug("JSSKeyManager: - " + issuer.getName());
+        }
+
+        return null;  // not implemented
+    }
+
+    @Override
+    public PrivateKey getPrivateKey(String alias) {
+
+        logger.debug("JSSKeyManager: getPrivateKey(" + alias + ")");
+
+        try {
+            CryptoManager cm = CryptoManager.getInstance();
+            org.mozilla.jss.crypto.X509Certificate cert = cm.findCertByNickname(alias);
+            PrivateKey privateKey = cm.findPrivKeyByCert(cert);
+
+            logger.debug("JSSKeyManager: key found: " + alias);
+            return privateKey;
+
+        } catch (ObjectNotFoundException e) {
+            logger.debug("JSSKeyManager: key not found: " + alias);
+            return null;
+
+        } catch (Throwable e) {
+            logger.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String[] getServerAliases(String keyType, Principal[] issuers) {
+        logger.debug("JSSKeyManager: getServerAliases()");
+        logger.debug("JSSKeyManager: key type: " + keyType);
+
+        logger.debug("JSSKeyManager: issuers:");
+        for (Principal issuer : issuers) {
+            logger.debug("JSSKeyManager: - " + issuer.getName());
+        }
+
+        return null;  // not implemented
+    }
+}

--- a/org/mozilla/jss/provider/javax/crypto/JSSKeyManager.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSKeyManager.java
@@ -17,7 +17,7 @@
  * All rights reserved.
  * END COPYRIGHT BLOCK */
 
-package org.dogtagpki.tomcat;
+package org.mozilla.jss.provider.javax.crypto;
 
 import java.net.Socket;
 import java.security.Principal;
@@ -30,10 +30,10 @@ import javax.net.ssl.X509KeyManager;
 
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.crypto.ObjectNotFoundException;
+import org.mozilla.jss.pkcs11.PK11Cert;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import sun.security.x509.X509CertImpl;
 
 public class JSSKeyManager implements X509KeyManager {
 
@@ -81,14 +81,17 @@ public class JSSKeyManager implements X509KeyManager {
             org.mozilla.jss.crypto.X509Certificate[] chain = cm.buildCertificateChain(cert);
             logger.debug("JSSKeyManager: cert chain:");
 
-            Collection<X509Certificate> list = new ArrayList<>();
+            Collection<org.mozilla.jss.pkcs11.PK11Cert> list = new ArrayList<>();
             for (org.mozilla.jss.crypto.X509Certificate c : chain) {
+                if (!(c instanceof PK11Cert)) {
+                    logger.error("JSSKeyManager: Can't cast to PK11Cert: " + c);
+                }
+
                 logger.debug("JSSKeyManager: - " + c.getSubjectDN());
-                list.add(new X509CertImpl(c.getEncoded()));
+                list.add((PK11Cert) c);
             }
 
             return list.toArray(new X509Certificate[list.size()]);
-
         } catch (Throwable e) {
             logger.error(e.getMessage(), e);
             throw new RuntimeException(e);

--- a/org/mozilla/jss/provider/javax/crypto/JSSKeyManagerFactory.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSKeyManagerFactory.java
@@ -1,0 +1,36 @@
+package org.mozilla.jss.provider.javax.crypto;
+
+import java.security.*;
+import javax.net.ssl.*;
+
+import org.mozilla.jss.*;
+import org.mozilla.jss.util.*;
+import org.mozilla.jss.provider.java.security.*;
+
+public class JSSKeyManagerFactory extends KeyManagerFactorySpi {
+    protected void engineInit(KeyStore ks, char[] password) throws KeyStoreException {
+        try {
+            // At most, we can update the password callback if one doesn't exist.
+            CryptoManager cm = CryptoManager.getInstance();
+
+            if (cm.getPasswordCallback() == null && password != null) {
+                PasswordCallback callback = new Password(password);
+                cm.setPasswordCallback(callback);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    protected void engineInit(ManagerFactoryParameters spec) {
+        // There is absolutely nothing we can do here, so exit without
+        // initializing anything.
+    }
+
+    protected KeyManager[] engineGetKeyManagers() {
+        KeyManager[] kms = new KeyManager[1];
+        kms[0] = new JSSKeyManager();
+
+        return kms;
+    }
+}

--- a/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
@@ -1,0 +1,197 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.tomcat;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import javax.net.ssl.X509TrustManager;
+
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.NotInitializedException;
+import org.mozilla.jss.netscape.security.util.Cert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import sun.security.x509.X509CertImpl;
+
+public class JSSTrustManager implements X509TrustManager {
+
+    final static Logger logger = LoggerFactory.getLogger(JSSTrustManager.class);
+
+    final static String SERVER_AUTH_OID = "1.3.6.1.5.5.7.3.1";
+    final static String CLIENT_AUTH_OID = "1.3.6.1.5.5.7.3.2";
+
+    public void checkCertChain(X509Certificate[] certChain, String keyUsage) throws Exception {
+
+        logger.debug("JSSTrustManager: checkCertChain(" + keyUsage + ")");
+
+        // sort cert chain from root to leaf
+        certChain = Cert.sortCertificateChain(certChain);
+
+        for (X509Certificate cert : certChain) {
+            logger.debug("JSSTrustManager:  - " + cert.getSubjectDN());
+        }
+
+        // get CA certs
+        X509Certificate[] caCerts = getAcceptedIssuers();
+
+        // validating cert chain from root to leaf
+        for (int i = 0; i < certChain.length; i++) {
+
+            X509Certificate cert = certChain[i];
+
+            // validating key usage on leaf cert only
+            String usage;
+            if (i == certChain.length - 1) {
+                usage = keyUsage;
+            } else {
+                usage = null;
+            }
+
+            checkCert(cert, caCerts, usage);
+
+            // use the current cert as the CA cert for the next cert in the chain
+            caCerts = new X509Certificate[] { cert };
+        }
+    }
+
+    public void checkCert(X509Certificate cert, X509Certificate[] caCerts, String keyUsage) throws Exception {
+
+        logger.debug("JSSTrustManager: checkCert(" + cert.getSubjectDN() + "):");
+
+        boolean[] aki = cert.getIssuerUniqueID();
+        logger.debug("JSSTrustManager: cert AKI: " + Arrays.toString(aki));
+
+        X509Certificate issuer = null;
+        for (X509Certificate caCert : caCerts) {
+
+            boolean[] ski = caCert.getSubjectUniqueID();
+            logger.debug("JSSTrustManager: SKI of " + caCert.getSubjectDN() + ": " + Arrays.toString(ski));
+
+            try {
+                cert.verify(caCert.getPublicKey(), "Mozilla-JSS");
+                issuer = caCert;
+                break;
+            } catch (Exception e) {
+                logger.debug("JSSTrustManager: invalid certificate: " + e);
+            }
+        }
+
+        if (issuer == null) {
+            throw new CertificateException("Unable to validate signature: " + cert.getSubjectDN());
+        }
+
+        logger.debug("JSSTrustManager: cert signed by " + issuer.getSubjectDN());
+
+        logger.debug("JSSTrustManager: checking validity range:");
+        logger.debug("JSSTrustManager:  - not before: " + cert.getNotBefore());
+        logger.debug("JSSTrustManager:  - not after: " + cert.getNotAfter());
+        cert.checkValidity();
+
+        if (keyUsage != null) {
+
+            List<String> extendedKeyUsages = cert.getExtendedKeyUsage();
+            logger.debug("JSSTrustManager: checking extended key usages:");
+
+            for (String extKeyUsage : extendedKeyUsages) {
+                logger.debug("JSSTrustManager:  - " + extKeyUsage);
+            }
+
+            if (extendedKeyUsages.contains(keyUsage)) {
+                logger.debug("JSSTrustManager: extended key usage found: " + keyUsage);
+            } else {
+                throw new CertificateException("Missing extended key usage: " + keyUsage);
+            }
+        }
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] certChain, String authType) throws CertificateException {
+
+        logger.debug("JSSTrustManager: checkClientTrusted(" + authType + "):");
+
+        try {
+            checkCertChain(certChain, CLIENT_AUTH_OID);
+            logger.debug("JSSTrustManager: SSL client certificate is valid");
+
+        } catch (CertificateException e) {
+            logger.warn("JSSTrustManager: Invalid SSL client certificate: " + e);
+            throw e;
+
+        } catch (Exception e) {
+            logger.warn("JSSTrustManager: Unable to validate certificate: " + e);
+            throw new CertificateException(e);
+        }
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] certChain, String authType) throws CertificateException {
+
+        logger.debug("JSSTrustManager: checkServerTrusted(" + certChain.length + ", " + authType + "):");
+
+        try {
+            checkCertChain(certChain, SERVER_AUTH_OID);
+            logger.debug("JSSTrustManager: SSL server certificate is valid");
+
+        } catch (CertificateException e) {
+            logger.warn("JSSTrustManager: Invalid SSL server certificate: " + e);
+            throw e;
+
+        } catch (Exception e) {
+            logger.warn("JSSTrustManager: Unable to validate SSL server certificate: " + e);
+            throw new CertificateException(e);
+        }
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+
+        logger.debug("JSSTrustManager: getAcceptedIssuers():");
+
+        Collection<X509Certificate> caCerts = new ArrayList<>();
+
+        try {
+            CryptoManager manager = CryptoManager.getInstance();
+            for (org.mozilla.jss.crypto.X509Certificate cert : manager.getCACerts()) {
+                logger.debug("JSSTrustManager:  - " + cert.getSubjectDN());
+
+                try {
+                    X509CertImpl caCert = new X509CertImpl(cert.getEncoded());
+                    caCert.checkValidity();
+                    caCerts.add(caCert);
+
+                } catch (Exception e) {
+                    logger.debug("JSSTrustManager: invalid CA certificate: " + e);
+                }
+            }
+
+        } catch (NotInitializedException e) {
+            logger.error("JSSTrustManager: Unable to get CryptoManager: " + e, e);
+            throw new RuntimeException(e);
+        }
+
+        return caCerts.toArray(new X509Certificate[caCerts.size()]);
+    }
+}

--- a/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
@@ -17,7 +17,7 @@
  * All rights reserved.
  * END COPYRIGHT BLOCK */
 
-package org.dogtagpki.tomcat;
+package org.mozilla.jss.provider.javax.crypto;
 
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -30,11 +30,10 @@ import javax.net.ssl.X509TrustManager;
 
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NotInitializedException;
+import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.netscape.security.util.Cert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import sun.security.x509.X509CertImpl;
 
 public class JSSTrustManager implements X509TrustManager {
 
@@ -178,7 +177,7 @@ public class JSSTrustManager implements X509TrustManager {
                 logger.debug("JSSTrustManager:  - " + cert.getSubjectDN());
 
                 try {
-                    X509CertImpl caCert = new X509CertImpl(cert.getEncoded());
+                    PK11Cert caCert = (PK11Cert) cert;
                     caCert.checkValidity();
                     caCerts.add(caCert);
 

--- a/org/mozilla/jss/provider/javax/crypto/JSSTrustManagerFactory.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSTrustManagerFactory.java
@@ -1,0 +1,20 @@
+package org.mozilla.jss.provider.javax.crypto;
+
+import java.security.*;
+import javax.net.ssl.*;
+
+public class JSSTrustManagerFactory extends TrustManagerFactorySpi {
+    protected void engineInit(KeyStore ks) {
+        // There is nothing we can do here.
+    }
+
+    protected void engineInit(ManagerFactoryParameters spec) {
+        // There is nothing we can do here.
+    }
+
+    protected TrustManager[] engineGetTrustManagers() {
+        TrustManager[] tms = new TrustManager[1];
+        tms[0] = new JSSTrustManager();
+        return tms;
+    }
+}


### PR DESCRIPTION
~Depends on commits from #158. Will be rebased once that is merged.~

This includes a KeyManager and TrustStore implementation in the JSS crypto provider. Copied from TomcatJSS into JSS.

Work in progress as:
 - [x] Needs to implement a KeyManagerFactory.
 - [x] Needs to implement a TrustManagerFactory.
 - [x] Factories need to be added to the actual JSSProvider.