### PR TITLE
Allow Travis Extras section to succeed quickly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
       env: BASE_IMAGE="fedora_29_jdk11"
     - stage: extra
       env: BASE_IMAGE="fedora_rawhide"
+    - stage: extra
+      env: BASE_IMAGE="fast_finish"
+      script:
+        - "true"
   allow_failures:
     - stage: extra
       env: BASE_IMAGE="pkcs11check"


### PR DESCRIPTION
By giving a simple `true` script, the Extras section will have a job
which succeeds quickly. This should make the entire Travis run take
less time, as while the Extras section is fast-finish, it won't finish
until the first job succeeds.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`