### PR TITLE
Add a few standard Java interfaces when possible

### DIFF
--- a/org/mozilla/jss/crypto/Cipher.java
+++ b/org/mozilla/jss/crypto/Cipher.java
@@ -22,6 +22,11 @@ import org.mozilla.jss.util.Assert;
  * call to <code>doFinal</code>.
  */
 public abstract class Cipher {
+    // Note: Cipher can't extend javax.crypto.Cipher because it is part of the
+    // provider mechanism. In particular, it isn't an abstract class, many of
+    // the methods are marked final, and it expects to instantiate a CipherSpi
+    // class instead of be directly created like things which override our
+    // Cipher class expect (e.g., PK11Cipher). This is why JSSCipherSpi exists.
 
     /**
      * Initializes a encryption context with a symmetric key.

--- a/org/mozilla/jss/crypto/SymmetricKey.java
+++ b/org/mozilla/jss/crypto/SymmetricKey.java
@@ -6,7 +6,7 @@ package org.mozilla.jss.crypto;
 import java.security.NoSuchAlgorithmException;
 import java.util.Hashtable;
 
-public interface SymmetricKey {
+public interface SymmetricKey extends javax.crypto.SecretKey {
 
     public static final Type DES = Type.DES;
     public static final Type DES3 = Type.DES3;

--- a/org/mozilla/jss/pkcs11/PK11Key.java
+++ b/org/mozilla/jss/pkcs11/PK11Key.java
@@ -10,7 +10,7 @@ import java.io.ObjectOutputStream;
 import java.io.IOException;
 
 
-abstract class PK11Key {
+abstract class PK11Key implements java.security.Key {
 
     //////////////////////////////////////////////////////////
     // Public Interface

--- a/org/mozilla/jss/pkcs11/PK11SymKey.java
+++ b/org/mozilla/jss/pkcs11/PK11SymKey.java
@@ -8,6 +8,8 @@ import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.util.Assert;
 
+// We've updated jss.crypto.SymmetricKey to extend javax.crypto.SecretKey, so
+// PK11SymKey implements that interface as well.
 public final class PK11SymKey implements SymmetricKey {
 
     protected PK11SymKey(byte[] pointer) {


### PR DESCRIPTION
This extends our interfaces to be compatible with the default JDK
interfaces whenever possible. In particular:

 - jss.crypto.SymmetricKey now extends javax.crypto.SecretKey
 - jss.pkcs11.PK11Key now implements java.security.Key

A few clarifying comments have been added where necessary.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`