### PR TITLE
Support JDK8-target on JDK11

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -249,6 +249,13 @@ macro(jss_config_java)
     list(APPEND JSS_JAVAC_FLAGS "${JAVAC_CLASSPATH}")
     list(APPEND JSS_JAVAC_FLAGS "-sourcepath")
     list(APPEND JSS_JAVAC_FLAGS "${PROJECT_SOURCE_DIR}")
+
+    # Ensure we're compatible with JDK 8
+    list(APPEND JSS_JAVAC_FLAGS "-target")
+    list(APPEND JSS_JAVAC_FLAGS "1.8")
+    list(APPEND JSS_JAVAC_FLAGS "-source")
+    list(APPEND JSS_JAVAC_FLAGS "1.8")
+
     if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
         list(APPEND JSS_JAVAC_FLAGS "-g")
     else()
@@ -260,6 +267,13 @@ macro(jss_config_java)
     list(APPEND JSS_TEST_JAVAC_FLAGS "${JAVAC_CLASSPATH}:${JUNIT4_JAR}")
     list(APPEND JSS_TEST_JAVAC_FLAGS "-sourcepath")
     list(APPEND JSS_TEST_JAVAC_FLAGS "${PROJECT_SOURCE_DIR}")
+
+    # Ensure we're compatible with JDK 8
+    list(APPEND JSS_TEST_JAVAC_FLAGS "-target")
+    list(APPEND JSS_TEST_JAVAC_FLAGS "1.8")
+    list(APPEND JSS_TEST_JAVAC_FLAGS "-source")
+    list(APPEND JSS_TEST_JAVAC_FLAGS "1.8")
+
     if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
         list(APPEND JSS_TEST_JAVAC_FLAGS "-g")
     else()

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -256,6 +256,12 @@ macro(jss_config_java)
     list(APPEND JSS_JAVAC_FLAGS "-source")
     list(APPEND JSS_JAVAC_FLAGS "1.8")
 
+    # Handle passed-in javac flags as well; assume they are valid.
+    separate_arguments(PASSED_JAVAC_FLAGS UNIX_COMMAND "$ENV{JAVACFLAGS}")
+    foreach(PASSED_JAVAC_FLAG ${PASSED_JAVAC_FLAGS})
+        list(APPEND JSS_JAVAC_FLAGS "${PASSED_JAVAC_FLAG}")
+    endforeach()
+
     if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
         list(APPEND JSS_JAVAC_FLAGS "-g")
     else()
@@ -273,6 +279,12 @@ macro(jss_config_java)
     list(APPEND JSS_TEST_JAVAC_FLAGS "1.8")
     list(APPEND JSS_TEST_JAVAC_FLAGS "-source")
     list(APPEND JSS_TEST_JAVAC_FLAGS "1.8")
+
+    # Handle passed-in javac flags as well; assume they are valid.
+    separate_arguments(PASSED_JAVAC_FLAGS UNIX_COMMAND "$ENV{JAVACFLAGS}")
+    foreach(PASSED_JAVAC_FLAG ${PASSED_JAVAC_FLAGS})
+        list(APPEND JSS_TEST_JAVAC_FLAGS "${PASSED_JAVAC_FLAG}")
+    endforeach()
 
     if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
         list(APPEND JSS_TEST_JAVAC_FLAGS "-g")


### PR DESCRIPTION
Reported by tjaalton on `#dogtag-pki`.

Adds two patches:

 - Use JDK8 as the source and target release; this ensures we don't use any JDK9+ features by accident, and ensures that if we're building with a newer compiler (e.g., JDK11's `javac`), we still end up with something backwards compatible.
 - Support [`JAVACFLAGS`](https://www.gnu.org/software/automake/manual/html_node/Java.html) as a method for passing flags to `javac` from the user.