### PR TITLE
Backport OCSP fixes

### DIFF
--- a/org/mozilla/jss/CryptoManager.c
+++ b/org/mozilla/jss/CryptoManager.c
@@ -1045,9 +1045,8 @@ Java_org_mozilla_jss_CryptoManager_OCSPCacheSettingsNative(
         ocsp_max_cache_entry_duration);
 
     if (rv != SECSuccess) {
-        JSS_throwMsgPrErr(env,
-                     GENERAL_SECURITY_EXCEPTION,
-                     "Failed to set OCSP cache: error "+ PORT_GetError());
+        JSS_throwMsgPrErrArg(env, GENERAL_SECURITY_EXCEPTION,
+            "Failed to set OCSP cache: error", PORT_GetError());
     }
 }
 
@@ -1061,9 +1060,8 @@ Java_org_mozilla_jss_CryptoManager_setOCSPTimeoutNative(
     rv = CERT_SetOCSPTimeout(ocsp_timeout);
 
     if (rv != SECSuccess) {
-        JSS_throwMsgPrErr(env,
-                     GENERAL_SECURITY_EXCEPTION,
-                     "Failed to set OCSP timeout: error "+ PORT_GetError());
+        JSS_throwMsgPrErrArg(env, GENERAL_SECURITY_EXCEPTION,
+            "Failed to set OCSP timeout: error ", PORT_GetError());
     }
 }
 

--- a/org/mozilla/jss/ssl/common.c
+++ b/org/mozilla/jss/ssl/common.c
@@ -902,21 +902,20 @@ finish:
 
 /* Get the trusted anchor for pkix */
 
-CERTCertificate * getRoot(CERTCertificate *cert, 
+CERTCertificate *getRoot(CERTCertificate *cert,
     SECCertUsage certUsage) 
 {
     CERTCertificate  *root = NULL;
     CERTCertListNode *node = NULL;
+    CERTCertList *certList = NULL;
 
-    if( !cert ) {
+    if (!cert) {
         goto finish;
     }
 
-    CERTCertList *certList =  CERT_GetCertChainFromCert(cert, 
-        PR_Now(), 
-        certUsage);
+    certList = CERT_GetCertChainFromCert(cert, PR_Now(), certUsage);
 
-    if( certList == NULL) {
+    if (certList == NULL) {
         goto finish;
     }
 
@@ -932,7 +931,7 @@ CERTCertificate * getRoot(CERTCertificate *cert,
 
 finish:
   
-    CERT_DestroyCertList (certList); 
+    CERT_DestroyCertList(certList);
     return root; 
 }
 

--- a/org/mozilla/jss/ssl/common.c
+++ b/org/mozilla/jss/ssl/common.c
@@ -1004,11 +1004,14 @@ SECStatus JSSL_verifyCertPKIX(CERTCertificate *cert,
     SECCertUsage certUsage = certUsageSSLClient /* 0 */;
     
     SECStatus res =  SECFailure;
+
+    CERTCertificate *root = NULL;
+
     if(cert == NULL) {
         goto finish;
     }
 
-    if(ocspPolicy != OCSP_LEAF_AND_CHAIN_POLICY) {
+    if (ocspPolicy != OCSP_LEAF_AND_CHAIN_POLICY) {
         goto finish;
     }
 
@@ -1046,7 +1049,7 @@ SECStatus JSSL_verifyCertPKIX(CERTCertificate *cert,
     SECCertificateUsage testUsage = certificateUsage;
     while (0 != (testUsage = testUsage >> 1)) { certUsage++; }
 
-    CERTCertificate *root = getRoot(cert,certUsage);
+    root = getRoot(cert,certUsage);
 
     /* Try to add the root as the trust anchor so all the
        other memebers of the ca chain will get validated.


### PR DESCRIPTION
Backport of three OCSP related fixes to `v4.4.x` branch.

These come from #175 and #180 against master.