### PR TITLE
Update PKCS11Constants

### DIFF
--- a/org/mozilla/jss/pkcs11/PKCS11Constants.java
+++ b/org/mozilla/jss/pkcs11/PKCS11Constants.java
@@ -4631,6 +4631,13 @@ public interface PKCS11Constants {
      *
      * Source file: /usr/include/nss3/pkcs11n.h
      */
+    public static final long CKM_NSS_CHACHA20_CTR = 0xCE534371L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
     public static final long CKM_NETSCAPE_PBE_SHA1_DES_CBC = 0x80000002L;
 
     /**


### PR DESCRIPTION
This includes the new ChaCha20 constant, `CKM_NSS_CHACHA20_CTR`,
introduced in upstream commit [e9fdd32dc33febcd0a3fcd46de1b223781b6960a](https://github.com/nss-dev/nss/commit/e9fdd32dc33febcd0a3fcd46de1b223781b6960a).

Fixes the test suite failure due to differences between our PKCS11Constants and NSS's versions. Noted in #195. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`