### PR TITLE
Fix issues with OCSP patch

### DIFF
--- a/org/mozilla/jss/CryptoManager.c
+++ b/org/mozilla/jss/CryptoManager.c
@@ -984,9 +984,8 @@ Java_org_mozilla_jss_CryptoManager_OCSPCacheSettingsNative(
         ocsp_max_cache_entry_duration);
 
     if (rv != SECSuccess) {
-        JSS_throwMsgPrErr(env,
-                     GENERAL_SECURITY_EXCEPTION,
-                     "Failed to set OCSP cache: error "+ PORT_GetError());
+        JSS_throwMsgPrErrArg(env, GENERAL_SECURITY_EXCEPTION,
+            "Failed to set OCSP cache: error", PORT_GetError());
     }
 }
 
@@ -1000,9 +999,8 @@ Java_org_mozilla_jss_CryptoManager_setOCSPTimeoutNative(
     rv = CERT_SetOCSPTimeout(ocsp_timeout);
 
     if (rv != SECSuccess) {
-        JSS_throwMsgPrErr(env,
-                     GENERAL_SECURITY_EXCEPTION,
-                     "Failed to set OCSP timeout: error "+ PORT_GetError());
+        JSS_throwMsgPrErrArg(env, GENERAL_SECURITY_EXCEPTION,
+            "Failed to set OCSP timeout: error ", PORT_GetError());
     }
 }
 

--- a/org/mozilla/jss/ssl/common.c
+++ b/org/mozilla/jss/ssl/common.c
@@ -992,11 +992,14 @@ SECStatus JSSL_verifyCertPKIX(CERTCertificate *cert,
     SECCertUsage certUsage = certUsageSSLClient /* 0 */;
     
     SECStatus res =  SECFailure;
+
+    CERTCertificate *root = NULL;
+
     if(cert == NULL) {
         goto finish;
     }
 
-    if(ocspPolicy != OCSP_LEAF_AND_CHAIN_POLICY) {
+    if (ocspPolicy != OCSP_LEAF_AND_CHAIN_POLICY) {
         goto finish;
     }
 
@@ -1034,7 +1037,7 @@ SECStatus JSSL_verifyCertPKIX(CERTCertificate *cert,
     SECCertificateUsage testUsage = certificateUsage;
     while (0 != (testUsage = testUsage >> 1)) { certUsage++; }
 
-    CERTCertificate *root = getRoot(cert,certUsage);
+    root = getRoot(cert,certUsage);
 
     /* Try to add the root as the trust anchor so all the
        other memebers of the ca chain will get validated.


### PR DESCRIPTION
In the OCSP patches, there were two issues detected by clang (on top of #175): 

 - Addition between a `const char *` and an `int`; this is legal in Java but not in C.
 - An uninitialized (and undefined) use of `root` due to the use of `goto`.