### PR TITLE
[nss.PR] Create BufferPRFD when peer_info is null

### DIFF
--- a/org/mozilla/jss/nss/PR.c
+++ b/org/mozilla/jss/nss/PR.c
@@ -69,7 +69,7 @@ Java_org_mozilla_jss_nss_PR_NewBufferPRFD(JNIEnv *env, jclass clazz,
         return result;
     }
 
-    if (!JSS_FromByteArray(env, peer_info, &real_peer_info, &peer_info_len)) {
+    if (peer_info != NULL && !JSS_FromByteArray(env, peer_info, &real_peer_info, &peer_info_len)) {
         return result;
     }
 


### PR DESCRIPTION
Unlike `read_buf` or `write_buf`, peer_info can reasonably be null; handle
this gracefully and create the `BufferPRFD` instead of returning a null
`PRFDProxy` reference.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`