### PR TITLE
Test SSL handshake without TCP model

### DIFF
--- a/org/mozilla/jss/tests/TestBufferPRFD.java
+++ b/org/mozilla/jss/tests/TestBufferPRFD.java
@@ -47,12 +47,8 @@ public class TestBufferPRFD {
     }
 
     public synchronized static PRFDProxy Setup_NSS_Client(PRFDProxy fd, String host) {
-        PRFDProxy model = SSL.ImportFD(null, PR.NewTCPSocket());
-        assert(model != null);
-
-        fd = SSL.ImportFD(model, fd);
+        fd = SSL.ImportFD(null, fd);
         assert(fd != null);
-        PR.Close(model);
 
         assert(SSL.ResetHandshake(fd, false) == 0);
         assert(SSL.SetURL(fd, host) == 0);
@@ -63,12 +59,8 @@ public class TestBufferPRFD {
     public synchronized static PRFDProxy Setup_NSS_Server(PRFDProxy fd, String host,
         PK11Cert cert, PK11PrivKey key) throws Exception
     {
-        PRFDProxy model = SSL.ImportFD(null, PR.NewTCPSocket());
-        assert(model != null);
-
-        fd = SSL.ImportFD(model, fd);
+        fd = SSL.ImportFD(null, fd);
         assert(fd != null);
-        PR.Close(model);
 
         assert(SSL.ConfigSecureServer(fd, cert, key, 1) == 0);
         assert(SSL.ConfigServerSessionIDCache(1, 100, 100, null) == 0);


### PR DESCRIPTION
The [NSS documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/SSL_functions/sslfnc.html#1085950) allows `SSL_ImportFD` to take a null first
parameter; in this case, NSS defaults will be used instead of defaults
from the model. Since we're creating the model *with* default parameters
(and not really saving a global model with updated parameters), don't
bother creating a model `PRFileDesc`.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`