### PR TITLE
Add hamcrest-core for Debian

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -205,7 +205,7 @@ macro(jss_config_java)
     )
     find_jar(
         HAMCREST_JAR
-        NAMES hamcrest/core
+        NAMES hamcrest/core hamcrest-core
     )
 
     # Validate that we've found the required JARs


### PR DESCRIPTION
While Debian packages a useful junit4 (that already includes
hamcrest-core in its MANIFEST's Class-Path), we might as well include
the correct path in the auto detection script to silence the incorrect
warning.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`