### PR TITLE
Add SHA2 HMAC

### DIFF
--- a/org/mozilla/jss/crypto/Algorithm.c
+++ b/org/mozilla/jss/crypto/Algorithm.c
@@ -94,8 +94,11 @@ JSS_AlgInfo JSS_AlgTable[NUM_ALGS] = {
 /* 64 */    {SEC_OID_AES_256_CBC, SEC_OID_TAG},
 /* the CKM_AES_KEY_WRAP_* have different defs than CKM_NSS_AES_KEY_WRAP_*  */
 /* 65 */    {CKM_AES_KEY_WRAP, PK11_MECH},
-/* 66 */    {CKM_AES_KEY_WRAP_PAD, PK11_MECH}
-/* REMEMBER TO UPDATE NUM_ALGS!!! */
+/* 66 */    {CKM_AES_KEY_WRAP_PAD, PK11_MECH},
+/* 67 */    {CKM_SHA256_HMAC, PK11_MECH},
+/* 68 */    {CKM_SHA384_HMAC, PK11_MECH},
+/* 69 */    {CKM_SHA512_HMAC, PK11_MECH}
+/* REMEMBER TO UPDATE NUM_ALGS!!! (in Algorithm.h) */
 };
 
 /***********************************************************************

--- a/org/mozilla/jss/crypto/Algorithm.h
+++ b/org/mozilla/jss/crypto/Algorithm.h
@@ -24,7 +24,7 @@ typedef struct JSS_AlgInfoStr {
     JSS_AlgType type;
 } JSS_AlgInfo;
 
-#define NUM_ALGS 67
+#define NUM_ALGS 70
 
 extern JSS_AlgInfo JSS_AlgTable[];
 extern CK_ULONG JSS_symkeyUsage[];

--- a/org/mozilla/jss/crypto/Algorithm.java
+++ b/org/mozilla/jss/crypto/Algorithm.java
@@ -236,4 +236,9 @@ public class Algorithm {
     // These underlying defs are currently different from the NSS AES KeyWrap
     protected static final int CKM_AES_KEY_WRAP=65;
     protected static final int CKM_AES_KEY_WRAP_PAD=66;
+
+    // PKCS#11 SHA2 HMAC
+    protected static final int CKM_SHA256_HMAC=67;
+    protected static final int CKM_SHA384_HMAC=68;
+    protected static final int CKM_SHA512_HMAC=69;
 }

--- a/org/mozilla/jss/crypto/KeyGenAlgorithm.java
+++ b/org/mozilla/jss/crypto/KeyGenAlgorithm.java
@@ -114,6 +114,24 @@ public class KeyGenAlgorithm extends Algorithm {
             "SHA1/HMAC", new FixedKeyStrengthValidator(160),
             null, null );
 
+    public static final KeyGenAlgorithm
+    SHA256_HMAC = new KeyGenAlgorithm(
+        CKM_SHA256_HMAC,
+            "SHA256/HMAC", new FixedKeyStrengthValidator(256),
+            null, null );
+
+    public static final KeyGenAlgorithm
+    SHA384_HMAC = new KeyGenAlgorithm(
+        CKM_SHA384_HMAC,
+            "SHA384/HMAC", new FixedKeyStrengthValidator(384),
+            null, null );
+
+    public static final KeyGenAlgorithm
+    SHA512_HMAC = new KeyGenAlgorithm(
+        CKM_SHA512_HMAC,
+            "SHA512/HMAC", new FixedKeyStrengthValidator(512),
+            null, null );
+
     //////////////////////////////////////////////////////////////
     public static final KeyGenAlgorithm
     AES = new KeyGenAlgorithm(CKM_AES_KEY_GEN, "AES",

--- a/org/mozilla/jss/crypto/SymmetricKey.java
+++ b/org/mozilla/jss/crypto/SymmetricKey.java
@@ -64,6 +64,12 @@ public interface SymmetricKey {
         public static final Type RC2 = new Type("RC2", KeyGenAlgorithm.RC2);
         public static final Type SHA1_HMAC = new Type("SHA1_HMAC",
             KeyGenAlgorithm.SHA1_HMAC);
+        public static final Type SHA256_HMAC = new Type("SHA256_HMAC",
+            KeyGenAlgorithm.SHA256_HMAC);
+        public static final Type SHA384_HMAC = new Type("SHA384_HMAC",
+            KeyGenAlgorithm.SHA384_HMAC);
+        public static final Type SHA512_HMAC = new Type("SHA512_HMAC",
+            KeyGenAlgorithm.SHA512_HMAC);
         public static final Type PBA_SHA1_HMAC = new Type("PBA_SHA1_HMAC",
             KeyGenAlgorithm.PBA_SHA1_HMAC);
         public static final Type AES = new Type("AES", KeyGenAlgorithm.AES);


### PR DESCRIPTION
~Blocked by #222 and #224; will be rebased once those merge.~

SHA2-based HMACs have different key lengths than SHA1. We should expose both in SymmetricKey, in case we end up using them. It isn't clear whether this is strictly checked by the API though: `SHA1_HMAC` has been used as the key type for SHA2-based HMACs already. The difference is likely minimal.

We should add a more extensive HMAC-based test suite to JSS to validate that our HMAC implementation is indeed correct and functions under either set of constants. To do so, we'll want to expose a byte-based key importing instead of requiring randomly generated keys.