### PR TITLE
Fix SHA1-HMAC in SymmetricKey

### DIFF
--- a/org/mozilla/jss/crypto/KeyGenAlgorithm.java
+++ b/org/mozilla/jss/crypto/KeyGenAlgorithm.java
@@ -108,6 +108,12 @@ public class KeyGenAlgorithm extends Algorithm {
             "PBA/SHA1/HMAC", new FixedKeyStrengthValidator(160),
             null, PBEKeyGenParams.class );
 
+    public static final KeyGenAlgorithm
+    SHA1_HMAC = new KeyGenAlgorithm(
+        CKM_SHA_1_HMAC,
+            "SHA1/HMAC", new FixedKeyStrengthValidator(160),
+            null, null );
+
     //////////////////////////////////////////////////////////////
     public static final KeyGenAlgorithm
     AES = new KeyGenAlgorithm(CKM_AES_KEY_GEN, "AES",

--- a/org/mozilla/jss/crypto/SymmetricKey.java
+++ b/org/mozilla/jss/crypto/SymmetricKey.java
@@ -63,6 +63,8 @@ public interface SymmetricKey {
         public static final Type RC4 = new Type("RC4", KeyGenAlgorithm.RC4);
         public static final Type RC2 = new Type("RC2", KeyGenAlgorithm.RC2);
         public static final Type SHA1_HMAC = new Type("SHA1_HMAC",
+            KeyGenAlgorithm.SHA1_HMAC);
+        public static final Type PBA_SHA1_HMAC = new Type("PBA_SHA1_HMAC",
             KeyGenAlgorithm.PBA_SHA1_HMAC);
         public static final Type AES = new Type("AES", KeyGenAlgorithm.AES);
 


### PR DESCRIPTION
In `SymmetricKey.java`, SHA-1 HMAC was defined as [`PBA_SHA1_HMAC`](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/os/pkcs11-curr-v2.40-os.html#_Toc228894782), a version
of HMAC for extending a password (using a salt) and turning it into a
key. Usually when one requests HMAC, one expects vanilla HMAC; use this
instead. We expose the old `SHA1_HMAC` (with PBA) as `PBA_SHA1_HMAC` now.
Note that later SHA-2 and SHA-3 algorithms lack PBA-based HMACs (in PKCS
v2.40 and v3.0 standards).

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`