### PR TITLE
Rename HMACTest -> CrossHMACTest

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -187,7 +187,7 @@ macro(jss_tests)
     )
     jss_test_java(
         NAME "HMAC"
-        COMMAND "org.mozilla.jss.tests.HMACTest" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
+        COMMAND "org.mozilla.jss.tests.CrossHMACTest" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
         DEPENDS "Setup_DBs"
     )
     jss_test_java(
@@ -288,7 +288,7 @@ macro(jss_tests)
         )
         jss_test_java(
             NAME "HMAC_FIPSMODE"
-            COMMAND "org.mozilla.jss.tests.HMACTest" "${RESULTS_NSSDB_FIPS_OUTPUT_DIR}" "${PASSWORD_FILE}"
+            COMMAND "org.mozilla.jss.tests.CrossHMACTest" "${RESULTS_NSSDB_FIPS_OUTPUT_DIR}" "${PASSWORD_FILE}"
             DEPENDS "Enable_FipsMODE"
         )
         jss_test_java(

--- a/org/mozilla/jss/tests/CrossHMACTest.java
+++ b/org/mozilla/jss/tests/CrossHMACTest.java
@@ -15,12 +15,12 @@ import org.mozilla.jss.util.PasswordCallback;
 
 /**
  * HMAC is a hash function based message authentication code.
- * HMACTest compares the HMAC created by Mozilla, IBM and Sun JCE.
+ * CrossHMACTest compares the HMAC created by Mozilla, IBM and Sun JCE.
  *
  * @author  Sandeep.Konchady@Sun.COM
  * @version 1.0
  */
-public class HMACTest {
+public class CrossHMACTest {
 
     private CryptoManager cm;
     /**
@@ -34,10 +34,10 @@ public class HMACTest {
         "HmacSHA384", "HmacSHA512"
     };
 
-    public HMACTest(String[] argv) throws Exception {
+    public CrossHMACTest(String[] argv) throws Exception {
         if (argv.length < 1) {
             System.out.println(
-                    "Usage: java org.mozilla.jss.tests.HMACTest " +
+                    "Usage: java org.mozilla.jss.tests.CrossHMACTest " +
                     "<dbdir> [password file only needed in FIPS mode]");
             System.exit(1);
         }
@@ -127,7 +127,7 @@ public class HMACTest {
     public static void main(String[] argv) {
 
         try {
-            HMACTest hmacTest = new HMACTest(argv);
+            CrossHMACTest hmacTest = new CrossHMACTest(argv);
 
             //The secret key must be a JSS key. That is, it must be an 
             //instanceof org.mozilla.jss.crypto.SecretKeyFacade.


### PR DESCRIPTION
On systems with case-insensitive file systems, cloning will likely fail
as there's two files with the "same" name but different contents:
`HmacTest.java` and `HMACTest.java`. Rename the latter, which attempts to
test different providers, to `CrossHMACTest`.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`