### PR TITLE
[WIP] Test SSLEngine

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -254,6 +254,16 @@ macro(jss_tests)
         COMMAND "org.mozilla.jss.tests.JSSProvider" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
         DEPENDS "List_CA_certs" "X509CertTest" "Secret_Key_Generation" "Symmetric_Key_Deriving" "SSLClientAuth"
     )
+    jss_test_java(
+        NAME "SSLEngine_RSA"
+        COMMAND "org.mozilla.jss.tests.TestSSLEngine" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}" "Client_RSA" "Server_RSA"
+        DEPENDS "List_CA_certs"
+    )
+    jss_test_java(
+        NAME "SSLEngine_ECDSA"
+        COMMAND "org.mozilla.jss.tests.TestSSLEngine" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}" "Client_ECDSA" "Server_ECDSA"
+        DEPENDS "SSLEngine_RSA"
+    )
 
     if(NOT FIPS_ENABLED)
         jss_test_java(
@@ -363,7 +373,7 @@ macro(jss_tests)
     )
 
 
-    # For compliance with several
+    # For compliance with several existing clients
     add_custom_target(
         check
         DEPENDS test
@@ -408,6 +418,7 @@ function(jss_test_java)
     list(APPEND EXEC_COMMAND "${TEST_CLASSPATH}")
     list(APPEND EXEC_COMMAND "-ea")
     list(APPEND EXEC_COMMAND "-Djava.library.path=${CMAKE_BINARY_DIR}")
+    list(APPEND EXEC_COMMAND "-Djava.util.logging.config.file=${PROJECT_SOURCE_DIR}/tools/logging.properties")
     set(EXEC_COMMAND "${EXEC_COMMAND};${TEST_JAVA_COMMAND}")
 
     if(TEST_JAVA_DEPENDS)

--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -283,6 +283,18 @@ public final class JSSProvider extends java.security.Provider {
         put("Alg.Alias.TrustManagerFactory.PKIX", "NssX509");
         put("Alg.Alias.TrustManagerFactory.X509", "NssX509");
         put("Alg.Alias.TrustManagerFactory.X.509", "NssX509");
+
+        /////////////////////////////////////////////////////////////
+        // TLS
+        /////////////////////////////////////////////////////////////
+        put("SSLContext.Default", "org.mozilla.jss.provider.javax.net.JSSContext");
+        put("SSLContext.SSL", "org.mozilla.jss.provider.javax.net.JSSContext");
+        put("SSLContext.SSLv3", "org.mozilla.jss.provider.javax.net.JSSContext");
+        put("SSLContext.TLS", "org.mozilla.jss.provider.javax.net.JSSContext");
+        put("SSLContext.TLSv1", "org.mozilla.jss.provider.javax.net.JSSContext");
+        put("SSLContext.TLSv1.1", "org.mozilla.jss.provider.javax.net.JSSContext");
+        put("SSLContext.TLSv1.2", "org.mozilla.jss.provider.javax.net.JSSContext");
+        put("SSLContext.TLSv1.3", "org.mozilla.jss.provider.javax.net.JSSContext");
     }
 
     public String toString() {

--- a/org/mozilla/jss/provider/javax/net/JSSContext.java
+++ b/org/mozilla/jss/provider/javax/net/JSSContext.java
@@ -1,0 +1,87 @@
+package org.mozilla.jss.provider.javax.net;
+
+import java.security.*;
+
+import javax.net.ssl.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
+import org.mozilla.jss.provider.javax.crypto.JSSTrustManager;
+import org.mozilla.jss.pkcs11.PK11Cert;
+import org.mozilla.jss.pkcs11.PK11PrivKey;
+import org.mozilla.jss.ssl.javax.JSSEngine;
+
+public class JSSContext extends SSLContextSpi {
+    public static Logger logger = LoggerFactory.getLogger(JSSContext.class);
+
+    JSSKeyManager key_manager = null;
+    JSSTrustManager trust_manager = null;
+
+    public void engineInit(KeyManager[] km, TrustManager[] tm, SecureRandom sr) throws KeyManagementException {
+        logger.debug("JSSContext: engineInit(" + km + ", " + tm + ", " + sr + ")");
+
+        if (km != null) {
+            for (KeyManager k : km) {
+                if (k instanceof JSSKeyManager) {
+                    key_manager = (JSSKeyManager) k;
+                    break;
+                }
+            }
+        }
+
+        if (tm != null) {
+            for (TrustManager t : tm) {
+                if (t instanceof JSSTrustManager) {
+                    trust_manager = (JSSTrustManager) t;
+                    break;
+                }
+            }
+        }
+    }
+
+    public SSLEngine engineCreateSSLEngine() {
+        logger.debug("JSSContext: engineCreateSSLEngine()");
+
+        JSSEngine ret = new JSSEngine();
+        initializeEngine(ret);
+
+        return ret;
+    }
+
+    public SSLEngine engineCreateSSLEngine(String host, int port) {
+        logger.debug("JSSContext: engineCreateSSLEngine(" + host + ", " + port + ")");
+
+        JSSEngine ret = new JSSEngine(host, port);
+        initializeEngine(ret);
+
+        return ret;
+    }
+
+    private void initializeEngine(JSSEngine eng) {
+        eng.setKeyManager(key_manager);
+        eng.setTrustManager(trust_manager);
+    }
+
+    public SSLSessionContext engineGetClientSessionContext() {
+        logger.debug("JSSContext: engineGetClientSessionContext() - not implemented");
+        return null;
+    }
+
+    public SSLSessionContext engineGetServerSessionContext() {
+        logger.debug("JSSContext: engineGetServerSessionContext() - not implemented");
+        return null;
+    }
+
+    public SSLServerSocketFactory engineGetServerSocketFactory() {
+        logger.debug("JSSContext: engineGetServerSocketFactory() - not implemented");
+        return null;
+    }
+
+    public SSLSocketFactory engineGetSocketFactory() {
+        logger.debug("JSSContext: engineGetSocketFactory() - not implemented");
+        return null;
+    }
+}

--- a/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -1,0 +1,1296 @@
+package org.mozilla.jss.ssl.javax;
+
+import java.lang.*;
+import java.util.*;
+
+import java.nio.ByteBuffer;
+
+import javax.net.ssl.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.mozilla.jss.nss.*;
+import org.mozilla.jss.ssl.*;
+import org.mozilla.jss.pkcs11.*;
+import org.mozilla.jss.provider.javax.crypto.*;
+
+public class JSSEngine extends javax.net.ssl.SSLEngine {
+    /*
+     * TODO list:
+     *
+     *  - Allow client authentication.
+     *
+     * Optional list:
+     *
+     *  - SSLSession object interactions?
+     */
+
+    public static Logger logger = LoggerFactory.getLogger(JSSEngine.class);
+
+    private static int BUFFER_SIZE = 1 << 12;
+
+    private boolean is_client = false;
+    private String peer_info = null;
+    private String hostname = null;
+    private BufferProxy read_buf = null;
+    private BufferProxy write_buf = null;
+    private SSLFDProxy ssl_fd = null;
+
+    private PK11Cert cert = null;
+    private PK11PrivKey key = null;
+    private X509KeyManager[] key_managers = null;
+    private X509TrustManager[] trust_managers = null;
+
+    private boolean need_client_auth = false;
+    private boolean want_client_auth = false;
+
+    private SSLEngineResult.HandshakeStatus handshake_state = SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+
+    private SSLCipher[] enabled_ciphers = null;
+    private SSLVersion min_protocol = null;
+    private SSLVersion max_protocol = null;
+
+    private JSSSession session = null;
+    private int unknown_state_count = 0;
+
+    private boolean step_handshake = false;
+
+    private boolean is_outbound_closed = false;
+    private boolean is_inbound_closed = false;
+
+    private SSLException ssl_exception = null;
+    private boolean seen_exception = false;
+
+    public JSSEngine() {
+        super();
+
+        peer_info = "";
+        session = new JSSSession(BUFFER_SIZE);
+        logger.debug("JSSEngine: constructor()");
+    }
+
+    public JSSEngine(String peerHost, int peerPort) {
+        super(peerHost, peerPort);
+
+        peer_info = peerHost + ":" + peerPort;
+        session = new JSSSession(BUFFER_SIZE);
+        session.setPeerHost(peerHost);
+        session.setPeerPort(peerPort);
+        logger.debug("JSSEngine: constructor(" + peerHost + ", " + peerPort + ")");
+    }
+
+    public JSSEngine(String peerHost, int peerPort, PK11Cert localCert, PK11PrivKey localKey) {
+        super(peerHost, peerPort);
+
+        peer_info = peerHost + ":" + peerHost;
+        cert = localCert;
+        key = localKey;
+        session = new JSSSession(BUFFER_SIZE);
+        session.setPeerHost(peerHost);
+        session.setPeerPort(peerPort);
+
+        logger.debug("JSSEngine: constructor(" + peerHost + ", " + peerPort + ", " + localCert + ", " + localKey + ")");
+    }
+
+    private String errorText(int error) {
+        // Convert the given error into a pretty string representation with
+        // as much information as is currently available.
+
+        String error_name = PR.ErrorToName(error);
+        String error_text = PR.GetErrorText();
+
+        if (error_name.isEmpty()) {
+            return "UNKNOWN (" + error + ")";
+        } else if (error_text.isEmpty()) {
+            return error_name + " (" + error + ")";
+        } else {
+            return error_name + " (" + error + "): " + error_text;
+        }
+    }
+
+    private void init() {
+        logger.debug("JSSEngine: init()");
+
+        // Initialize our JSSEngine when we begin to handshake; otherwise,
+        // calls to Set<Option>(...) won't be processed if we call it too
+        // early; some of these need to be applied at initialization.
+
+        // Ensure we don't leak ssl_fd if we're called multiple times.
+        if (ssl_fd != null) {
+            try {
+                PR.Close(ssl_fd);
+                ssl_fd = null;
+            } catch (Exception e) {
+                logger.debug("JSSEngine: init() -- error closing previously open ssl_fd: " + e);
+            }
+        }
+
+        // Create buffers for interacting with NSS.
+        createBuffers();
+        createBufferFD();
+
+        // Initialize the appropriate end of this connection.
+        if (is_client) {
+            initClient();
+        } else {
+            initServer();
+        }
+
+        // Apply the requested cipher suites and protocols.
+        applyCiphers();
+        applyProtocols();
+
+        // Apply hostname information (via setURL).
+        applyHosts();
+
+        // Apply TrustManager(s) information for validating the peer's
+        // certificate.
+        applyTrustManagers();
+    }
+
+    private void createBuffers() {
+        logger.debug("JSSEngine: createBuffers()");
+
+        // If the buffers exist, destroy them and recreate.
+        if (read_buf != null) {
+            Buffer.Free(read_buf);
+        }
+        read_buf = Buffer.Create(BUFFER_SIZE);
+
+        if (write_buf != null) {
+            Buffer.Free(write_buf);
+        }
+        write_buf = Buffer.Create(BUFFER_SIZE);
+    }
+
+    private void createBufferFD() {
+        logger.debug("JSSEngine: createBufferFD()");
+
+        // Create the basis for the ssl_fd from the pair of buffers.
+        PRFDProxy fd = null;
+        if (peer_info != null && peer_info.length() != 0) {
+            fd = PR.NewBufferPRFD(read_buf, write_buf, peer_info.getBytes());
+        } else {
+            fd = PR.NewBufferPRFD(read_buf, write_buf, null);
+        }
+
+        if (fd == null) {
+            throw new RuntimeException("JSSEngine.init(): Error creating buffer-backed PRFileDesc.");
+        }
+
+        // Initialize ssl_fd from the model Buffer-backed PRFileDesc.
+        ssl_fd = SSL.ImportFD(null, fd);
+
+        // Turn on SSL Alert Logging for the ssl_fd object.
+        int ret = SSL.EnableAlertLogging(ssl_fd);
+        if (ret == SSL.SECFailure) {
+            throw new RuntimeException("JSSEngine.init(): Unable to enable SSL Alert Logging on this SSLFDProxy instance.");
+        }
+    }
+
+    private void initClient() {
+        logger.debug("JSSEngine: initClient()");
+
+        // Update handshake status; client initiates connection, so we
+        // need to wrap first.
+        handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+
+        step_handshake = true;
+    }
+
+    private void initServer() {
+        logger.debug("JSSEngine: initServer()");
+
+        // The only time cert and key are required are when we're creating a
+        // server SSLEngine.
+        if (cert == null || key == null) {
+            throw new IllegalArgumentException("JSSEngine: must be initialized with server certificate and key!");
+        }
+
+        logger.debug("JSSEngine.initServer(): " + cert);
+        logger.debug("JSSEngine.initServer(): " + key);
+
+        // Configure SSL server with the given certificate and its private
+        // key.
+        if (SSL.ConfigServerCert(ssl_fd, cert, key) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to initialize server with cert and key: " + errorText(PR.GetError()));
+        }
+        session.setLocalCertificates(new PK11Cert[]{ cert } );
+
+        // Create a small session cache.
+        //
+        // TODO: Make this configurable.
+        if (SSL.ConfigServerSessionIDCache(1, 100, 100, null) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to configure server session cache " + errorText(PR.GetError()));
+        }
+
+        // Update handshake status; client initiates connection, so wait
+        // for unwrap on the server end.
+        handshake_state = SSLEngineResult.HandshakeStatus.NEED_UNWRAP;
+
+        // Only specify these on the server side as they affect what we
+        // want from the remote peer in NSS. In the server case, this is
+        // client auth, but if we were to set these on the client, it would
+        // affect server auth.
+        if (SSL.OptionSet(ssl_fd, SSL.REQUEST_CERTIFICATE, want_client_auth || need_client_auth ? 1 : 0) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to configure SSL_REQUEST_CERTIFICATE option: " + errorText(PR.GetError()));
+        }
+
+        if (SSL.OptionSet(ssl_fd, SSL.REQUIRE_CERTIFICATE, need_client_auth ? 1 : 0) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to configure SSL_REQUIRE_CERTIFICATE option: " + errorText(PR.GetError()));
+        }
+
+        step_handshake = true;
+    }
+
+    private void applyCiphers() {
+        logger.debug("JSSEngine: applyCiphers()");
+        // Enabled the ciphersuites specified by setEnabledCipherSuites(...).
+        // When this isn't called, enabled_ciphers will be null, so we'll just
+        // use whatever is enabled by default.
+        if (enabled_ciphers == null) {
+            return;
+        }
+
+        // We need to disable the suite if it isn't present in the list of
+        // suites above. Be lazy about it for the time being and disable all
+        // cipher suites first.
+        for (SSLCipher suite : SSLCipher.values()) {
+            if (SSL.CipherPrefSet(ssl_fd, suite.getID(), false) == SSL.SECFailure) {
+                logger.debug("Unable to set cipher suite preference for " + suite.name() + ": " + errorText(PR.GetError()));
+            }
+        }
+
+        // Only enable these particular suites. When a cipher suite can't be
+        // enabled it is most likely due to local policy. Log it. Also log
+        // which ciphers were successfully enabled for debugging purposes.
+        for (SSLCipher suite : enabled_ciphers) {
+            if (suite == null) {
+                continue;
+            }
+
+            if (SSL.CipherPrefSet(ssl_fd, suite.getID(), true) == SSL.SECFailure) {
+                logger.warn("Unable to enable cipher suite " + suite + ": " + errorText(PR.GetError()));
+            } else {
+                logger.debug("Enabled cipher suite " + suite + ": " + errorText(PR.GetError()));
+            }
+        }
+    }
+
+    private void applyProtocols() {
+        logger.debug("JSSEngine: applyProtocols()");
+        // Enable the protocols only when both a maximum and minimum protocol
+        // version are specified.
+        if (min_protocol == null || max_protocol == null) {
+            return;
+        }
+
+        // We should bound this range by crypto-policies in the future to
+        // match the current behavior.
+        SSLVersionRange vrange = new SSLVersionRange(min_protocol, max_protocol);
+
+        if (SSL.VersionRangeSet(ssl_fd, vrange) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to set version range: " + errorText(PR.GetError()));
+        }
+    }
+
+    private void applyHosts() {
+        logger.debug("JSSEngine: applyHosts()");
+
+        // This is most useful for the client end of the connection; this
+        // specifies what to match the server's certificate against.
+        if (hostname != null) {
+            if (SSL.SetURL(ssl_fd, hostname) == SSL.SECFailure) {
+                throw new RuntimeException("Unable to configure server hostname: " + errorText(PR.GetError()));
+            }
+        }
+    }
+
+    private void applyTrustManagers() {
+        logger.debug("JSSEngine: applyTrustManagers()");
+
+        // If none have been specified, exit early.
+        if (trust_managers == null || trust_managers.length == 0) {
+            logger.debug("JSSEngine: no TrustManagers to apply.");
+            return;
+        }
+
+        // Check if we have a single JSSNativeTrustManager.
+        if (trust_managers.length == 1 && trust_managers[0] instanceof JSSNativeTrustManager) {
+            // This is a dummy TrustManager. It signifies that we should call
+            // SSL.ConfigJSSDefaultCertAuthCallback(...) on this SSL
+            // PRFileDesc pointer, letting us utilize the same certificate
+            // validation logic that SSLSocket had.
+            if (SSL.ConfigJSSDefaultCertAuthCallback(ssl_fd) == SSL.SECFailure) {
+                throw new RuntimeException("Unable to configure JSSNativeTrustManager on this JSSengine: " + errorText(PR.GetError()));
+            }
+        }
+    }
+
+    public void beginHandshake() {
+        logger.debug("JSSEngine: beginHandshake()");
+
+        // We assume beginHandshake(...) is the entry point for initializing
+        // the buffer. In particular, wrap(...) / unwrap(...) *MUST* call
+        // beginHandshake(...) if ssl_fd == null.
+
+        // ssl_fd == null <-> we've not initialized anything yet.
+        if (ssl_fd == null) {
+            init();
+        }
+
+        // Always, reset the handshake status, using the existing
+        // socket and configuration (which might've been just created).
+        //
+        // Also, NSS's SSL_ResetHandshake takes a parameter "asServer" which
+        // is the opposite of "is_client".
+        if (SSL.ResetHandshake(ssl_fd, !is_client) == SSL.SECFailure) {
+            throw new RuntimeException("Unable to begin handshake: " + errorText(PR.GetError()));
+        }
+    }
+
+    public void closeInbound() {
+        logger.debug("JSSEngine: closeInbound()");
+
+        PR.Shutdown(ssl_fd, PR.SHUTDOWN_RCV);
+        is_inbound_closed = true;
+    }
+
+    public void closeOutbound() {
+        logger.debug("JSSEngine: closeOutbound()");
+
+        PR.Shutdown(ssl_fd, PR.SHUTDOWN_SEND);
+        is_outbound_closed = true;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public Runnable getDelegatedTask() {
+        logger.debug("JSSEngine: getDelegatedTask()");
+
+        // We fake being a non-blocking SSLEngine. In particular, we never
+        // export tasks as delegated tasks (e.g., OCSP checking), so this
+        // method will always return null.
+
+        return null;
+    }
+
+    private void queryEnabledCipherSuites() {
+        logger.debug("JSSEngine: queryEnabledCipherSuites()");
+        ArrayList<SSLCipher> enabledCiphers = new ArrayList<SSLCipher>();
+
+        for (SSLCipher cipher : SSLCipher.values()) {
+            try {
+                if (SSL.CipherPrefGet(ssl_fd, cipher.getID())) {
+                    enabledCiphers.add(cipher);
+                }
+            } catch (Exception e) {
+                // Do nothing -- this shouldn't happen as SSLCipher should be
+                // synced with NSS. However, we'll just log this exception as
+                // a warning. At worst we fail to report that a cipher suite is
+                // enabled.
+                logger.warn("Unable to get the value of cipher: " + cipher.name() + " (" + cipher.getID() + "): " + e.getMessage());
+            }
+        }
+
+        enabled_ciphers = enabledCiphers.toArray(new SSLCipher[0]);
+    }
+
+    public String[] getEnabledCipherSuites() {
+        logger.debug("JSSEngine: getEnabledCipherSuites()");
+
+        // This only happens in the event that setEnabledCipherSuites(...)
+        // isn't called. In which case, we'll need to explicitly query the
+        // list off the ssl_fd.
+        if (enabled_ciphers == null && ssl_fd == null) {
+            queryEnabledCipherSuites();
+        }
+
+        if (enabled_ciphers == null) {
+            // TODO: Query default ciphersuites here.
+            throw new RuntimeException("Unable to query enabled ciphers off of empty ssl_fd.");
+        }
+
+        // Use JSSParameters to do the heavy lifting of converting our list
+        // of cipher suites to an array of Strings.
+        JSSParameters parser = new JSSParameters();
+        parser.setCipherSuites(enabled_ciphers);
+        return parser.getCipherSuites();
+    }
+
+    private void queryEnabledProtocols() {
+        logger.debug("JSSEngine: queryEnabledProtocols()");
+        SSLVersionRange vrange = null;
+        try {
+            vrange = SSL.VersionRangeGet(ssl_fd);
+        } catch (Exception e) {
+            // This shouldn't happen unless the PRFDProxy is null.
+            throw new RuntimeException("JSSEngine.queryEnabledProtocols() Unexpected failure: " + e.getMessage(), e);
+        }
+
+        if (vrange == null) {
+            // Again; this shouldn't happen as the vrange should always
+            // be created by VersionRangeGet(...).
+            throw new RuntimeException("JSSEngine.queryEnabledProtocols() - null protocol range");
+        }
+
+        min_protocol = vrange.getMinVersion();
+        max_protocol = vrange.getMaxVersion();
+    }
+
+    public String[] getEnabledProtocols() {
+        logger.debug("JSSEngine: getEnabledProtocols()");
+
+        if ((min_protocol == null || max_protocol == null) && ssl_fd != null) {
+            queryEnabledProtocols();
+        }
+
+        if (min_protocol == null || max_protocol == null) {
+            // TODO: Query default ciphersuites here.
+            throw new RuntimeException("JSSEngine.getEnabledProtocls() - Unable to query enabled protocols off of empty ssl_fd.");
+        }
+
+        // Use JSSParameters to do the heavy lifting of converting the
+        // SSLVersionRange to a list of JDK-conforming Strings.
+        JSSParameters parser = new JSSParameters();
+        parser.setProtocols(min_protocol, max_protocol);
+        return parser.getProtocols();
+    }
+
+    public boolean getEnableSessionCreation() {
+        logger.debug("JSSEngine: getEnableSessionCreation() - not implemented");
+        return true;
+    }
+
+    public SSLEngineResult.HandshakeStatus getHandshakeStatus() {
+        logger.debug("JSSEngine: getHandshakeStatus()");
+        try {
+            updateHandshakeState();
+        } catch (SSLException se) {
+            // Do nothing -- updateHandshakeStatus() should throw the same
+            // exception again, so it is safe to discard it. We also can't
+            // just pass the SSLException to the caller of this method, as
+            // they aren't expecting it.
+        }
+        return handshake_state;
+    }
+
+    public boolean getNeedClientAuth() {
+        logger.debug("JSSEngine: getNeedClientAuth()");
+        return need_client_auth;
+    }
+
+    public SSLSession getSession() {
+        logger.debug("JSSEngine: getSession() - not implemented");
+        return session;
+    }
+
+    public String[] getSupportedCipherSuites() {
+        logger.debug("JSSEngine: getSupportedCipherSuites() - not implemented");
+        return null;
+    }
+
+    public String[] getSupportedProtocols() {
+        logger.debug("JSSEngine: getSupportedProtocols() - not implemented");
+        return null;
+    }
+
+    public boolean getUseClientMode() {
+        logger.debug("JSSEngine: getUseClientMode()");
+        return is_client;
+    }
+
+    public boolean getWantClientAuth() {
+        logger.debug("JSSEngine: getWantClientAuth()");
+        return want_client_auth;
+    }
+
+    public boolean isInboundDone() {
+        logger.debug("JSSEngine: isInboundDone() - not implemented");
+        return is_inbound_closed;
+    }
+
+    public boolean isOutboundDone() {
+        logger.debug("JSSEngine: isOutboundDone() - not implemented");
+        return is_outbound_closed;
+    }
+
+    public SecurityStatusResult getStatus() {
+        if (ssl_fd == null) {
+            return null;
+        }
+
+        return SSL.SecurityStatus(ssl_fd);
+    }
+
+    public void setSSLParameters(SSLParameters params) {
+        logger.debug("JSSEngine: setSSLParameters(" + params + ")");
+
+        JSSParameters parsed = null;
+
+        // Try to cast the passed parameter into a JSSParameters. This has
+        // additional fields we usually need for construction of a NSS-backed
+        // SSLEngine. Otherwise, parse the values into JSS-specific fields.
+        // If we didn't create the JSSParameters here, both calls
+        // (setEnabledCipherSuites, setEnabledProtocols) would construct their
+        // own JSSParameters.
+        if (params instanceof JSSParameters) {
+            parsed = (JSSParameters) params;
+        } else {
+            parsed = new JSSParameters(params);
+        }
+
+        if (parsed.getSSLCiphers() != null) {
+            setEnabledCipherSuites(parsed.getSSLCiphers());
+        }
+
+        if (parsed.getSSLVersionRange() != null) {
+            setEnabledProtocols(parsed.getSSLVersionRange());
+        }
+
+        setWantClientAuth(parsed.getWantClientAuth());
+        setNeedClientAuth(parsed.getNeedClientAuth());
+
+        // In the event we haven't explicitly set cert and key, try and infer
+        // them from the list of ServerNames specified... We assume that when
+        // the SSLEngine has a certificate already, we want to use them, even
+        // if parsed has a null certificate.
+        if (parsed.getAlias() != null && key_managers != null && key_managers.length > 0 && cert == null && key == null) {
+            setCertFromAlias(parsed.getAlias());
+        }
+
+        if (parsed.getHostname() != null) {
+            setHostname(parsed.getHostname());
+        }
+    }
+
+    public void setHostname(String name) {
+        hostname = name;
+    }
+
+    public void setCertFromAlias(String alias) throws IllegalArgumentException {
+        logger.debug("JSSEngine: setCertFromAlias()");
+        if (alias == null) {
+            cert = null;
+            key = null;
+            return;
+        }
+
+        if (cert != null || key != null) {
+            throw new IllegalArgumentException("SSLEngine already has certificates; refusing to change them.");
+        }
+
+        if (key_managers == null || key_managers.length == 0) {
+            throw new IllegalArgumentException("Missing or null KeyManagers; refusing to search for cert");
+        }
+
+        for (X509KeyManager key_manager : key_managers) {
+            if (key_manager == null) {
+                throw new IllegalArgumentException("Missing or null KeyManager; refusing to search for cert");
+            }
+
+            if (!(key_manager instanceof JSSKeyManager)) {
+                continue;
+            }
+
+            JSSKeyManager jkm = (JSSKeyManager) key_manager;
+
+            // While the return type of CryptoManager.findCertByNickname is
+            // technically org.mozilla.jss.crypto.X509Certificate, in practice
+            // they are always PK11Cert instances.
+            cert = (PK11Cert) jkm.getCertificate(alias);
+            key = (PK11PrivKey) jkm.getPrivateKey(alias);
+        }
+
+        if (cert == null && key == null) {
+            throw new IllegalArgumentException("JSSEngine.setCertFromAlias: Unable to find certificate and key for specified alias!");
+        }
+    }
+
+    public void setEnabledCipherSuites(String[] suites) throws IllegalArgumentException {
+        logger.debug("JSSEngine: setEnabledCipherSuites(");
+        for (String suite : suites) {
+            logger.debug("\t" + suite + ",");
+        }
+        logger.debug(")");
+
+        JSSParameters parser = new JSSParameters();
+        parser.setCipherSuites(suites);
+
+        if (parser.getSSLCiphers() == null) {
+            enabled_ciphers = null;
+            return;
+        }
+
+        setEnabledCipherSuites(parser.getSSLCiphers());
+    }
+
+    public void setEnabledCipherSuites(SSLCipher[] suites) {
+        logger.debug("JSSEngine: setEnabledCipherSuites(SSLCipher[] ...)");
+        enabled_ciphers = suites.clone();
+    }
+
+    /**
+     * Set the range of SSL protocols supported by this SSLEngine instance.
+     *
+     * Note that this enables all protocols in the range of min(protocols) to
+     * max(protocols), inclusive due to the underlying call to NSS's
+     * SSL_VersionRangeSet(...).
+     */
+    public void setEnabledProtocols(String[] protocols) throws IllegalArgumentException {
+        logger.debug("JSSEngine: setEnabledProtocols(");
+        for (String protocol : protocols) {
+            logger.debug("\t" + protocol + ",");
+        }
+        logger.debug(")");
+
+        JSSParameters parser = new JSSParameters();
+        parser.setProtocols(protocols);
+
+        SSLVersionRange vrange = parser.getSSLVersionRange();
+        setEnabledProtocols(vrange);
+    }
+
+    public void setEnabledProtocols(SSLVersion min, SSLVersion max) throws IllegalArgumentException {
+        logger.debug("JSSEngine: setEnabledProtocols()");
+        if ((min_protocol == null && max_protocol != null) || (min_protocol != null && max_protocol == null)) {
+            throw new IllegalArgumentException("Expected min and max to either both be null or both be not-null; not mixed: (" + min + ", " + max + ")");
+        }
+        min_protocol = min;
+        max_protocol = max;
+    }
+
+    public void setEnabledProtocols(SSLVersionRange vrange) {
+        logger.debug("JSSEngine: setEnabledProtocols()");
+        if (vrange == null) {
+            min_protocol = null;
+            max_protocol = null;
+            return;
+        }
+
+        min_protocol = vrange.getMinVersion();
+        max_protocol = vrange.getMaxVersion();
+    }
+
+    public void setEnableSessionCreation(boolean flag) {
+        logger.debug("JSSEngine: setEnableSessionCreation(" + flag + ") - not implemented");
+    }
+
+    public void setNeedClientAuth(boolean need) {
+        logger.debug("JSSEngine: setNeedClientAuth(" + need + ")");
+        need_client_auth = need;
+    }
+
+    public void setUseClientMode(boolean mode) throws IllegalArgumentException {
+        logger.debug("JSSEngine: setUseClientMode(" + mode + ")");
+        if (ssl_fd != null) {
+            throw new IllegalArgumentException("Cannot change client mode after beginning handshake.");
+        }
+
+        is_client = mode;
+    }
+
+    public void setWantClientAuth(boolean want) {
+        logger.debug("JSSEngine: setWantClientAuth(" + want + ")");
+        want_client_auth = want;
+    }
+
+    /**
+     * Set public and private key material; useful when doing client auth or
+     * if this wasn't provided to the constructor. Can also be used to remove
+     * key material; however note that both arguments must match: either both
+     * certificate and key are null or both are not-null.
+     */
+    public void setKeyMaterials(PK11Cert our_cert, PK11PrivKey our_key) throws IllegalArgumentException {
+        logger.debug("JSSEngine: setKeyMaterials()");
+        if (ssl_fd != null) {
+            throw new RuntimeException("It is too late to call setKeyMaterials when the handshake has already started.");
+        }
+
+        if ((our_cert == null && our_key != null) || (our_cert != null && our_key == null)) {
+            throw new IllegalArgumentException("JSSEngine.setKeyMaterials(): Either both cert and key must be null or both must be not-null");
+        }
+
+        cert = our_cert;
+        key = our_key;
+    }
+
+    /**
+     * Set the internal KeyManager, when present.
+     */
+    public void setKeyManager(JSSKeyManager km) {
+        key_managers = new X509KeyManager[] { km };
+    }
+
+    /**
+     * Set the internal list of KeyManagers.
+     */
+    public void setKeyManagers(X509KeyManager[] xkms) {
+        key_managers = xkms;
+
+    }
+
+    /**
+     * Set the internal TrustManager, when present.
+     */
+    public void setTrustManager(JSSTrustManager tm) {
+        trust_managers = new X509TrustManager[] { tm };
+    }
+
+    /**
+     * Set the internal list of TrustManagers.
+     */
+    public void setTrustManagers(X509TrustManager[] xtms) {
+        trust_managers = xtms;
+    }
+
+    private int computeSize(ByteBuffer[] buffers, int offset, int length) throws IllegalArgumentException {
+        logger.debug("JSSEngine: computeSize()");
+        int result = 0;
+
+        if (buffers == null || buffers.length == 0) {
+            logger.debug("JSSEngine.compueSize(): no buffers - result=" + result);
+            return result;
+        }
+
+        // Semantics of arguments:
+        //
+        // - buffers is where we're reading/writing application data.
+        // - offset is the index of the first buffer we read/write to.
+        // - length is the total number of buffers we read/write to.
+        //
+        // We use a relative index and an absolute index to handle these
+        // constraints.
+        for (int rel_index = 0; rel_index < length; rel_index++) {
+            int index = offset + rel_index;
+            if (index >= buffers.length) {
+                throw new IllegalArgumentException("offset (" + offset + ") or length (" + length + ") exceeds contract based on number of buffers (" + buffers.length + ")");
+            }
+
+            if (rel_index == 0 && buffers[index] == null) {
+                // If our first buffer is null, assume the rest are and skip
+                // everything else. This commonly happens when null is passed
+                // as the src parameter to wrap or when null is passed as the
+                // dst parameter to unwrap.
+                logger.debug("JSSEngine.compueSize(): null first buffer - result=" + result);
+                return result;
+            }
+
+            if (buffers[index] == null) {
+                throw new IllegalArgumentException("Buffer at index " + index + " is null.");
+            }
+
+            result += buffers[index].remaining();
+        }
+
+        logger.debug("JSSEngine.compueSize(): result=" + result);
+
+        return result;
+    }
+
+    private int putData(byte[] data, ByteBuffer[] buffers, int offset, int length) {
+        logger.debug("JSSEngine: putData()");
+        // Handle the rather unreasonable task of moving data into the buffers.
+        // We assume the buffer parameters have already been checked by
+        // computeSize(...); that is, offset/length contracts hold and that
+        // each buffer in the range is non-null.
+        //
+        // We also assume that data.length does not exceed the total number
+        // of bytes the buffers can hold; this is what computeSize(...)'s
+        // return value should ensure. This directly means that the inner
+        // while loop won't exceed the bounds of offset+length.
+
+        int buffer_index = offset;
+        int data_index = 0;
+
+        if (data == null || buffers == null) {
+            return data_index;
+        }
+
+        for (data_index = 0; data_index < data.length; data_index++) {
+            // Ensure we have have a buffer with capacity.
+            while ((buffers[buffer_index] == null || buffers[buffer_index].remaining() <= 0) &&
+                    (buffer_index < offset + length)) {
+                buffer_index += 1;
+            }
+            if (buffer_index >= offset + length) {
+                break;
+            }
+
+            // TODO: use bulk copy
+            buffers[buffer_index].put(data[data_index]);
+        }
+
+        return data_index;
+    }
+
+    private void updateSession() {
+        try {
+            PK11Cert[] peer_chain = SSL.PeerCertificateChain(ssl_fd);
+            session.setPeerCertificates(peer_chain);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private SSLException checkSSLAlerts() {
+        logger.debug("JSSEngine: Checking inbound and outbound SSL Alerts. Have " + ssl_fd.inboundAlerts.size() + " inbound and " + ssl_fd.outboundAlerts.size() + " outbound alerts.");
+
+        // Prefer inbound alerts to outbound alerts.
+        while (ssl_fd.inboundOffset < ssl_fd.inboundAlerts.size()) {
+            SSLAlertEvent event = ssl_fd.inboundAlerts.get(ssl_fd.inboundOffset);
+            ssl_fd.inboundOffset += 1;
+
+            logger.debug("JSSEngine: Got inbound alert: " + event.toString());
+
+            SSLException exception = event.toException();
+            if (exception != null) {
+                return exception;
+            }
+        }
+
+        while (ssl_fd.outboundOffset < ssl_fd.outboundAlerts.size()) {
+            SSLAlertEvent event = ssl_fd.outboundAlerts.get(ssl_fd.outboundOffset);
+            ssl_fd.outboundOffset += 1;
+
+            logger.debug("JSSEngine: Got outbound alert: " + event.toString());
+
+            SSLException exception = event.toException();
+            if (exception != null) {
+                return exception;
+            }
+        }
+
+        return null;
+    }
+
+    private void updateHandshakeState() throws SSLException {
+        logger.debug("JSSEngine: updateHandshakeState()");
+
+        if (seen_exception) {
+            if (ssl_exception != null) {
+                throw ssl_exception;
+            }
+
+            return;
+        }
+
+        // If we're already done, we should check for SSL ALerts.
+        if (!step_handshake && handshake_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
+            logger.debug("JSSEngine.updateHandshakeState() - not handshaking");
+            unknown_state_count = 0;
+
+            ssl_exception = checkSSLAlerts();
+            if (ssl_exception != null) {
+                seen_exception = true;
+                throw ssl_exception;
+            }
+
+            return;
+        }
+
+        // If we've previously finished handshaking, then move to
+        // NOT_HANDSHAKING. Now is also a good time to check for any
+        // alerts.
+        if (!step_handshake && handshake_state == SSLEngineResult.HandshakeStatus.FINISHED) {
+            logger.debug("JSSEngine.updateHandshakeState() - FINISHED to NOT_HANDSHAKING");
+            handshake_state = SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+            unknown_state_count = 0;
+
+            ssl_exception = checkSSLAlerts();
+            if (ssl_exception != null) {
+                seen_exception = true;
+                throw ssl_exception;
+            }
+
+            return;
+        }
+
+        // Before we step the handshake, check our current security status.
+        // This informs us of our possible return codes.
+        SecurityStatusResult preHandshakeStatus = getStatus();
+
+        // Since we're not obviously done handshaking, and the last time we
+        // were called, we were still handshaking, step the handshake.
+        logger.debug("JSSEngine.updateHandshakeState() - forcing handshake");
+        if (SSL.ForceHandshake(ssl_fd) == SSL.SECFailure) {
+            int error_value = PR.GetError();
+
+            if (error_value != PRErrors.WOULD_BLOCK_ERROR) {
+                logger.debug("JSSEngine.updateHandshakeState() - FATAL " + getStatus().toString());
+                ssl_exception = new SSLHandshakeException("Error duing SSL.ForceHandshake() :: " + errorText(error_value));
+                seen_exception = true;
+                handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+                throw ssl_exception;
+            }
+        }
+
+        // Check if we've just finished handshaking.
+        SecurityStatusResult handshakeStatus = getStatus();
+        logger.debug("JSSSEngine.updateHandshakeState() - pre: " + preHandshakeStatus.toString());
+        logger.debug("JSSSEngine.updateHandshakeState() - post: " + handshakeStatus.toString());
+        logger.debug("JSSEngine.updateHandshakeState() - read_buf.read=" + Buffer.ReadCapacity(read_buf) + " read_buf.write=" + Buffer.WriteCapacity(read_buf) + " write_buf.read=" + Buffer.ReadCapacity(write_buf) + " write_buf.write=" + Buffer.WriteCapacity(write_buf));
+
+        // Set NEED_WRAP when we have data to send to the client.
+        if (Buffer.ReadCapacity(write_buf) > 0 && handshake_state != SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+            // Can't write; to read, we need to call wrap to provide more
+            // data to write.
+            logger.debug("JSSEngine.updateHandshakeState() - can write " + Buffer.ReadCapacity(write_buf) + " bytes, NEED_WRAP to process");
+            handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+            unknown_state_count = 0;
+            return;
+        }
+
+        // Delay the check to see if the handshake finished until after we
+        // send the CLIENT FINISHED message and recieved the SERVER FINISHED
+        // message if we're a client. Otherwise, wait to send SERVER FINISHED
+        // message. This is because NSS thinks the handshake has finished
+        // (according to SecurityStatusResult since it has sent the massage)
+        // but we haven't yet gotten around to doing so if we're in a WRAP()
+        // call.
+        if (handshakeStatus.on == 1 && Buffer.ReadCapacity(write_buf) == 0) {
+            logger.debug("JSSEngine.updateHandshakeState() - handshakeStatus.on is 1, so we've just finished handshaking");
+            updateSession();
+            step_handshake = false;
+            handshake_state = SSLEngineResult.HandshakeStatus.FINISHED;
+            unknown_state_count = 0;
+            return;
+        }
+
+        if (Buffer.ReadCapacity(read_buf) == 0 && handshake_state != SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+            // Set NEED_UNWRAP when we have no data to read from the client.
+            logger.debug("JSSEngine.updateHandshakeState() - can read " + Buffer.ReadCapacity(read_buf) + " bytes, NEED_UNWRAP to give us more");
+            handshake_state = SSLEngineResult.HandshakeStatus.NEED_UNWRAP;
+            unknown_state_count = 0;
+            return;
+        }
+
+        unknown_state_count += 1;
+        if (unknown_state_count >= 4) {
+            if (handshake_state == SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+                handshake_state = SSLEngineResult.HandshakeStatus.NEED_UNWRAP;
+            } else {
+                handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+            }
+            unknown_state_count = 1;
+        }
+    }
+
+    private boolean isHandshakeFinished() {
+        logger.debug("JSSEngine: isHandshakeFinished()");
+        return (handshake_state == SSLEngineResult.HandshakeStatus.FINISHED ||
+                (ssl_fd != null && handshake_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING));
+    }
+
+    public void logData() {
+        logger.debug("===BEGIN SSLEngine Information===");
+        logger.debug(" - handshake_state: " + handshake_state + " unknown_state_count: " + unknown_state_count);
+        if (read_buf != null) {
+            logger.debug(" - read_buf.read: " + Buffer.ReadCapacity(read_buf) + " read_buf.write: " + Buffer.WriteCapacity(read_buf));
+        }
+        if (write_buf != null) {
+            logger.debug(" - write_buf.read: " + Buffer.ReadCapacity(write_buf) + " write_buf.write: " + Buffer.WriteCapacity(write_buf));
+        }
+        if (ssl_fd != null) {
+            logger.debug(" - status: " + getStatus().toString());
+        }
+        logger.debug(" - is_inbound_closed: " + is_inbound_closed + " is_outbound_closed: " + is_outbound_closed);
+        logger.debug("===END SSLEngine Information===");
+    }
+
+    public SSLEngineResult unwrap(ByteBuffer src, ByteBuffer[] dsts, int offset, int length) throws IllegalArgumentException, SSLException {
+        logger.debug("JSSEngine: unwrap(ssl_fd=" + ssl_fd + ")");
+        // In this method, we're taking the network wire contents of src and
+        // passing them as the read side of our buffer. If there's any data
+        // for us to read from the remote peer (via ssl_fd), we place it in
+        // the various dsts.
+        //
+        // However, we also need to detect if the handshake is still ongoing;
+        // if so, we can't send data (from src) until then.
+
+        if (ssl_fd == null) {
+            beginHandshake();
+        }
+
+        // wire_data is the number of bytes from src we've written into
+        // read_buf. This is bounded above by src.capcity but also the
+        // free space left in read_buf to write to. Allows us to size the
+        // temporary byte array appropriately.
+        int wire_data = (int) Buffer.WriteCapacity(read_buf);
+        if (src == null) {
+            wire_data = 0;
+        } else {
+            // We need to know how many bytes have been written into src: this
+            // is via src.remaining().
+            wire_data = Math.min(wire_data, src.remaining());
+        }
+
+        // Order of operations:
+        //  1. Read data from srcs
+        //  2. Update handshake status
+        //  3. Write data to dsts
+        //
+        // Since srcs is coming from the data, it could affect our ability to
+        // handshake. It could also affect our ability to write data to dsts,
+        // as src could provide new data to decrypt. When no new data from src
+        // is present, we could have residual steps in handshake(), in which
+        // case no data would be written to dsts. Lastly, even if no new data
+        // from srcs, could still have residual data in read_buf, so we should
+        // attempt to read from the ssl_fd.
+
+        // When we have data from src, write it to read_buf.
+        if (wire_data > 0) {
+            byte[] wire_buffer = new byte[wire_data];
+            src.get(wire_buffer);
+            int written = (int) Buffer.Write(read_buf, wire_buffer);
+
+            // For safety: ensure everything we thought we could write was
+            // actually written. Otherwise, we've done something wrong.
+            wire_data = Math.min(wire_data, written);
+
+            // TODO: Determine if we should write the trail of wire_buffer
+            // back to the front of src... Seems like unnecessary work.
+            logger.debug("JSSEngine.unwrap(): Wrote " + wire_data + " bytes to read_buf.");
+        }
+
+        // In the above, we should always try to read and write data. However,
+        // sometimes updateHandshakeState(...) will throw an exception.
+        // Ideally, we'd still read/write data and save the exception for
+        // later.
+        SSLException excpt = null;
+
+        try {
+            // Check to see if we need to step our handshake process or not.
+            updateHandshakeState();
+        } catch (SSLException e) {
+            excpt = e;
+            assert(excpt == ssl_exception);
+        }
+
+        // Actual amount of data written to the buffer.
+        int app_data = 0;
+
+        // Maximum theoretical amount of data we could've written to the
+        // destination. This is bounded by the lower of both the size of
+        // our dsts and the maximum BUFFER_SIZE. Worst case, we'll be forced
+        // to call unwrap(...) multiple times.
+        int max_app_data = Math.min(computeSize(dsts, offset, length), BUFFER_SIZE);
+
+        // When we have app data to write over the network, go ahead and do
+        // so. This involves reading from ssl_fd and writing to dsts. We don't
+        // currently have a good proxy metric for "can read from a ssl_fd",
+        // so always attempt it if the handshake is finished.
+        if (max_app_data > 0 && isHandshakeFinished()) {
+            byte[] app_buffer = PR.Read(ssl_fd, max_app_data);
+            logger.debug("JSSEngine.unwrap() - " + app_buffer + " error=" + errorText(PR.GetError()));
+            if (app_buffer == null && PR.GetError() == 0) {
+                is_inbound_closed = true;
+            } else {
+                app_data = putData(app_buffer, dsts, offset, length);
+            }
+        }
+
+        // Before we return, check if an exception occurred and throw it if
+        // one did.
+        if (excpt != null) {
+            logger.info("JSSEngine.unwrap() - Got SSLException: " + excpt);
+            ssl_exception = null;
+            handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+            throw excpt;
+        }
+
+        // Need a way to introspect the open/closed state of the TLS
+        // connection.
+
+        logger.debug("JSSEngine.unwrap() - Finished");
+        logger.debug(" - Status: " + SSLEngineResult.Status.OK);
+        logger.debug(" - Handshake State: " + handshake_state);
+        logger.debug(" - wire_data: " + wire_data);
+        logger.debug(" - app_data: " + app_data);
+
+        return new SSLEngineResult(SSLEngineResult.Status.OK, handshake_state, wire_data, app_data);
+    }
+
+    public int writeData(ByteBuffer[] srcs, int offset, int length) {
+        logger.debug("JSSEngine: writeData()");
+        // This is the tough end of reading/writing. There's two potential
+        // places buffering could occur:
+        //
+        //  - Inside the NSS library (unclear if this happens).
+        //  - write_buf
+        //
+        // So when we call PR.Write(ssl_fd, data), it isn't guaranteed that
+        // we can write all of data to ssl_fd (unlike with all our other read
+        // or write operations where we have a clear bound). In the event that
+        // our Write call is truncated, we have to put data back into the
+        // buffer from whence it was read.
+        //
+        // However, we do use Buffer.WriteCapacity(write_buf) as a proxy
+        // metric for how much we can write without having to place data back
+        // in a src buffer.
+        int data_length = 0;
+
+        int index = offset;
+        int max_index = offset + length;
+
+        while (index < max_index) {
+            // If we don't have any remaining bytes in this buffer, skip it.
+            if (srcs[index].remaining() <= 0) {
+                index += 1;
+                continue;
+            }
+            logger.debug("JSSEngine.writeData(): index=" + index + " max_index=" + max_index);
+
+            // We expect (i.e., need to construct a buffer) to write up to
+            // this much. Note that this is non-zero since we're taking the
+            // max here and we guarantee with the previous statement that
+            // srcs[index].remaining() > 0.
+            int expected_write = srcs[index].remaining();
+            logger.debug("JSSEngine.writeData(): expected_write=" + expected_write + " write_cap=" + Buffer.WriteCapacity(write_buf) + " read_cap=" + Buffer.ReadCapacity(read_buf));
+
+            // Get data from our current srcs[index] buffer.
+            byte[] app_data = new byte[expected_write];
+            srcs[index].get(app_data);
+
+            // Actual amount written.
+            int this_write = PR.Write(ssl_fd, app_data);
+            logger.debug("JSSEngine.writeData(): this_write=" + this_write);
+            if (this_write < 0) {
+                int error = PR.GetError();
+                if (error != PRErrors.WOULD_BLOCK_ERROR) {
+                    throw new RuntimeException("Unable to write to internal ssl_fd: " + errorText(PR.GetError()));
+                }
+
+                break;
+            }
+
+            data_length += this_write;
+
+            if (this_write == 0) {
+                // Revert our position to the previous position and break: we
+                // are out of space to write into our SSL FD.
+                int pos = srcs[index].position();
+                int delta = expected_write - this_write;
+                srcs[index].position(pos - delta);
+                break;
+            }
+        }
+
+        logger.debug("JSSEngine.writeData(): data_length=" + data_length);
+
+        return data_length;
+    }
+
+
+    public SSLEngineResult wrap(ByteBuffer[] srcs, int offset, int length, ByteBuffer dst) throws IllegalArgumentException, SSLException {
+        logger.debug("JSSEngine: wrap(ssl_fd=" + ssl_fd + ")");
+        // In this method, we're taking the application data from the various
+        // srcs and writing it to the remote peer (via ssl_fd). If there's any
+        // data for us to send to the remote peer, we place it in dst.
+        //
+        // However, we also need to detect if the handshake is still ongoing;
+        // if so, we can't send data (from src) until then.
+
+        if (ssl_fd == null) {
+            beginHandshake();
+        }
+
+        // Order of operations:
+        //  1. Step the handshake
+        //  2. Write data from srcs to ssl_fd
+        //  3. Write data from write_buf to dst
+        //
+        // This isn't technically locally optimal: it could be that write_buf
+        // is full while we're handshaking so step 1 could be a no-op, but
+        // we could read from write_buf and step the handshake then. However,
+        // on our next call to wrap() would also step the handshake, which
+        // two in a row would almost certainly result in one being a no-op.
+        // Both steps 1 and 2 could write data to dsts. At best 2 will fail if
+        // write_buf is full, however, we'd again end up calling wrap() again
+        // anyways.
+
+        // In the above, we should always try to read and write data. However,
+        // sometimes updateHandshakeState(...) will throw an exception.
+        // Ideally, we'd still read/write data and save the exception for
+        // later.
+        SSLException excpt = null;
+
+        try {
+            // Check to see if we need to step our handshake process or not.
+            updateHandshakeState();
+        } catch (SSLException e) {
+            excpt = e;
+            assert(excpt == ssl_exception);
+        }
+
+        if (excpt == null && ssl_exception == null && seen_exception) {
+            handshake_state = SSLEngineResult.HandshakeStatus.FINISHED;
+        }
+
+        // Actual amount of data read from srcs (and written to ssl_fd). This
+        // is determined by the PR.Write(...) call on ssl_fd.
+        int app_data = 0;
+
+        // Maximum theoretical amount of data we could've read from srcs.
+        // While this isn't strictly bounded above by BUFFER_SIZE (as it is
+        // being written to ssl_fd instead of to read_buf or write_buf), we're
+        // better off limiting ourselves to a reasonable limit.
+        int max_app_data = Math.min(computeSize(srcs, offset, length), BUFFER_SIZE);
+
+        // Try writing data from srcs to
+        if (max_app_data > 0 && isHandshakeFinished()) {
+            logger.debug("JSSEngine.wrap(): writing from srcs to buffer...");
+            app_data = writeData(srcs, offset, length);
+        } else {
+            logger.debug("JSSEngine.wrap(): not writing from srcs to buffer: max_app_data=" + max_app_data + " handshake_finished=" + isHandshakeFinished());
+        }
+
+        // wire_data is the number of bytes written to dst. This is bounded
+        // above by two fields: the number of bytes we can read from
+        // write_buf, and the size of dst, if present.
+        int wire_data = (int) Buffer.ReadCapacity(write_buf);
+        if (dst == null) {
+            wire_data = 0;
+        } else {
+            // We want to know how much free space there is in dst for us to
+            // write to. This is given by dst.remaining().
+            wire_data = Math.min(wire_data, dst.remaining());
+        }
+
+        // Try reading data from write_buf to dst
+        if (wire_data > 0) {
+            byte[] wire_buffer = Buffer.Read(write_buf, wire_data);
+            dst.put(wire_buffer);
+            logger.debug("JSSEngine.wrap() - Wrote " + wire_buffer.length + " bytes to dst.");
+        }
+
+        // Before we return, check if an exception occurred and throw it if
+        // one did.
+        if (excpt != null) {
+            logger.info("JSSEngine.wrap() - Got SSLException: " + excpt);
+            ssl_exception = null;
+            throw excpt;
+        }
+
+        // Need a way to introspect the open/closed state of the TLS
+        // connection.
+
+        SSLEngineResult.Status handshake_status = SSLEngineResult.Status.OK;
+
+        if (ssl_exception == null && seen_exception) {
+            handshake_status = SSLEngineResult.Status.CLOSED;
+            closeInbound();
+            closeOutbound();
+        }
+
+        logger.debug("JSSEngine.wrap() - Finished");
+        logger.debug(" - Status: " + handshake_status);
+        logger.debug(" - Handshake State: " + handshake_state);
+        logger.debug(" - wire_data: " + wire_data);
+        logger.debug(" - app_data: " + app_data);
+        return new SSLEngineResult(handshake_status, handshake_state, app_data, wire_data);
+    }
+}

--- a/org/mozilla/jss/ssl/javax/JSSSession.java
+++ b/org/mozilla/jss/ssl/javax/JSSSession.java
@@ -1,0 +1,156 @@
+package org.mozilla.jss.ssl.javax;
+
+import java.security.cert.Certificate;
+import javax.security.cert.X509Certificate;
+import java.security.Principal;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+public class JSSSession implements SSLSession {
+    private int application_buffer_size;
+    private String cipher_suite;
+    private long creation_time;
+    private byte[] session_id;
+    private long last_access_time;
+    private Certificate[] local_certificates;
+    private Principal local_principal;
+    private int packet_buffer_size;
+    private X509Certificate[] peer_chain;
+    private Certificate[] peer_certificates;
+    private String peer_host;
+    private int peer_port;
+    private Principal peer_principal;
+    private String protocol;
+
+    JSSSession(int buffer_size) {
+        creation_time = System.currentTimeMillis();
+        application_buffer_size = buffer_size;
+        packet_buffer_size = buffer_size;
+        setLastAccessedTime();
+    }
+
+    public byte[] getId() {
+        return session_id;
+    }
+
+    protected void setId(byte[] new_id) {
+        session_id = new_id;
+        setLastAccessedTime();
+    }
+
+    public SSLSessionContext getSessionContext() {
+        return null;
+    }
+
+    public long getCreationTime() {
+        return creation_time;
+    }
+
+    public long getLastAccessedTime() {
+        return last_access_time;
+    }
+
+    protected void setLastAccessedTime() {
+        last_access_time = System.currentTimeMillis();
+    }
+
+    public void invalidate() {}
+    public boolean isValid() { return true; }
+    public void putValue(String name, Object value) {}
+    public Object getValue(String name) { return null; }
+    public void removeValue(String name) {}
+    public String[] getValueNames() { return null; }
+
+    public Certificate[] getPeerCertificates() {
+        return peer_certificates;
+    }
+
+    protected void setPeerCertificates(Certificate[] new_certs) {
+        peer_certificates = new_certs;
+        setLastAccessedTime();
+    }
+
+    public Certificate[] getLocalCertificates() {
+        return local_certificates;
+    }
+
+    protected void setLocalCertificates(Certificate[] new_certs) {
+        local_certificates = new_certs;
+        setLastAccessedTime();
+    }
+
+    public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
+        if (peer_chain == null) {
+            throw new SSLPeerUnverifiedException("");
+        }
+        return peer_chain;
+    }
+
+    protected void setPeerCertificateChain(X509Certificate[] new_chain) {
+        peer_chain = new_chain;
+        setLastAccessedTime();
+    }
+
+    public Principal getPeerPrincipal() {
+        return peer_principal;
+    }
+
+    protected void setPeerPrincipal(Principal new_principal) {
+        peer_principal = new_principal;
+        setLastAccessedTime();
+    }
+
+    public Principal getLocalPrincipal() {
+        return local_principal;
+    }
+
+    protected void setLocalPrincipal(Principal new_principal) {
+        local_principal = new_principal;
+        setLastAccessedTime();
+    }
+
+    public String getCipherSuite() {
+        return cipher_suite;
+    }
+
+    protected void setCipherSuite(String new_suite) {
+        cipher_suite = new_suite;
+        setLastAccessedTime();
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    protected void setProtocol(String new_protocol) {
+        protocol = new_protocol;
+        setLastAccessedTime();
+    }
+
+    public String getPeerHost() {
+        return peer_host;
+    }
+
+    public void setPeerHost(String new_host) {
+        peer_host = new_host;
+        setLastAccessedTime();
+    }
+
+    public int getPeerPort() {
+        return peer_port;
+    }
+
+    public void setPeerPort(int new_port) {
+        peer_port = new_port;
+        setLastAccessedTime();
+    }
+
+    public int getPacketBufferSize() {
+        return packet_buffer_size;
+    }
+
+    public int getApplicationBufferSize() {
+        return application_buffer_size;
+    }
+}

--- a/org/mozilla/jss/tests/TestSSLEngine.java
+++ b/org/mozilla/jss/tests/TestSSLEngine.java
@@ -1,0 +1,354 @@
+package org.mozilla.jss.tests;
+
+import java.lang.*;
+import java.nio.*;
+import java.util.*;
+import java.security.*;
+import javax.net.ssl.*;
+
+import org.mozilla.jss.*;
+import org.mozilla.jss.nss.*;
+import org.mozilla.jss.ssl.*;
+import org.mozilla.jss.ssl.javax.*;
+import org.mozilla.jss.provider.javax.crypto.*;
+
+public class TestSSLEngine {
+    public static void initialize(String[] args) throws Exception {
+        CryptoManager.initialize(args[0]);
+        CryptoManager cm = CryptoManager.getInstance();
+        cm.setPasswordCallback(new FilePasswordCallback(args[1]));
+    }
+
+    public static void testProvided() throws Exception {
+        SSLContext ctx = SSLContext.getDefault();
+        System.err.println(ctx.getProvider());
+
+        SSLEngine raw_eng = ctx.createSSLEngine();
+        assert(raw_eng instanceof JSSEngine);
+    }
+
+    public static JSSParameters createParameters(String alias) throws Exception {
+        JSSParameters params = new JSSParameters();
+
+        params.setProtocols(SSLVersion.TLS_1_2, SSLVersion.TLS_1_3);
+        params.setAlias(alias);
+        params.setHostname("localhost");
+
+        return params;
+    }
+
+    public static KeyManager[] getKMs() throws Exception {
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NssX509");
+        return kmf.getKeyManagers();
+    }
+
+    public static TrustManager[] getTMs() throws Exception {
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("NssX509");
+        return tmf.getTrustManagers();
+    }
+
+    public static void testHandshake(JSSEngine client_eng, JSSEngine server_eng) throws Exception {
+        // Ensure we exit in case of a bug... :-)
+        int counter = 0;
+        int max_steps = 20;
+        int max_data = client_eng.getSession().getApplicationBufferSize();
+
+        boolean client_done = false;
+        boolean server_done = false;
+
+        ArrayList<ByteBuffer> c2s_buffers = new ArrayList<ByteBuffer>();
+        ArrayList<ByteBuffer> s2c_buffers = new ArrayList<ByteBuffer>();
+        for (counter = 0; counter < max_steps; counter++) {
+            SSLEngineResult.HandshakeStatus client_state = client_eng.getHandshakeStatus();
+            SSLEngineResult.HandshakeStatus server_state = server_eng.getHandshakeStatus();
+            System.err.println("client_done=" + client_done + " | client_eng.getHandshakeStatus()=" + client_state + " | c2s_buffers.size=" + c2s_buffers.size());
+            System.err.println("server_done=" + server_done + " | server_eng.getHandshakeStatus()=" + server_state + " | s2c_buffers.size=" + s2c_buffers.size());
+
+            System.err.println("\n\n=====BEGIN CLIENT=====");
+
+            if (!client_done && client_state == SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+                ByteBuffer src = null;
+                ByteBuffer dst = ByteBuffer.allocate(max_data);
+
+                SSLEngineResult r = client_eng.wrap(src, dst);
+                dst.flip();
+
+                if (r.getStatus() != SSLEngineResult.Status.OK) {
+                    throw new RuntimeException("Unknown result from client_eng.wrap(): " + r.getStatus());
+                } else if (dst.hasRemaining()) {
+                    // Since we flipped our buffer, we can use hasRemaining()
+                    // to check if there's data we should unwrap on the client
+                    // side. There is, so add it to the candidates.
+                    c2s_buffers.add(dst);
+                }
+            } else if (!client_done && client_state == SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+                while (s2c_buffers.size() > 0) {
+                    ByteBuffer src = s2c_buffers.remove(0);
+                    ByteBuffer dst = null;
+
+                    SSLEngineResult r = client_eng.unwrap(src, dst);
+                    if (r.getStatus() != SSLEngineResult.Status.OK) {
+                        throw new RuntimeException("Unknown result from client_eng.unwrap(): " + r.getStatus());
+                    } else if (src.hasRemaining()) {
+                        // Since we have bytes left after reading it, put it
+                        // back on the front of the stack.
+                        s2c_buffers.add(0, src);
+
+                        // After only partially reading a buffer, it is
+                        // unlikely that we'll be able to continue, so break.
+                        break;
+                    } else if (r.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+                        break;
+                    }
+                }
+            } else if (counter > 1 && !client_done && (client_state == SSLEngineResult.HandshakeStatus.FINISHED || client_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING)) {
+                System.err.println("Client: " + server_eng.getHandshakeStatus());
+                client_done = true;
+            } else if (!client_done) {
+                throw new RuntimeException("Unknown status for client_eng: " + client_state);
+            }
+
+            System.err.println("=====END CLIENT=====\n\n");
+            System.err.println("\n\n=====BEGIN SERVER=====");
+
+            if (!server_done && server_state == SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+                ByteBuffer src = null;
+                ByteBuffer dst = ByteBuffer.allocate(max_data);
+
+                SSLEngineResult r = server_eng.wrap(src, dst);
+                dst.flip();
+
+                if (r.getStatus() != SSLEngineResult.Status.OK) {
+                    throw new RuntimeException("Unknown result from server_eng.wrap(): " + r.getStatus());
+                } else if (dst.hasRemaining()) {
+                    // Since we flipped our buffer, we can use hasRemaining()
+                    // to check if there's data we should unwrap on the client
+                    // side. There is, so add it to the candidates.
+                    s2c_buffers.add(dst);
+                }
+            } else if (!server_done && server_state == SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+                while (c2s_buffers.size() > 0) {
+                    ByteBuffer src = c2s_buffers.remove(0);
+                    ByteBuffer dst = null;
+
+                    SSLEngineResult r = server_eng.unwrap(src, dst);
+                    if (r.getStatus() != SSLEngineResult.Status.OK) {
+                        throw new RuntimeException("Unknown result from server_eng.unwrap(): " + r.getStatus());
+                    } else if (src.hasRemaining()) {
+                        // Since we have bytes left after reading it, put it
+                        // back on the front of the stack.
+                        c2s_buffers.add(0, src);
+
+                        // After only partially reading a buffer, it is
+                        // unlikely that we'll be able to continue, so break.
+                        break;
+                    } else if (r.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+                        break;
+                    }
+                }
+            } else if (counter > 1 && !server_done && (server_state == SSLEngineResult.HandshakeStatus.FINISHED || server_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING)) {
+                System.err.println("Server: " + server_eng.getHandshakeStatus());
+                server_done = true;
+            } else if (!server_done) {
+                throw new RuntimeException("Unknown status for server handshake status: " + server_state);
+            }
+            System.err.println("=====END SERVER=====\n\n");
+
+            if (client_done && server_done) {
+                assert(c2s_buffers.size() == 0);
+                assert(s2c_buffers.size() == 0);
+
+                break;
+            }
+        }
+
+        if (counter == max_steps) {
+            throw new RuntimeException("Unable to complete a handshake in " + max_steps + " steps; assuming we were stuck in an infinite loop: c2s_buffers.size=" + c2s_buffers.size() + " s2c_buffers.size=" + s2c_buffers.size());
+        }
+    }
+
+    public static void testSendData(JSSEngine send, JSSEngine recv, ByteBuffer mesg, ByteBuffer inter, ByteBuffer dest) throws Exception {
+        int start_pos = mesg.position();
+        int mesg_size = mesg.remaining();
+        int counter = 0;
+        int max_counter = 10;
+
+        SSLEngineResult r;
+
+        for (counter = 0; counter < max_counter; counter++) {
+            r = send.wrap(mesg, inter);
+            inter.flip();
+
+            System.err.println("Bytes of plaintext message: " + mesg_size);
+
+            if (r.getStatus() != SSLEngineResult.Status.OK) {
+                throw new RuntimeException("Unknown result from send.wrap(): " + r.getStatus());
+            } else if (inter.hasRemaining()) {
+                break;
+            }
+        }
+        if (counter == max_counter) {
+            throw new RuntimeException("Reasonably expected to get encrypted data during wrap.");
+        }
+
+        System.err.println("Bytes of ciphertext message: " + inter.remaining());
+        assert(inter.remaining() >= mesg_size);
+
+        r = recv.unwrap(inter, dest);
+        dest.flip();
+
+        if (r.getStatus() != SSLEngineResult.Status.OK) {
+            throw new RuntimeException("Unknown result from send.wrap(): " + r.getStatus());
+        } else if (!dest.hasRemaining()) {
+            throw new RuntimeException("Reasonably expected to get encrypted data during unwrap.");
+        }
+
+        System.err.println("Bytes of decrypted message: " + dest.remaining());
+
+        mesg.position(start_pos);
+        byte[] orig = new byte[dest.remaining()];
+        byte[] copy = new byte[dest.remaining()];
+
+        mesg.get(orig);
+        dest.get(copy);
+
+        if (!Arrays.equals(orig, copy)) {
+            throw new RuntimeException("Expected data received to equal that sent!");
+        }
+    }
+
+    public static void testPostHandshakeTransfer(JSSEngine client_eng, JSSEngine server_eng) throws Exception {
+        assert(client_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING || client_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.FINISHED);
+        assert(server_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING || server_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.FINISHED);
+
+        // Ensure we exit in case of a bug... :-)
+        int counter = 0;
+        int max_data = client_eng.getSession().getApplicationBufferSize();
+
+        ByteBuffer client_msg = ByteBuffer.wrap("Cooking MCs".getBytes());
+        ByteBuffer c2s_buffer = ByteBuffer.allocate(max_data);
+        ByteBuffer server_unwrap = ByteBuffer.allocate(max_data);
+        testSendData(client_eng, server_eng, client_msg, c2s_buffer, server_unwrap);
+
+        ByteBuffer server_msg = ByteBuffer.wrap("like a pound of bacon".getBytes());
+        ByteBuffer s2c_buffer = ByteBuffer.allocate(max_data);
+        ByteBuffer client_unwrap = ByteBuffer.allocate(max_data);
+        testSendData(server_eng, client_eng, server_msg, s2c_buffer, client_unwrap);
+    }
+
+    public static void sendData(JSSEngine send, JSSEngine recv) throws Exception {
+        int counter = 0;
+        int max_tries = 20;
+        int max_data = send.getSession().getApplicationBufferSize();
+
+        ByteBuffer src = null;
+        ByteBuffer transfer = ByteBuffer.allocate(max_data);
+        ByteBuffer read = ByteBuffer.allocate(max_data);
+
+        SSLEngineResult r = null;
+
+        for (counter = 0; counter < max_tries; counter++) {
+            r = send.wrap(src, transfer);
+            transfer.flip();
+
+            if (r.getStatus() != SSLEngineResult.Status.OK) {
+                throw new RuntimeException("Unknown result from send.wrap(): " + r.getStatus());
+            } else if (transfer.hasRemaining()) {
+                break;
+            }
+        }
+
+        if (counter == max_tries) {
+            throw new RuntimeException("Reasonably expected to send CLOSE_NOTIFY alert to other party.");
+        }
+
+        r = recv.unwrap(transfer, read);
+        read.flip();
+
+        if (r.getStatus() != SSLEngineResult.Status.OK) {
+            throw new RuntimeException("Unknown result from recv.unwrap(): " + r.getStatus());
+        } else if (read.hasRemaining()) {
+            throw new RuntimeException("Expected not to recieve any data but got " + read.remaining() + " bytes during unwrap.");
+        }
+    }
+
+    public static void testClose(JSSEngine client_eng, JSSEngine server_eng) throws Exception {
+        assert(client_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING || client_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.FINISHED);
+        assert(server_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING || server_eng.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.FINISHED);
+        assert(client_eng.getStatus().on == 1);
+        assert(server_eng.getStatus().on == 1);
+        assert(client_eng.isInboundDone() == false);
+        assert(server_eng.isInboundDone() == false);
+
+        client_eng.closeOutbound();
+        assert(client_eng.isOutboundDone() == true);
+        sendData(client_eng, server_eng);
+        assert(server_eng.isInboundDone() == true);
+
+        server_eng.closeOutbound();
+        assert(server_eng.isOutboundDone() == true);
+        sendData(server_eng, client_eng);
+        assert(client_eng.isInboundDone() == true);
+    }
+
+    public static void testBasicHandshake(SSLContext ctx, String client_alias, String server_alias) throws Exception {
+        JSSEngine client_eng = (JSSEngine) ctx.createSSLEngine();
+        client_eng.setSSLParameters(createParameters(client_alias));
+        client_eng.setUseClientMode(true);
+        client_eng.beginHandshake();
+
+        System.err.println("client_eng protocols: ");
+        for (String version : client_eng.getEnabledProtocols()) {
+            System.err.println(" - " + version);
+        }
+
+        JSSEngine server_eng = (JSSEngine) ctx.createSSLEngine();
+        server_eng.setSSLParameters(createParameters(server_alias));
+        server_eng.setUseClientMode(false);
+        server_eng.beginHandshake();
+
+        testHandshake(client_eng, server_eng);
+        testPostHandshakeTransfer(client_eng, server_eng);
+        testClose(client_eng, server_eng);
+    }
+
+    public static void testBasicClientServer(String[] args) throws Exception {
+        SSLContext ctx = SSLContext.getDefault();
+        ctx.init(getKMs(), getTMs(), null);
+
+        String client_alias = args[2];
+        String server_alias = args[3];
+
+        testBasicHandshake(ctx, client_alias, server_alias);
+    }
+
+    public static void testNativeClientServer(String[] args) throws Exception {
+        SSLContext ctx = SSLContext.getDefault();
+        ctx.init(getKMs(), new TrustManager[] { new JSSNativeTrustManager() }, null);
+
+        String client_alias = args[2];
+        String server_alias = args[3];
+
+        testBasicHandshake(ctx, client_alias, server_alias);
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Args:
+        //  - nssdb
+        //  - nssdb password
+        //  - client cert
+        //  - server cert
+
+        System.out.println("Initializing CryptoManager...");
+        initialize(args);
+
+        System.out.println("Testing provided instance...");
+        testProvided();
+
+        System.out.println("Testing basic handshake with TMs from provider...");
+        testBasicClientServer(args);
+
+        System.out.println("Testing basic handshake with native TM...");
+        testBasicClientServer(args);
+    }
+}


### PR DESCRIPTION
Initial test case for the [`SSLEngine`](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLEngine.html) implementation in #150. Will be rebased once that is merged.

Checklist of tests:
 - [x] We create a JSSEngine by default after registering the provider. 
 - [x] We can do a basic handshake.
 - [x] We can send data.
 - [ ] We fail to handshake with an invalid certificate.
 - [ ] We test client authentication.
 - [ ] We test HSM-backed keys.
 - [ ] We interoperate with and can handshake with JSSE's SSLEngine.
     - [ ] server: JSSE -- client: JSS
     - [ ] server: JSS -- client: JSSE
 - [ ] We follow CryptoPolicies by default. 
 - [ ] We interoperate with `openssl` or similar.

For reference, the Oracle standard test is in [my testbed](https://github.com/cipherboy/testbed/tree/master/java-sslengine).

---

Only the commits after "Begin `TestSSLEngine.java`" are unique to this PR. The rest are rebased from #150. 