### PR TITLE
Add alternative HMAC names for JSSProvider

### DIFF
--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -236,6 +236,10 @@ public final class JSSProvider extends java.security.Provider {
         put("Mac.HmacSHA512",
             "org.mozilla.jss.provider.javax.crypto.JSSMacSpi$HmacSHA512");
         put("Alg.Alias.Mac.Hmac-SHA512", "HmacSHA512");
+        put("Alg.Alias.Mac.SHA-1-HMAC", "HmacSHA1");
+        put("Alg.Alias.Mac.SHA-256-HMAC", "HmacSHA256");
+        put("Alg.Alias.Mac.SHA-384-HMAC", "HmacSHA384");
+        put("Alg.Alias.Mac.SHA-512-HMAC", "HmacSHA512");
 
 
         /////////////////////////////////////////////////////////////


### PR DESCRIPTION
As mentioned in [`dogtagpki/pki pr#230`](https://github.com/dogtagpki/pki/pull/230), we should add these to the JSS provider to avoid the need for `CryptoUtil.getHMACAlgName(...)`. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`