### PR TITLE
Declare certList earlier in ssl/common.c:getRoot

### DIFF
--- a/org/mozilla/jss/ssl/common.c
+++ b/org/mozilla/jss/ssl/common.c
@@ -890,21 +890,20 @@ finish:
 
 /* Get the trusted anchor for pkix */
 
-CERTCertificate * getRoot(CERTCertificate *cert, 
+CERTCertificate *getRoot(CERTCertificate *cert,
     SECCertUsage certUsage) 
 {
     CERTCertificate  *root = NULL;
     CERTCertListNode *node = NULL;
+    CERTCertList *certList = NULL;
 
-    if( !cert ) {
+    if (!cert) {
         goto finish;
     }
 
-    CERTCertList *certList =  CERT_GetCertChainFromCert(cert, 
-        PR_Now(), 
-        certUsage);
+    certList = CERT_GetCertChainFromCert(cert, PR_Now(), certUsage);
 
-    if( certList == NULL) {
+    if (certList == NULL) {
         goto finish;
     }
 
@@ -920,7 +919,7 @@ CERTCertificate * getRoot(CERTCertificate *cert,
 
 finish:
   
-    CERT_DestroyCertList (certList); 
+    CERT_DestroyCertList(certList);
     return root; 
 }
 


### PR DESCRIPTION
This fixes the following compilation warning:

```c
jss/org/mozilla/jss/ssl/common.c: In function ‘getRoot’:
jss/org/mozilla/jss/ssl/common.c:923:5: warning: ‘certList’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     CERT_DestroyCertList (certList);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`