### PR TITLE
Add SSL.OptionGet

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -355,6 +355,7 @@ Java_org_mozilla_jss_nss_PR_getPRShutdownBoth;
 
 Java_org_mozilla_jss_nss_SSL_ImportFD;
 Java_org_mozilla_jss_nss_SSL_OptionSet;
+Java_org_mozilla_jss_nss_SSL_OptionGet;
 Java_org_mozilla_jss_nss_SSL_SetURL;
 Java_org_mozilla_jss_nss_SSL_SecurityStatus;
 Java_org_mozilla_jss_nss_SSL_ResetHandshake;

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -6,6 +6,7 @@
 #include <jni.h>
 
 #include "java_ids.h"
+#include "jss_exceptions.h"
 #include "jssutil.h"
 #include "pk11util.h"
 #include "PRFDProxy.h"
@@ -94,6 +95,28 @@ Java_org_mozilla_jss_nss_SSL_OptionSet(JNIEnv *env, jclass clazz, jobject fd,
     }
 
     return SSL_OptionSet(real_fd, option, val);
+}
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_SSL_OptionGet(JNIEnv *env, jclass clazz, jobject fd,
+    jint option)
+{
+    PRFileDesc *real_fd = NULL;
+    int result = -1;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        JSS_throwMsg(env, INVALID_PARAMETER_EXCEPTION,
+            "Unable to dereference fd object");
+        return result;
+    }
+
+    if (SSL_OptionGet(real_fd, option, &result) != SECSuccess) {
+        JSS_throwMsg(env, ILLEGAL_ARGUMENT_EXCEPTION,
+            "Unknown option to get or getting option failed");
+    }
+    return result;
 }
 
 JNIEXPORT int JNICALL

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -24,6 +24,14 @@ public class SSL {
     public static native int OptionSet(PRFDProxy fd, int option, int val);
 
     /**
+     * Get the value of a SSL option on the specified PRFileDesc. Note that
+     * this raises an exception in the case of an invalid option.
+     *
+     * See also: SSL_OptionGet in /usr/include/nss3/ssl.h
+     */
+    public static native int OptionGet(PRFDProxy fd, int option) throws Exception;
+
+    /**
      * Set the hostname of a handshake on the specified PRFileDesc.
      *
      * See also: SSL_SetURL in /usr/include/nss3/ssl.h

--- a/org/mozilla/jss/tests/TestRawSSL.java
+++ b/org/mozilla/jss/tests/TestRawSSL.java
@@ -16,18 +16,33 @@ public class TestRawSSL {
         assert(PR.Close(ssl_fd) == 0);
     }
 
-    public static void TestSSLOptionSet() {
+    public static void TestSSLOptions() throws Exception {
         PRFDProxy fd = PR.NewTCPSocket();
         assert(fd != null);
 
         PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
         assert(ssl_fd != null);
 
-        // 7 == SSL_ENABLE_SSL2; disable it
-        assert(SSL.OptionSet(ssl_fd, 7, 0) == 0);
+        // 8 == SSL_ENABLE_SSL3; disable it
+        assert(SSL.OptionSet(ssl_fd, 8, 0) == 0);
+
+        // Validate that the set worked.
+        assert(SSL.OptionGet(ssl_fd, 8) == 0);
+
+        // Renable SSL_ENABLE_SSL3 and validate it worked
+        assert(SSL.OptionSet(ssl_fd, 8, 1) == 0);
+        assert(SSL.OptionGet(ssl_fd, 8) == 1);
 
         // Ensure that setting an invalid option fails
         assert(SSL.OptionSet(ssl_fd, 799999, 0) != 0);
+
+        // Ensure that getting an invalid option fails
+        try {
+            SSL.OptionGet(ssl_fd, 79999999);
+            assert(false);
+        } catch (Exception e) {
+            assert(true);
+        }
 
         assert(PR.Close(ssl_fd) == 0);
     }
@@ -73,7 +88,7 @@ public class TestRawSSL {
         assert(PR.Close(ssl_fd) == 0);
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         System.loadLibrary("jss4");
 
         if (args.length != 1) {
@@ -84,8 +99,8 @@ public class TestRawSSL {
         System.out.println("Calling TestSSLImportFD()...");
         TestSSLImportFD();
 
-        System.out.println("Calling TestSSLOptionSet()...");
-        TestSSLOptionSet();
+        System.out.println("Calling TestSSLOptions()...");
+        TestSSLOptions();
 
         System.out.println("Calling TestSSLSetURL()...");
         TestSSLSetURL();


### PR DESCRIPTION
To mirror `SSL.OptionSet`, expose `SSL_OptionGet` as `org.mozilla.jss.nss.SSL.OptionGet`. 