### PR TITLE
Terminate SSL test cases after too many attempts

### DIFF
--- a/org/mozilla/jss/tests/TestBufferPRFD.c
+++ b/org/mozilla/jss/tests/TestBufferPRFD.c
@@ -313,6 +313,8 @@ int main(int argc, char** argv)
      * size, we'll be able to step one of the two sides until something useful
      * happens. */
     printf("Trying handshake...\n");
+
+    int count = 0;
     while (!is_finished(c_nspr, s_nspr)) {
         printf("Client Handshake:\n");
         if (SSL_ForceHandshake(c_nspr) != SECSuccess) {
@@ -335,6 +337,10 @@ int main(int argc, char** argv)
         }
 
         printf("\n\n");
+        count += 1;
+        if (count >= 40) {
+            fprintf(stderr, "error: unable to make progress after %d steps!\n", count);
+        }
     }
 
     /* Send a test message from client -> server to ensure that the connection

--- a/org/mozilla/jss/tests/TestBufferPRFD.java
+++ b/org/mozilla/jss/tests/TestBufferPRFD.java
@@ -140,6 +140,7 @@ public class TestBufferPRFD {
         assert(!IsHandshakeFinished(c_nspr, s_nspr));
 
         /* Try a handshake */
+        int count = 0;
         while(!IsHandshakeFinished(c_nspr, s_nspr)) {
             if (SSL.ForceHandshake(c_nspr) != SSL.SECSuccess) {
                 int error = PR.GetError();
@@ -156,6 +157,12 @@ public class TestBufferPRFD {
                     System.out.println("Unexpected error: " + new String(PR.ErrorToName(error)) + " (" + error + ")");
                     System.exit(1);
                 }
+            }
+
+            count += 1;
+            if (count >= 40) {
+                System.err.println("Error: unable to make progress after " + count + " steps!");
+                System.exit(1);
             }
         }
         System.out.println("Handshake completed successfully!\n");


### PR DESCRIPTION
When the handshake fails to complete in a certain number of steps,
terminate it. We set this limit as 40 as it should be significantly
larger than the number of required steps (since the buffer limit is at
2048, we'd expect no more than 10 steps, even with a large certificate
or chain).

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`