### PR TITLE
Set an explicit C standard: C99

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -128,6 +128,7 @@ macro(jss_config_cflags)
     endif()
 
     list(APPEND JSS_RAW_C_FLAGS "-Wall")
+    list(APPEND JSS_RAW_C_FLAGS "-std=gnu99")
     list(APPEND JSS_RAW_C_FLAGS "-Wno-cast-function-type")
     list(APPEND JSS_RAW_C_FLAGS "-Wno-unused-parameter")
     list(APPEND JSS_RAW_C_FLAGS "-Werror-implicit-function-declaration")


### PR DESCRIPTION
All platforms we support should support the newer C99 standard.
Explicitly pass it during build to ensure we don't fail to build on
platforms where the default is C89.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`