### PR TITLE
Add -Wall -Wextra -Werror to Ubuntu build

### DIFF
--- a/tools/Dockerfiles/ubuntu_jdk8
+++ b/tools/Dockerfiles/ubuntu_jdk8
@@ -27,7 +27,7 @@ CMD true \
         && rm -rf build \
         && mkdir build \
         && cd build \
-        && cmake .. \
+        && CFLAGS="-Wall -Wextra -Werror" cmake .. \
         && make all \
         && ctest --output-on-failure \
         && true


### PR DESCRIPTION
We should have at least one build using this to ensure we detect issues
earlier.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`