### PR TITLE
Fix CHECK_DEPRECATION compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ cmake_minimum_required(VERSION 3.0.2)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 # Define optional variables and conditionals.
-if (DEFINED CHECK_DEPRECATION)
-    set(CMAKE_JAVA_COMPILE_FLAGS "-Xlint:deprecation")
+if (DEFINED ENV{CHECK_DEPRECATION})
+    list(APPEND JSS_JAVAC_FLAGS "-Xlint:deprecation")
 endif()
 
 # Build a debug build by default when no type is specified on the command line


### PR DESCRIPTION
The old build system respected the `CHECK_DEPRECATION` environment
variable to enforce deprecation checks during (Java) compilation
time. In the new system, this was broken by not using the `ENV{}`
construct and not adding the flag to the correct variable.

This was reported by @emaldona.


Should be backported to `v4.5.x` branch as well. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`