### PR TITLE
fix typo in JUnit CMake variable

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -243,7 +243,7 @@ macro(jss_config_java)
         message(WARNING "Test dependency sfl4j-jdk14.jar not found by find_jar! Tests might not run properly.")
     endif()
 
-    if(JUINT4_JAR STREQUAL "JUNIT4_JAR-NOTFOUND")
+    if(JUNIT4_JAR STREQUAL "JUNIT4_JAR-NOTFOUND")
         message(FATAL_ERROR "Test dependency junit4.jar not found by find_jar! Tests will not compile.")
     endif()
 


### PR DESCRIPTION
might need to get backported to 4.5 if so desired

also for jaxb, the errormessage refers to javaee-jaxb-api.jar while only checking for jaxb-api.jar but i don't know how common that name actually is so i didn't touch that part