### PR TITLE
Switch to SSL_ConfigServerCert

### DIFF
--- a/org/mozilla/jss/ssl/SSLServerSocket.c
+++ b/org/mozilla/jss/ssl/SSLServerSocket.c
@@ -216,7 +216,6 @@ Java_org_mozilla_jss_ssl_SSLServerSocket_setServerCert(
     CERTCertificate* cert=NULL;
     PK11SlotInfo* slot=NULL;
     SECKEYPrivateKey* privKey=NULL;
-    SSLKEAType certKEA;
     SECStatus status;
 
     if( certObj == NULL ) {
@@ -237,8 +236,7 @@ Java_org_mozilla_jss_ssl_SSLServerSocket_setServerCert(
 
     privKey = PK11_FindPrivateKeyFromCert(slot, cert, NULL);
     if (privKey != NULL) {
-        certKEA = NSS_FindCertKEAType(cert);
-        status = SSL_ConfigSecureServer(sock->fd, cert, privKey, certKEA); 
+        status = SSL_ConfigServerCert(sock->fd, cert, privKey, NULL, 0);
         if( status != SECSuccess) {
             JSSL_throwSSLSocketException(env,
                 "Failed to configure secure server certificate and key");


### PR DESCRIPTION
In `SSLServerSocket.c`, we use the deprecated form, `SSL_ConfigSecureServer`.
Switch to using the newer form, `SSL_ConfigServerCert`. This also saves us
a call to check the KEA usage.

`SSL_ConfigSecureServer` [deprecation notice](https://github.com/nss-dev/nss/blob/master/lib/ssl/ssl.h#L986-L998).

`SSL_ConfigServerCert` [description](https://github.com/nss-dev/nss/blob/master/lib/ssl/ssl.h#L933-L984).

NSS likely won't remove `SSL_ConfigSecureServer`, but we might as well do our part to help with its deprecation. Since we're just querying KEA directly, passing the default `NULL` struct will do the same. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`