### PR TITLE
Add HSM support for PKCS#11 AES KeyWrap/Padding

### DIFF
--- a/org/mozilla/jss/crypto/Algorithm.c
+++ b/org/mozilla/jss/crypto/Algorithm.c
@@ -92,7 +92,10 @@ JSS_AlgInfo JSS_AlgTable[NUM_ALGS] = {
 /* 61 */    {SEC_OID_AES_192_ECB, SEC_OID_TAG},
 /* 62 */    {SEC_OID_AES_192_CBC, SEC_OID_TAG},
 /* 63 */    {SEC_OID_AES_256_ECB, SEC_OID_TAG},
-/* 64 */    {SEC_OID_AES_256_CBC, SEC_OID_TAG}
+/* 64 */    {SEC_OID_AES_256_CBC, SEC_OID_TAG},
+/* the CKM_AES_KEY_WRAP_* have different defs than CKM_NSS_AES_KEY_WRAP_*  */
+/* 65 */    {CKM_AES_KEY_WRAP, PK11_MECH},
+/* 66 */    {CKM_AES_KEY_WRAP_PAD, PK11_MECH}
 /* REMEMBER TO UPDATE NUM_ALGS!!! */
 };
 

--- a/org/mozilla/jss/crypto/Algorithm.h
+++ b/org/mozilla/jss/crypto/Algorithm.h
@@ -24,7 +24,7 @@ typedef struct JSS_AlgInfoStr {
     JSS_AlgType type;
 } JSS_AlgInfo;
 
-#define NUM_ALGS 65
+#define NUM_ALGS 67
 
 extern JSS_AlgInfo JSS_AlgTable[];
 extern CK_ULONG JSS_symkeyUsage[];
@@ -56,6 +56,17 @@ JSS_getOidTagFromAlg(JNIEnv *env, jobject alg);
  */
 CK_MECHANISM_TYPE
 JSS_getPK11MechFromAlg(JNIEnv *env, jobject alg);
+
+// The following are put here because NSS has not defined these yet
+#ifndef CKM_AES_KEY_WRAP
+#define CKM_AES_KEY_WRAP 0x2109
+#endif
+#ifndef CKM_AES_KEY_WRAP_PAD
+#define CKM_AES_KEY_WRAP_PAD 0x210a
+#endif
+#ifndef CKM_AES_KEY_WRAP_KWP
+#define CKM_AES_KEY_WRAP_KWP 0x210b
+#endif
 
 PR_END_EXTERN_C
 

--- a/org/mozilla/jss/crypto/Algorithm.java
+++ b/org/mozilla/jss/crypto/Algorithm.java
@@ -210,6 +210,8 @@ public class Algorithm {
     protected static final short SEC_OID_PKCS5_PBES2=54;
     protected static final short SEC_OID_PKCS5_PBMAC1=55;
     protected static final short SEC_OID_ANSIX962_ECDSA_SIGNATURE_SPECIFIED_DIGEST=56;
+
+    // NSS AES KeyWrap
     protected static final short CKM_NSS_AES_KEY_WRAP=57;
     protected static final short CKM_NSS_AES_KEY_WRAP_PAD=58;
 
@@ -220,4 +222,9 @@ public class Algorithm {
     protected static final short SEC_OID_AES_192_CBC = 62;
     protected static final short SEC_OID_AES_256_ECB = 63;
     protected static final short SEC_OID_AES_256_CBC = 64;
+
+    // PKCS#11 AES KeyWrap
+    // These underlying defs are currently different from the NSS AES KeyWrap
+    protected static final short CKM_AES_KEY_WRAP=65;
+    protected static final short CKM_AES_KEY_WRAP_PAD=66;
 }

--- a/org/mozilla/jss/crypto/EncryptionAlgorithm.java
+++ b/org/mozilla/jss/crypto/EncryptionAlgorithm.java
@@ -239,6 +239,10 @@ public class EncryptionAlgorithm extends Algorithm {
         Alg alg = Alg.fromString(algName);
         Mode mode = Mode.fromString(modeName);
         Padding padding = Padding.fromString(paddingName);
+
+        if (paddingName == null || paddingName.equals(""))
+            padding = Padding.NONE;
+
         int i;
         for(i = 0; i < len; ++i ) {
             EncryptionAlgorithm cur =

--- a/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
+++ b/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
@@ -115,8 +115,13 @@ public class KeyWrapAlgorithm extends Algorithm {
     RC2_CBC_PAD = new KeyWrapAlgorithm(CKM_RC2_CBC_PAD, "RC2/CBC/PKCS5Padding",
                         RC2ParameterSpec.class, true, 8);
 
-    // Note: AES_KEY_WRAP is not suitable for wrapping private keys;
-    //       Use AES_KEY_WRAP_PAD instead
+    /*
+     * Note: AES_KEY_WRAP is not suitable for wrapping private keys;
+     *       Use AES_KEY_WRAP_PAD instead
+     * Also note that although it is mapped to CKM_NSS_AES_KEY_WRAP_*
+     * here, down in PK11KeyWrapper.c, logic exists to map to
+     * CKM_AES_KEY_WRAP_* if it is determined to recognize the mechanism
+     */
     public static final KeyWrapAlgorithm
     AES_KEY_WRAP = new KeyWrapAlgorithm(CKM_NSS_AES_KEY_WRAP, "AES KeyWrap/NoPadding",
                         (Class<?>) null, false, 8);

--- a/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
+++ b/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
@@ -115,21 +115,20 @@ public class KeyWrapAlgorithm extends Algorithm {
     RC2_CBC_PAD = new KeyWrapAlgorithm(CKM_RC2_CBC_PAD, "RC2/CBC/PKCS5Padding",
                         RC2ParameterSpec.class, true, 8);
 
+    // Note: AES_KEY_WRAP is not suitable for wrapping private keys;
+    //       Use AES_KEY_WRAP_PAD instead
     public static final KeyWrapAlgorithm
-    AES_KEY_WRAP = new KeyWrapAlgorithm(CKM_NSS_AES_KEY_WRAP, "AES KeyWrap",
-                (Class<?>) null, true, 8);
+    AES_KEY_WRAP = new KeyWrapAlgorithm(CKM_NSS_AES_KEY_WRAP, "AES KeyWrap/NoPadding",
+                        (Class<?>) null, false, 8);
 
     public static final KeyWrapAlgorithm
     AES_KEY_WRAP_PAD = new KeyWrapAlgorithm(CKM_NSS_AES_KEY_WRAP_PAD, "AES KeyWrap/Padding",
                 (Class<?>) null, true, 8);
 
-    // Known OIDs; copied from the CertUtil class from the
-    // com.netscape.cmsutil.crypto package of PKI.
     public static final OBJECT_IDENTIFIER AES_KEY_WRAP_PAD_OID = new OBJECT_IDENTIFIER("2.16.840.1.101.3.4.1.8");
+    public static final OBJECT_IDENTIFIER AES_KEY_WRAP_OID = new OBJECT_IDENTIFIER("2.16.840.1.101.3.4.1.5");
     public static final OBJECT_IDENTIFIER AES_CBC_PAD_OID = new OBJECT_IDENTIFIER("2.16.840.1.101.3.4.1.2");
     public static final OBJECT_IDENTIFIER DES3_CBC_PAD_OID = new OBJECT_IDENTIFIER("1.2.840.113549.3.7");
-
-    // This OID does not come from CertUtil; it was added for completeness.
     public static final OBJECT_IDENTIFIER DES_CBC_PAD_OID = new OBJECT_IDENTIFIER("1.3.14.3.2.7");
 
     public static KeyWrapAlgorithm fromOID(String wrapOID) throws NoSuchAlgorithmException {
@@ -137,6 +136,9 @@ public class KeyWrapAlgorithm extends Algorithm {
 
         if (oid.equals(AES_KEY_WRAP_PAD_OID))
             return AES_KEY_WRAP_PAD;
+
+        if (oid.equals(AES_KEY_WRAP_OID))
+            return AES_KEY_WRAP;
 
         if (oid.equals(AES_CBC_PAD_OID))
             return AES_CBC_PAD;

--- a/org/mozilla/jss/pkcs11/pk11util.h
+++ b/org/mozilla/jss/pkcs11/pk11util.h
@@ -510,6 +510,14 @@ JSS_PK11_closeSession(PK11SlotInfo *slot, CK_SESSION_HANDLE session,
 char*
 JSS_PK11_getErrorString(CK_RV crv);
 
+/***********************************************************************
+ *
+ * getSupportedWrappingMechanism
+ *
+ * Returns a 
+ */
+CK_MECHANISM_TYPE getSupportedWrappingMechanism(JNIEnv *env, jobject algObj, PK11SlotInfo *slot);
+
 
 PR_END_EXTERN_C
 

--- a/org/mozilla/jss/tests/KeyWrapping.java
+++ b/org/mozilla/jss/tests/KeyWrapping.java
@@ -72,7 +72,7 @@ public class KeyWrapping {
         // wrap a private with a symmetric
         keyWrap = keyToken.getKeyWrapper(KeyWrapAlgorithm.DES3_CBC_PAD);
         IVParameterSpec iv = new IVParameterSpec(recovered);
-        keyWrap.initWrap(keyWrapper,iv);
+        keyWrap.initWrap(keyWrapper, iv);
         KeyPairGenerator kpg =
             keyToken.getKeyPairGenerator(KeyPairAlgorithm.RSA);
         kpg.initialize(512);
@@ -91,8 +91,33 @@ public class KeyWrapping {
         PrivateKey newPrivk = keyWrap.unwrapTemporaryPrivate(wrappedKey,
             PrivateKey.RSA, pub );
 
+        // wrap a private with a symmetric using AES_KEY_WRAP_PAD
+        keyWrap = keyToken.getKeyWrapper(KeyWrapAlgorithm.AES_KEY_WRAP_PAD);
+        // IVParameterSpec iv = new IVParameterSpec(recovered);
+        keyWrap.initWrap(keyWrapper,null /*iv*/);
+        KeyPairGenerator kpg2 =
+            keyToken.getKeyPairGenerator(KeyPairAlgorithm.RSA);
+        kpg2.initialize(512);
+        kpg2.temporaryPairs(true);
+        KeyPair kp2 = kpg2.genKeyPair();
+        java.security.PublicKey pub2 = kp2.getPublic();
+        PrivateKey privk2 = (org.mozilla.jss.crypto.PrivateKey)kp2.getPrivate();
+
+        wrappedKey = keyWrap.wrap(privk2);
+        System.out.println("Original key:");
+        displayByteArray(privk2.getUniqueID());
+        privk2 = null; kp2 = null;
+        //keyToken.getCryptoStore().deletePrivateKey(privk);
+
+        keyWrap.initUnwrap(keyWrapper,iv);
+        PrivateKey newPrivk2 = keyWrap.unwrapTemporaryPrivate(wrappedKey,
+            PrivateKey.RSA, pub );
+
         System.out.println("New key:");
-        displayByteArray(newPrivk.getUniqueID());
+        displayByteArray(newPrivk2.getUniqueID());
+
+        System.out.println("New key:");
+        displayByteArray(newPrivk2.getUniqueID());
 
         // wrap a symmetric with a private
         keyWrap = keyToken.getKeyWrapper(KeyWrapAlgorithm.RSA);


### PR DESCRIPTION
This patch adds  HSM support for the PKCS#11 standard defined KeyWrap/Padding
mechanism. Prior to this patch, only NSS (CKM_NSS_AES_KEY_WRAP_PAD) was supported.
Note that this is based on Thales's projection of having the following supported
in the next SW version, 12.60: CKM_AES_KEY_WRAP_PAD
For completeness, CKM_AES_KEY_WRAP is also added, although it is not suitable
for private key wrapping.