### PR TITLE
Remove Assert._assert usage

### DIFF
--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -287,16 +287,16 @@ public final class CryptoManager implements TokenSupplier
         while(tokens.hasMoreElements()) {
             PK11Token token = (PK11Token) tokens.nextElement();
             if( token.isInternalCryptoToken() ) {
-                Assert._assert(internalCryptoToken == null);
+                assert(internalCryptoToken == null);
                 internalCryptoToken = token;
             }
             if( token.isInternalKeyStorageToken() ) {
-                Assert._assert(internalKeyStorageToken == null);
+                assert(internalKeyStorageToken == null);
                 internalKeyStorageToken = token;
             }
         }
-        Assert._assert(internalKeyStorageToken != null);
-        Assert._assert(internalCryptoToken != null);
+        assert(internalKeyStorageToken != null);
+        assert(internalCryptoToken != null);
     }
 
     /**
@@ -826,7 +826,7 @@ public final class CryptoManager implements TokenSupplier
     findCertByNickname(String nickname)
         throws ObjectNotFoundException, TokenException
     {
-        Assert._assert(nickname!=null);
+        assert(nickname!=null);
         return findCertByNicknameNative(nickname);
     }
 
@@ -842,7 +842,7 @@ public final class CryptoManager implements TokenSupplier
     findCertsByNickname(String nickname)
         throws TokenException
     {
-        Assert._assert(nickname!=null);
+        assert(nickname!=null);
         return findCertsByNicknameNative(nickname);
     }
 
@@ -934,7 +934,7 @@ public final class CryptoManager implements TokenSupplier
     findPrivKeyByCert(org.mozilla.jss.crypto.X509Certificate cert)
         throws ObjectNotFoundException, TokenException
     {
-        Assert._assert(cert!=null);
+        assert(cert!=null);
         if(! (cert instanceof org.mozilla.jss.pkcs11.PK11Cert)) {
             throw new ObjectNotFoundException("Non-pkcs11 cert passed to PK11Finder");
         }

--- a/org/mozilla/jss/asn1/ANY.java
+++ b/org/mozilla/jss/asn1/ANY.java
@@ -192,7 +192,7 @@ public class ANY implements ASN1Value {
     {
         byte[] contents = getContents();
         ASN1Header oldHead = getHeader();
-        Assert._assert( contents.length == oldHead.getContentLength() );
+        assert( contents.length == oldHead.getContentLength() );
 
         ASN1Header newHead = new ASN1Header( alternateTag, oldHead.getForm(),
                                 contents.length);

--- a/org/mozilla/jss/asn1/ASN1Header.java
+++ b/org/mozilla/jss/asn1/ASN1Header.java
@@ -152,7 +152,7 @@ public class ASN1Header {
                 next = (byte) inInt;
                 bV.addElement( Byte.valueOf(next) );
             } while( (next & 0x80) == 0x80 );
-            Assert._assert( bV.size() > 0 );
+            assert( bV.size() > 0 );
 
             //
             // Copy Vector of 7-bit bytes into array of 8-bit bytes.
@@ -171,10 +171,10 @@ public class ASN1Header {
             // end (LSB) to the beginning (MSB).
             a = bA.length - 1;
             for( v=bV.size()-1 ; v >= 0; v--) {
-                Assert._assert( v >= 0 );
-                Assert._assert( v < bV.size() );
-                Assert._assert( a >= 0 );
-                Assert._assert( a < bA.length );
+                assert( v >= 0 );
+                assert( v < bV.size() );
+                assert( a >= 0 );
+                assert( a < bA.length );
 
                 // MSB is not part of the number
                 byte b = (byte) ( bV.elementAt(v).byteValue() & 0x7f );
@@ -184,7 +184,7 @@ public class ASN1Header {
                     // in the array.  We've already got the less-significant
                     // bits, now copy the more-significant bits into
                     // the next element of the array.
-                    Assert._assert( a > 0 );
+                    assert( a > 0 );
                     --a;
                     bA[a] |= b >>> (8-shift);
                 }
@@ -247,7 +247,7 @@ public class ASN1Header {
     {
         this.tag = tag;
         this.form = form;
-        Assert._assert(contentLength >= 0);
+        assert(contentLength >= 0);
         this.contentLength = contentLength;
     }
 
@@ -333,7 +333,7 @@ public class ASN1Header {
      */
     public static byte[] unsignedBigIntToByteArray(BigInteger bi) {
         // make sure it is not negative
-        Assert._assert( bi.compareTo(BigInteger.valueOf(0)) != -1 );
+        assert( bi.compareTo(BigInteger.valueOf(0)) != -1 );
 
         // find minimal number of bytes to hold this value
         int bitlen = bi.bitLength(); // minimal number of bits, without sign
@@ -351,8 +351,8 @@ public class ASN1Header {
             return withSign;
         } else {
             // trim off extra byte at the beginning
-            Assert._assert( bytelen == withSign.length - 1 );
-            Assert._assert( withSign[0] == 0 );
+            assert( bytelen == withSign.length - 1 );
+            assert( withSign[0] == 0 );
             byte[] without = new byte[bytelen];
             System.arraycopy(withSign,1, without, 0, bytelen);
             return without;

--- a/org/mozilla/jss/asn1/BIT_STRING.java
+++ b/org/mozilla/jss/asn1/BIT_STRING.java
@@ -65,7 +65,7 @@ public class BIT_STRING implements ASN1Value {
         // allocate enough bytes to hold all the bits
         bits = new byte[(numBits+7) / 8];
         padCount = (bits.length * 8) - numBits;
-        Assert._assert( padCount >= 0 && padCount <= 7);
+        assert( padCount >= 0 && padCount <= 7);
 
         for(int i=0; i < numBits; i++) {
             if( bs.get(i) ) {
@@ -197,7 +197,7 @@ public class BIT_STRING implements ASN1Value {
                         break;
                     }
                 }
-                Assert._assert(padBits >=0 && padBits <= 7);
+                assert(padBits >=0 && padBits <= 7);
             }
         } else {
             // Don't remove trailing zeroes. Just write the bits out as-is.

--- a/org/mozilla/jss/asn1/CHOICE.java
+++ b/org/mozilla/jss/asn1/CHOICE.java
@@ -80,7 +80,7 @@ public class CHOICE implements ASN1Value {
     public void encode( Tag implicitTag, OutputStream ostream )
         throws IOException
     {
-        Assert._assert(implicitTag.equals(tag));
+        assert(implicitTag.equals(tag));
         val.encode( tag, ostream );
     }
 

--- a/org/mozilla/jss/asn1/EXPLICIT.java
+++ b/org/mozilla/jss/asn1/EXPLICIT.java
@@ -35,7 +35,7 @@ public class EXPLICIT implements ASN1Value {
      * @param content Content.
      */
     public EXPLICIT( Tag tag, ASN1Value content ) {
-        Assert._assert(tag!=null && content!=null);
+        assert(tag!=null && content!=null);
         this.content = content;
         this.tag = tag;
     }

--- a/org/mozilla/jss/asn1/OBJECT_IDENTIFIER.java
+++ b/org/mozilla/jss/asn1/OBJECT_IDENTIFIER.java
@@ -198,12 +198,12 @@ public class OBJECT_IDENTIFIER implements ASN1Value {
      * off, it just checks for null.
      */
     private static void checkLongArray(long[] numbers) {
-        Assert._assert(numbers != null);
+        assert(numbers != null);
         if(numbers == null) {
             throw new NullPointerException();
         }
-        Assert._assert(numbers.length >= 2);
-        Assert._assert( numbers[0]==0 || numbers[0]==1 || numbers[0]==2 );
+        assert(numbers.length >= 2);
+        assert( numbers[0]==0 || numbers[0]==1 || numbers[0]==2 );
     }
 
 
@@ -243,7 +243,7 @@ public class OBJECT_IDENTIFIER implements ASN1Value {
         while(stok.hasMoreElements()) {
             numbers[i++] = Long.parseLong( stok.nextToken() );
         }
-        Assert._assert( i == numbers.length );
+        assert( i == numbers.length );
         checkLongArray(numbers);
     }
 
@@ -387,17 +387,17 @@ public class OBJECT_IDENTIFIER implements ASN1Value {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         // handle first number
-        Assert._assert(numbers.length >= 2);
+        assert(numbers.length >= 2);
         long n = numbers[0];
-        Assert._assert( n == 0 || n == 1 || n == 2 );
+        assert( n == 0 || n == 1 || n == 2 );
         long outb = ( numbers[0] * 40 ) + numbers[1];
-        Assert._assert( ((byte)outb) == outb );
+        assert( ((byte)outb) == outb );
         out.write( (byte)outb );
 
         // handle consecutive numbers
         for( int i = 2; i < numbers.length; i++ ) {
             n = numbers[i];
-            Assert._assert( n >= 0 );
+            assert( n >= 0 );
 
             // array of output bytes, in reverse order.  10 bytes, at 7 bits
             // per byte, is 70 bits, which is more than enough to handle
@@ -417,7 +417,7 @@ public class OBJECT_IDENTIFIER implements ASN1Value {
                 // all but last byte have MSB==1
                 out.write( rev[idx--]  | 0x80 );
             }
-            Assert._assert(idx == 0);
+            assert(idx == 0);
             // last byte has MSB==0
             out.write( rev[0] );
         }
@@ -539,7 +539,7 @@ public static class Template implements ASN1Template {
             throw new InvalidBERException("End-of-file reached while "+
                 "decoding OBJECT IDENTIFIER");
         }
-        Assert._assert( (n & 0xff) == n );
+        assert( (n & 0xff) == n );
         return (byte) n;
     }
 

--- a/org/mozilla/jss/asn1/SEQUENCE.java
+++ b/org/mozilla/jss/asn1/SEQUENCE.java
@@ -443,7 +443,7 @@ public static class Template implements ASN1Template {
             throw new InvalidBERException("SEQUENCE is " + remainingContent +
                 " bytes longer than expected");
         }
-        Assert._assert( remainingContent == 0 || remainingContent == -1 );
+        assert( remainingContent == 0 || remainingContent == -1 );
 
         // If this was indefinite-length encoding, consume the end-of-contents
         if( remainingContent == -1 ) {
@@ -455,7 +455,7 @@ public static class Template implements ASN1Template {
 
         // Make sure we stayed in sync
         if( ! repeatableElement ) {
-            Assert._assert(index == seq.size());
+            assert(index == seq.size());
         }
 
         return seq;

--- a/org/mozilla/jss/asn1/SET.java
+++ b/org/mozilla/jss/asn1/SET.java
@@ -300,11 +300,11 @@ public class SET implements ASN1Value {
 
         // equal up to the minimal endpoint
         if( left.length > min ) {
-            Assert._assert(right.length==min);
+            assert(right.length==min);
             return 1;
         }
         if( right.length > min ) {
-            Assert._assert(left.length==min);
+            assert(left.length==min);
             return -1;
         }
         return 0;
@@ -739,7 +739,7 @@ public static class Template implements ASN1Template {
 
         // We check for this after we read in each item, so this shouldn't
         // happen
-        Assert._assert( remainingContent == 0 || remainingContent == -1);
+        assert( remainingContent == 0 || remainingContent == -1);
 
         // Deal with elements that weren't present.
         int size = elements.size();

--- a/org/mozilla/jss/asn1/TimeBase.java
+++ b/org/mozilla/jss/asn1/TimeBase.java
@@ -65,27 +65,27 @@ public abstract class TimeBase implements ASN1Value {
         }
 
         val = cal.get(Calendar.MONTH) + 1;
-        Assert._assert( val >= 1 && val <= 12 );
+        assert( val >= 1 && val <= 12 );
         ostream.write( (val / 10) + '0' );
         ostream.write( (val % 10) + '0' );
 
         val = cal.get(Calendar.DAY_OF_MONTH);
-        Assert._assert( val >=1 && val <= 31 );
+        assert( val >=1 && val <= 31 );
         ostream.write( (val / 10) + '0' );
         ostream.write( (val % 10) + '0' );
 
         val = cal.get(Calendar.HOUR_OF_DAY);
-        Assert._assert( val >= 0 && val <= 23 );
+        assert( val >= 0 && val <= 23 );
         ostream.write( (val / 10) + '0' );
         ostream.write( (val % 10) + '0' );
 
         val = cal.get(Calendar.MINUTE);
-        Assert._assert( val >=0 && val <= 59 );
+        assert( val >=0 && val <= 59 );
         ostream.write( (val / 10) + '0' );
         ostream.write( (val % 10) + '0' );
 
         val = cal.get(Calendar.SECOND);
-        Assert._assert( val >= 0 && val <= 59 );
+        assert( val >= 0 && val <= 59 );
         ostream.write( (val / 10) + '0' );
         ostream.write( (val % 10) + '0' );
 

--- a/org/mozilla/jss/crypto/Cipher.java
+++ b/org/mozilla/jss/crypto/Cipher.java
@@ -126,7 +126,7 @@ public abstract class Cipher {
      */
     public static byte[]
     pad(byte[] toBePadded, int blockSize) {
-        Assert._assert(blockSize > 0);
+        assert(blockSize > 0);
 
         // the padOctet is also the number of pad octets
         byte padOctet = (byte) (blockSize - (toBePadded.length % blockSize));

--- a/org/mozilla/jss/crypto/PQGParams.java
+++ b/org/mozilla/jss/crypto/PQGParams.java
@@ -152,7 +152,7 @@ public class PQGParams extends DSAParameterSpec {
         byte[] ret;
 
         // big must not be negative
-        Assert._assert(big.signum() != -1);
+        assert(big.signum() != -1);
 
         // bitLength is the size of the data without the sign bit.  If
         // it exactly fills an integral number of bytes, that means a whole
@@ -161,7 +161,7 @@ public class PQGParams extends DSAParameterSpec {
         if(big.bitLength() % 8 == 0) {
             byte[] array = big.toByteArray();
             // The first byte should just be sign bits
-            Assert._assert( array[0] == 0 );
+            assert( array[0] == 0 );
             ret = new byte[array.length-1];
             System.arraycopy(array, 1, ret, 0, ret.length);
         } else {

--- a/org/mozilla/jss/crypto/PrivateKey.java
+++ b/org/mozilla/jss/crypto/PrivateKey.java
@@ -60,7 +60,7 @@ public interface PrivateKey extends java.security.PrivateKey
             this.name = name;
             Object old = oidMap.put(oid, this);
             this.pkcs11Type = pkcs11Type;
-            Assert._assert( old == null );
+            assert( old == null );
         }
 
         private static Hashtable<OBJECT_IDENTIFIER, Type> oidMap = new Hashtable<>();

--- a/org/mozilla/jss/pkcs11/KeyType.java
+++ b/org/mozilla/jss/pkcs11/KeyType.java
@@ -32,13 +32,13 @@ public final class KeyType {
     protected KeyType(Algorithm[] algs, String name) {
         int i;
 
-        Assert._assert(algs!=null);
+        assert(algs!=null);
 
         algorithms = algs.clone();
 
         // Register this key as the key type for each of its algorithms
         for(i=0; i < algorithms.length; i++) {
-            Assert._assert(! algHash.containsKey(algorithms[i]) );
+            assert(! algHash.containsKey(algorithms[i]) );
             algHash.put(algorithms[i], this);
         }
         this.name = name;
@@ -59,14 +59,14 @@ public final class KeyType {
     static public KeyType getKeyTypeFromAlgorithm(Algorithm alg)
         throws NoSuchAlgorithmException
     {
-        Assert._assert(alg!=null);
+        assert(alg!=null);
         Object obj = algHash.get(alg);
 
         if(obj == null) {
             throw new NoSuchAlgorithmException();
         }
 
-        Assert._assert( obj instanceof KeyType );
+        assert( obj instanceof KeyType );
 
         return (KeyType) obj;
     }

--- a/org/mozilla/jss/pkcs11/PK11Cert.java
+++ b/org/mozilla/jss/pkcs11/PK11Cert.java
@@ -402,13 +402,13 @@ public class PK11Cert
 	// Construction
 	/////////////////////////////////////////////////////////////
 	//PK11Cert(CertProxy proxy) {
-    //    Assert._assert(proxy!=null);
+    //    assert(proxy!=null);
 	//	this.certProxy = proxy;
 	//}
 
 	PK11Cert(byte[] certPtr, byte[] slotPtr, String nickname) {
-        Assert._assert(certPtr!=null);
-        Assert._assert(slotPtr!=null);
+        assert(certPtr!=null);
+        assert(slotPtr!=null);
 		certProxy = new CertProxy(certPtr);
 		tokenProxy = new TokenProxy(slotPtr);
 		this.nickname = nickname;

--- a/org/mozilla/jss/pkcs11/PK11Key.java
+++ b/org/mozilla/jss/pkcs11/PK11Key.java
@@ -9,6 +9,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.IOException;
 
+import org.mozilla.jss.util.AssertionException;
+
 
 abstract class PK11Key implements java.security.Key {
 
@@ -42,12 +44,12 @@ abstract class PK11Key implements java.security.Key {
     // Override serialization methods so that we don't get serialized,
     // even though we are supposed to support it as an implementation of Key.
     private void writeObject(ObjectOutputStream out) throws IOException {
-        Assert._assert(false, "PKCS#11 Key is not really serializable");
+        throw new AssertionException("PKCS#11 Key is not really serializable");
     }
 
     private void readObject(ObjectInputStream in)
         throws IOException, ClassNotFoundException {
-        Assert._assert(false, "PKCS#11 Key is not really serializable");
+        throw new AssertionException("PKCS#11 Key is not really serializable");
     }
 
 

--- a/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.java
+++ b/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.java
@@ -323,7 +323,7 @@ public final class PK11KeyPairGenerator
     public PK11KeyPairGenerator(PK11Token token, KeyPairAlgorithm algorithm)
         throws NoSuchAlgorithmException, TokenException
     {
-        Assert._assert(token!=null && algorithm!=null);
+        assert(token!=null && algorithm!=null);
 
         mKeygenOnInternalToken = false;
 
@@ -382,7 +382,7 @@ public final class PK11KeyPairGenerator
                     "be 512, 768, or 1024.");
             }
         } else {
-            Assert._assert( algorithm == KeyPairAlgorithm.EC );
+            assert( algorithm == KeyPairAlgorithm.EC );
             if (strength < 112) {
                 // for EC, "strength" is actually a code for curves defined in
                 //   ECCurve_Code
@@ -429,7 +429,7 @@ public final class PK11KeyPairGenerator
                 throw new InvalidAlgorithmParameterException();
             }
         } else {
-            Assert._assert( algorithm == KeyPairAlgorithm.EC);
+            assert( algorithm == KeyPairAlgorithm.EC);
             // requires JAVA 1.5
             // if(! (params instanceof ECParameterSpec) ) {
             //   throw new InvalidAlgorithmParameterException();
@@ -489,7 +489,7 @@ public final class PK11KeyPairGenerator
                 extractablePairMode,
                 opFlags, opFlagsMask);
         } else {
-            Assert._assert( algorithm == KeyPairAlgorithm.EC );
+            assert( algorithm == KeyPairAlgorithm.EC );
             // requires JAVA 1.5 for ECParameters.
             //
             //AlgorithmParameters ecParams =
@@ -680,9 +680,9 @@ public final class PK11KeyPairGenerator
     private static synchronized void
     testDefaults() {
         if(!defaultsTested) {
-            Assert._assert(PQG1024.paramsAreValid());
-            Assert._assert(PQG768.paramsAreValid());
-            Assert._assert(PQG512.paramsAreValid());
+            assert(PQG1024.paramsAreValid());
+            assert(PQG768.paramsAreValid());
+            assert(PQG512.paramsAreValid());
             defaultsTested = true;
         }
     }

--- a/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
+++ b/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
@@ -249,14 +249,14 @@ final class PK11KeyWrapper implements KeyWrapper {
         checkWrappee(toBeWrapped);
 
         if( symKey != null ) {
-            Assert._assert( privKey==null && pubKey==null );
+            assert( privKey==null && pubKey==null );
             return nativeWrapPrivWithSym(token, toBeWrapped, symKey, algorithm,
                 IV);
         } else {
             throw new InvalidKeyException(
                 "Wrapping a private key with a public key is not supported");
             /*
-            Assert._assert( pubKey!=null && privKey==null && symKey==null );
+            assert( pubKey!=null && privKey==null && symKey==null );
             return nativeWrapPrivWithPub(token, toBeWrapped, pubKey, algorithm,
                     IV);
             */
@@ -277,11 +277,11 @@ final class PK11KeyWrapper implements KeyWrapper {
         checkWrappee(toBeWrapped);
 
         if( symKey != null ) {
-            Assert._assert( privKey==null && pubKey==null );
+            assert( privKey==null && pubKey==null );
             return nativeWrapSymWithSym(token, toBeWrapped, symKey, algorithm,
                         IV);
         } else {
-            Assert._assert( pubKey!=null && privKey==null && symKey==null );
+            assert( pubKey!=null && privKey==null && symKey==null );
             return nativeWrapSymWithPub(token, toBeWrapped, pubKey, algorithm,
                         IV);
         }
@@ -410,7 +410,7 @@ final class PK11KeyWrapper implements KeyWrapper {
         }
 
         if( symKey != null ) {
-            Assert._assert(pubKey==null && privKey==null);
+            assert(pubKey==null && privKey==null);
             PrivateKey importedKey = nativeUnwrapPrivWithSym(
                 token, symKey, wrapped, algorithm, algFromType(type),
                 publicValue, IV, temporary);
@@ -433,7 +433,7 @@ final class PK11KeyWrapper implements KeyWrapper {
             throw new InvalidKeyException("Unwrapping a private key with"
                 + " a private key is not supported");
             /*
-            Assert._assert(privKey!=null && pubKey==null && symKey==null);
+            assert(privKey!=null && pubKey==null && symKey==null);
             return nativeUnwrapPrivWithPriv(token, privKey, wrapped, algorithm,
                         algFromType(type), publicValue, IV, temporary );
             */
@@ -542,11 +542,11 @@ final class PK11KeyWrapper implements KeyWrapper {
                 usageEnum,temporary );
         } else {
             if( symKey != null ) {
-                Assert._assert(pubKey==null && privKey==null);
+                assert(pubKey==null && privKey==null);
                 return nativeUnwrapSymWithSym(token, symKey, wrapped, algorithm,
                         algFromType(type), keyLen, IV, usageEnum,temporary);
             } else {
-                Assert._assert(privKey!=null && pubKey==null && symKey==null);
+                assert(privKey!=null && pubKey==null && symKey==null);
                 throw new TokenException("We do not support permnament unwrapping with private key.");
             }
         }
@@ -582,11 +582,11 @@ final class PK11KeyWrapper implements KeyWrapper {
                 usageEnum, temporary );
         } else {
             if( symKey != null ) {
-                Assert._assert(pubKey==null && privKey==null);
+                assert(pubKey==null && privKey==null);
                 return nativeUnwrapSymWithSym(token, symKey, wrapped, algorithm,
                         algFromType(type), keyLen, IV, usageEnum,temporary);
             } else {
-                Assert._assert(privKey!=null && pubKey==null && symKey==null);
+                assert(privKey!=null && pubKey==null && symKey==null);
                 return nativeUnwrapSymWithPriv(token, privKey, wrapped,
                     algorithm, algFromType(type), keyLen, IV, usageEnum );
             }
@@ -600,7 +600,7 @@ final class PK11KeyWrapper implements KeyWrapper {
         } else if (type == PrivateKey.DSA) {
             return KeyPairAlgorithm.DSAFamily;
         } else {
-            Assert._assert( type == PrivateKey.EC);
+            assert( type == PrivateKey.EC);
             return KeyPairAlgorithm.ECFamily;
 	}
     }
@@ -620,7 +620,7 @@ final class PK11KeyWrapper implements KeyWrapper {
         } else if( type == SymmetricKey.SHA1_HMAC) {
             return HMACAlgorithm.SHA1;
         } else  {
-            Assert._assert( type == SymmetricKey.RC2 );
+            assert( type == SymmetricKey.RC2 );
             return EncryptionAlgorithm.RC2_CBC;
         }
     }

--- a/org/mozilla/jss/pkcs11/PK11Module.java
+++ b/org/mozilla/jss/pkcs11/PK11Module.java
@@ -19,7 +19,7 @@ public final class PK11Module {
      * This constructor should only be called from native code.
      */
     private PK11Module(byte[] pointer) {
-        Assert._assert(pointer!=null);
+        assert(pointer!=null);
         moduleProxy = new ModuleProxy(pointer);
         reloadTokens();
     }

--- a/org/mozilla/jss/pkcs11/PK11PrivKey.java
+++ b/org/mozilla/jss/pkcs11/PK11PrivKey.java
@@ -23,7 +23,7 @@ public class PK11PrivKey extends org.mozilla.jss.pkcs11.PK11Key
     private PK11PrivKey() { }
 
     protected PK11PrivKey(byte[] pointer) {
-        Assert._assert(pointer!=null);
+        assert(pointer!=null);
         keyProxy = new PrivateKeyProxy(pointer);
     }
 
@@ -52,7 +52,7 @@ public class PK11PrivKey extends org.mozilla.jss.pkcs11.PK11Key
         } else if (kt == KeyType.DSA) {
             return PrivateKey.Type.DSA;
         } else {
-            Assert._assert(kt == KeyType.EC);
+            assert(kt == KeyType.EC);
             return PrivateKey.Type.EC;
 	}
     }

--- a/org/mozilla/jss/pkcs11/PK11PubKey.java
+++ b/org/mozilla/jss/pkcs11/PK11PubKey.java
@@ -16,7 +16,7 @@ public class PK11PubKey extends org.mozilla.jss.pkcs11.PK11Key
     private static final long serialVersionUID = 1L;
 
     protected PK11PubKey(byte[] pointer) {
-        Assert._assert(pointer!=null);
+        assert(pointer!=null);
         keyProxy = new PublicKeyProxy(pointer);
     }
 

--- a/org/mozilla/jss/pkcs11/PK11Signature.java
+++ b/org/mozilla/jss/pkcs11/PK11Signature.java
@@ -28,7 +28,7 @@ final class PK11Signature extends org.mozilla.jss.crypto.SignatureSpi {
 	public PK11Signature(PK11Token token, SignatureAlgorithm algorithm)
 		throws NoSuchAlgorithmException, TokenException
 	{
-        Assert._assert(token!=null && algorithm!=null);
+        assert(token!=null && algorithm!=null);
 
         // Make sure this token supports this algorithm.  It's OK if
         // it only supports the signing part; the hashing can be done
@@ -54,7 +54,7 @@ final class PK11Signature extends org.mozilla.jss.crypto.SignatureSpi {
 	{
         PK11PrivKey privKey;
 
-        Assert._assert(privateKey!=null);
+        assert(privateKey!=null);
 
         //
         // Scrutinize the key. Make sure it:
@@ -128,7 +128,7 @@ final class PK11Signature extends org.mozilla.jss.crypto.SignatureSpi {
 	{
 		PK11PubKey pubKey;
 
-        Assert._assert(publicKey!=null);
+        assert(publicKey!=null);
 
         //
         // Scrutinize the key. Make sure it:
@@ -181,7 +181,7 @@ final class PK11Signature extends org.mozilla.jss.crypto.SignatureSpi {
     public void engineUpdate(byte[] b, int off, int len)
         throws SignatureException, TokenException
     {
-        Assert._assert(b != null);
+        assert(b != null);
         if( (state==SIGN || state==VERIFY) ) {
             if(!raw && sigContext==null) {
                 throw new SignatureException("Signature has no context");
@@ -189,13 +189,13 @@ final class PK11Signature extends org.mozilla.jss.crypto.SignatureSpi {
                 throw new SignatureException("Raw signature has no input stream");
             }
         } else {
-            Assert._assert(state == UNINITIALIZED);
+            assert(state == UNINITIALIZED);
             throw new SignatureException("Signature is not initialized");
         }
-        Assert._assert(token!=null);
-        Assert._assert(tokenProxy!=null);
-        Assert._assert(algorithm!=null);
-        Assert._assert(key!=null);
+        assert(token!=null);
+        assert(tokenProxy!=null);
+        assert(algorithm!=null);
+        assert(key!=null);
 
         if( raw ) {
             rawInput.write(b, off, len);
@@ -219,10 +219,10 @@ final class PK11Signature extends org.mozilla.jss.crypto.SignatureSpi {
         } else if(raw && rawInput==null) {
             throw new SignatureException("Signature has no input");
         }
-        Assert._assert(token!=null);
-        Assert._assert(tokenProxy!=null);
-        Assert._assert(algorithm!=null);
-        Assert._assert(key!=null);
+        assert(token!=null);
+        assert(tokenProxy!=null);
+        assert(algorithm!=null);
+        assert(key!=null);
 
         byte[] result;
         if( raw ) {
@@ -241,7 +241,7 @@ final class PK11Signature extends org.mozilla.jss.crypto.SignatureSpi {
     public int engineSign(byte[] outbuf, int offset, int len)
         throws SignatureException, TokenException
     {
-        Assert._assert(outbuf!=null);
+        assert(outbuf!=null);
         byte[] sig;
         if( raw ) {
             sig = engineRawSignNative(token, (PK11PrivKey)key,
@@ -273,7 +273,7 @@ final class PK11Signature extends org.mozilla.jss.crypto.SignatureSpi {
     public boolean engineVerify(byte[] sigBytes)
         throws SignatureException, TokenException
     {
-        Assert._assert(sigBytes!=null);
+        assert(sigBytes!=null);
 		if(state != VERIFY) {
 			throw new SignatureException(
 						"Signature is not initialized properly");
@@ -284,10 +284,10 @@ final class PK11Signature extends org.mozilla.jss.crypto.SignatureSpi {
         if(raw && rawInput==null) {
             throw new SignatureException("Signature has no input");
         }
-		Assert._assert(token!=null);
-		Assert._assert(tokenProxy!=null);
-		Assert._assert(algorithm!=null);
-		Assert._assert(key!=null);
+		assert(token!=null);
+		assert(tokenProxy!=null);
+		assert(algorithm!=null);
+		assert(key!=null);
 
 		if(sigBytes==null) {
 			return false;

--- a/org/mozilla/jss/pkcs11/PK11Store.java
+++ b/org/mozilla/jss/pkcs11/PK11Store.java
@@ -211,7 +211,7 @@ public final class PK11Store implements CryptoStore {
 	////////////////////////////////////////////////////////////
     protected boolean updated;
 	public PK11Store(TokenProxy proxy) {
-        Assert._assert(proxy!=null);
+        assert(proxy!=null);
 		this.storeProxy = proxy;
 	}
 

--- a/org/mozilla/jss/pkcs11/PK11SymKey.java
+++ b/org/mozilla/jss/pkcs11/PK11SymKey.java
@@ -13,13 +13,13 @@ import org.mozilla.jss.util.Assert;
 public final class PK11SymKey implements SymmetricKey {
 
     protected PK11SymKey(byte[] pointer) {
-        Assert._assert(pointer!=null);
+        assert(pointer!=null);
         keyProxy  = new SymKeyProxy(pointer);
         nickName = null;
     }
 
     protected PK11SymKey(byte[] pointer,String nickName) {
-        Assert._assert(pointer!=null);
+        assert(pointer!=null);
         keyProxy  = new SymKeyProxy(pointer);
         this.nickName = nickName;
      }

--- a/org/mozilla/jss/pkcs11/PK11Token.java
+++ b/org/mozilla/jss/pkcs11/PK11Token.java
@@ -74,7 +74,7 @@ public final class PK11Token implements CryptoToken {
     getSignatureContext(SignatureAlgorithm algorithm)
             throws NoSuchAlgorithmException, TokenException
     {
-        Assert._assert(algorithm!=null);
+        assert(algorithm!=null);
         return Tunnel.constructSignature( algorithm,
                 new PK11Signature(this, algorithm) );
     }
@@ -161,7 +161,7 @@ public final class PK11Token implements CryptoToken {
     getKeyPairGenerator(KeyPairAlgorithm algorithm)
             throws NoSuchAlgorithmException, TokenException
     {
-        Assert._assert(algorithm!=null);
+        assert(algorithm!=null);
         return new KeyPairGenerator(algorithm,
                 new PK11KeyPairGenerator(this, algorithm));
     }
@@ -540,7 +540,7 @@ public final class PK11Token implements CryptoToken {
      * Default constructor should never be called.
      */
     protected PK11Token() {
-        Assert._assert(false);
+        assert(false);
     }
 
     /**
@@ -549,7 +549,7 @@ public final class PK11Token implements CryptoToken {
      * @param pointer A byte array containing a pointer to a PKCS #11 slot.
      */
     protected PK11Token(byte[] pointer, boolean internal, boolean keyStorage) {
-        Assert._assert(pointer!=null);
+        assert(pointer!=null);
         tokenProxy = new TokenProxy(pointer);
         mIsInternalCryptoToken = internal;
         mIsInternalKeyStorageToken = keyStorage;
@@ -558,7 +558,7 @@ public final class PK11Token implements CryptoToken {
 
 /*
 	protected PK11Token(TokenProxy proxy) {
-        Assert._assert(proxy!=null);
+        assert(proxy!=null);
 		this.tokenProxy = proxy;
 	}
 */

--- a/org/mozilla/jss/pkcs12/PasswordConverter.java
+++ b/org/mozilla/jss/pkcs12/PasswordConverter.java
@@ -25,7 +25,7 @@ public final class PasswordConverter
             }
             bytes[b++] = 0;
             bytes[b++] = 0;
-            Assert._assert(b == bytes.length);
+            assert(b == bytes.length);
 
             return bytes;
         }

--- a/org/mozilla/jss/pkcs7/Attribute.java
+++ b/org/mozilla/jss/pkcs7/Attribute.java
@@ -105,7 +105,7 @@ public static class Template implements ASN1Template {
         SEQUENCE seq = (SEQUENCE) seqt.decode(implicit, istream);
 
         // The template should have enforced this
-        Assert._assert(seq.size() == 2);
+        assert(seq.size() == 2);
 
         return new Attribute( (OBJECT_IDENTIFIER) seq.elementAt(0),
                               (SET)               seq.elementAt(1));

--- a/org/mozilla/jss/pkcs7/ContentInfo.java
+++ b/org/mozilla/jss/pkcs7/ContentInfo.java
@@ -226,7 +226,7 @@ public class ContentInfo implements ASN1Value {
             throws IOException, InvalidBERException
             {
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag,istream);
-                Assert._assert(seq.size() == 2);
+                assert(seq.size() == 2);
                 ASN1Value content;
 
                 if( seq.elementAt(1) == null ) {

--- a/org/mozilla/jss/pkcs7/DigestInfo.java
+++ b/org/mozilla/jss/pkcs7/DigestInfo.java
@@ -64,7 +64,7 @@ public class DigestInfo implements ASN1Value {
      */
     private static boolean byteArraysAreSame(byte[] left, byte[] right) {
 
-        Assert._assert(left!=null && right!=null);
+        assert(left!=null && right!=null);
 
         if( left.length != right.length ) {
             return false;

--- a/org/mozilla/jss/pkcs7/EncryptedContentInfo.java
+++ b/org/mozilla/jss/pkcs7/EncryptedContentInfo.java
@@ -339,7 +339,7 @@ public class EncryptedContentInfo implements ASN1Value {
                 seqt.addOptionalElement(new Tag(0), new OCTET_STRING.Template());
 
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag,istream);
-                Assert._assert(seq.size() ==3);
+                assert(seq.size() ==3);
 
                 return new EncryptedContentInfo(
                     (OBJECT_IDENTIFIER)   seq.elementAt(0),

--- a/org/mozilla/jss/pkcs7/EnvelopedData.java
+++ b/org/mozilla/jss/pkcs7/EnvelopedData.java
@@ -93,7 +93,7 @@ public class EnvelopedData implements ASN1Value {
                 seqt.addElement(new EncryptedContentInfo.Template());
 
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag,istream);
-                Assert._assert(seq.size() ==3);
+                assert(seq.size() ==3);
 
                 return new EnvelopedData(
                     (INTEGER)               seq.elementAt(0),

--- a/org/mozilla/jss/pkcs7/IssuerAndSerialNumber.java
+++ b/org/mozilla/jss/pkcs7/IssuerAndSerialNumber.java
@@ -114,7 +114,7 @@ public class IssuerAndSerialNumber implements ASN1Value {
         {
             SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
 
-            Assert._assert(seq.size() == 2);
+            assert(seq.size() == 2);
 
             return new IssuerAndSerialNumber(
                             (Name)      seq.elementAt(0),

--- a/org/mozilla/jss/pkcs7/RecipientInfo.java
+++ b/org/mozilla/jss/pkcs7/RecipientInfo.java
@@ -61,9 +61,9 @@ public class RecipientInfo implements ASN1Value {
 			   AlgorithmIdentifier keyEncryptionAlgorithmID,
 			   OCTET_STRING encryptedKey) {
 
-	Assert._assert(issuerAndSerialNumber != null);
-	Assert._assert(keyEncryptionAlgorithmID != null);
-	Assert._assert(encryptedKey != null);
+	assert(issuerAndSerialNumber != null);
+	assert(keyEncryptionAlgorithmID != null);
+	assert(encryptedKey != null);
 
 
         this.version = version;
@@ -118,7 +118,7 @@ public class RecipientInfo implements ASN1Value {
                 seqt.addElement(new OCTET_STRING.Template());
 
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag,istream);
-                Assert._assert(seq.size() ==4);
+                assert(seq.size() ==4);
 
                 return new RecipientInfo(
                     (INTEGER)               seq.elementAt(0),

--- a/org/mozilla/jss/pkcs7/SignedData.java
+++ b/org/mozilla/jss/pkcs7/SignedData.java
@@ -378,7 +378,7 @@ public class SignedData implements ASN1Value {
             throws IOException, InvalidBERException
             {
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
-                Assert._assert(seq.size() == 6);
+                assert(seq.size() == 6);
 
                 return new SignedData(
                     (INTEGER)     seq.elementAt(0),

--- a/org/mozilla/jss/pkcs7/SignerInfo.java
+++ b/org/mozilla/jss/pkcs7/SignerInfo.java
@@ -289,7 +289,7 @@ public class SignerInfo implements ASN1Value {
 
         if( authenticatedAttributes != null )
         {
-            Assert._assert( authenticatedAttributes.size() >= 2 );
+            assert( authenticatedAttributes.size() >= 2 );
             this.authenticatedAttributes = authenticatedAttributes;
         }
 
@@ -699,7 +699,7 @@ public class SignerInfo implements ASN1Value {
      */
     private static boolean byteArraysAreSame(byte[] left, byte[] right) {
 
-        Assert._assert(left!=null && right!=null);
+        assert(left!=null && right!=null);
 
         if( left.length != right.length ) {
             return false;
@@ -804,7 +804,7 @@ public class SignerInfo implements ASN1Value {
             throws IOException, InvalidBERException
             {
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag,istream);
-                Assert._assert(seq.size() == 7);
+                assert(seq.size() == 7);
 
                 return new SignerInfo(
                     (INTEGER)                   seq.elementAt(0),

--- a/org/mozilla/jss/pkix/cert/CertificateInfo.java
+++ b/org/mozilla/jss/pkix/cert/CertificateInfo.java
@@ -224,7 +224,7 @@ public class CertificateInfo implements ASN1Value {
      * Should only be called if this field is present.
      */
     public BIT_STRING getIssuerUniqueIdentifier() {
-        Assert._assert(issuerUniqueIdentifier != null);
+        assert(issuerUniqueIdentifier != null);
         return issuerUniqueIdentifier;
     }
 
@@ -245,7 +245,7 @@ public class CertificateInfo implements ASN1Value {
         return (subjectUniqueIdentifier!=null);
     }
     public BIT_STRING getSubjectUniqueIdentifier() {
-        Assert._assert(subjectUniqueIdentifier != null);
+        assert(subjectUniqueIdentifier != null);
         return subjectUniqueIdentifier;
     }
 
@@ -297,7 +297,7 @@ public class CertificateInfo implements ASN1Value {
 
             int size = extensions.size();
             for(int i=0; i < size; i++) {
-                Assert._assert(extensions.elementAt(i) instanceof Extension);
+                assert(extensions.elementAt(i) instanceof Extension);
             }
 
         verifyNotNull(extensions);

--- a/org/mozilla/jss/pkix/cert/SubjectKeyIdentifier.java
+++ b/org/mozilla/jss/pkix/cert/SubjectKeyIdentifier.java
@@ -80,7 +80,7 @@ public class SubjectKeyIdentifier extends Extension {
             throws IOException, InvalidBERException
         {
             SEQUENCE seq = (SEQUENCE) seqt.decode(implicit, istream);
-            Assert._assert( ((OBJECT_IDENTIFIER) seq.elementAt(0)).equals(OID) );
+            assert( ((OBJECT_IDENTIFIER) seq.elementAt(0)).equals(OID) );
 
             return new SubjectKeyIdentifier(
                 ((BOOLEAN) seq.elementAt(1)).toBoolean(),

--- a/org/mozilla/jss/pkix/cmc/BodyPartReference.java
+++ b/org/mozilla/jss/pkix/cmc/BodyPartReference.java
@@ -104,7 +104,7 @@ public class BodyPartReference implements ASN1Value {
      */
     public void addBodyPartId(int id) {
         INTEGER id1 = new INTEGER(id);
-        Assert._assert(id1.compareTo(BODYIDMAX) <= 0);
+        assert(id1.compareTo(BODYIDMAX) <= 0);
         bodyPartPath.addElement( id1 );
     }
 
@@ -138,7 +138,7 @@ public class BodyPartReference implements ASN1Value {
         if (type == BodyPartID ) {
             return INTEGER.TAG;
         } else {
-            Assert._assert( type == BodyPartPath);
+            assert( type == BodyPartPath);
             return SEQUENCE.TAG;
         }
     }
@@ -147,7 +147,7 @@ public class BodyPartReference implements ASN1Value {
         if (type == BodyPartID ) {
             bodyPartID.encode(ostream);
         } else {
-            Assert._assert( type == BodyPartPath);
+            assert( type == BodyPartPath);
             bodyPartPath.encode(ostream);
         }
     }
@@ -188,7 +188,7 @@ public class BodyPartReference implements ASN1Value {
             if( c.getTag().equals(INTEGER.TAG) ) {
                 return new BodyPartReference(BodyPartID, (INTEGER) c.getValue() , null);
             } else {
-                Assert._assert( c.getTag().equals(SEQUENCE.TAG) );
+                assert( c.getTag().equals(SEQUENCE.TAG) );
                 return new BodyPartReference(BodyPartPath, null, (SEQUENCE) c.getValue());
             }
         }

--- a/org/mozilla/jss/pkix/cmc/CMCStatusInfo.java
+++ b/org/mozilla/jss/pkix/cmc/CMCStatusInfo.java
@@ -129,7 +129,7 @@ public class CMCStatusInfo implements ASN1Value {
      */
     public void addBodyPartID(int id) {
 		INTEGER id1 = new INTEGER(id);
-        Assert._assert(id1.compareTo(BODYIDMAX) <= 0);
+        assert(id1.compareTo(BODYIDMAX) <= 0);
         bodyList.addElement( id1 );
     }
 

--- a/org/mozilla/jss/pkix/cmc/CMCStatusInfoV2.java
+++ b/org/mozilla/jss/pkix/cmc/CMCStatusInfoV2.java
@@ -174,7 +174,7 @@ public class CMCStatusInfoV2 implements ASN1Value {
      */
     public void addBodyPartID(int id) {
         INTEGER id1 = new INTEGER(id);
-        Assert._assert(id1.compareTo(BODYIDMAX) <= 0);
+        assert(id1.compareTo(BODYIDMAX) <= 0);
         bodyList.addElement( id1 );
     }
 

--- a/org/mozilla/jss/pkix/cmc/ExtendedFailInfo.java
+++ b/org/mozilla/jss/pkix/cmc/ExtendedFailInfo.java
@@ -141,7 +141,7 @@ public class ExtendedFailInfo implements ASN1Value {
             SEQUENCE seq = (SEQUENCE) seqt.decode(implicit, istream);
 
             // The template should have enforced this
-            Assert._assert(seq.size() == 2);
+            assert(seq.size() == 2);
 
             return new ExtendedFailInfo( (OBJECT_IDENTIFIER) seq.elementAt(0),
                                             seq.elementAt(1) );

--- a/org/mozilla/jss/pkix/cmc/LraPopWitness.java
+++ b/org/mozilla/jss/pkix/cmc/LraPopWitness.java
@@ -60,7 +60,7 @@ public class LraPopWitness implements ASN1Value {
      */
     public void addBodyPartId(int id) {
         INTEGER id1 = new INTEGER(id);
-        Assert._assert(id1.compareTo(BODYIDMAX) <= 0);
+        assert(id1.compareTo(BODYIDMAX) <= 0);
         bodyIds.addElement( id1 );
     }
 

--- a/org/mozilla/jss/pkix/cmc/OtherInfo.java
+++ b/org/mozilla/jss/pkix/cmc/OtherInfo.java
@@ -107,7 +107,7 @@ public class OtherInfo implements ASN1Value {
                     +" parameter failInfo is null");
             }
         } else {
-            Assert._assert( type == PEND );
+            assert( type == PEND );
             if (pendInfo == null) {
                 throw new IllegalArgumentException("OtherInfo constructor"
                     +" parameter pendInfo is null");
@@ -146,7 +146,7 @@ public class OtherInfo implements ASN1Value {
                     +" parameter pendInfo is null");
             }
         } else {
-            Assert._assert( type == EXTENDED );
+            assert( type == EXTENDED );
             if (extendedFailInfo == null) {
                 throw new IllegalArgumentException("OtherInfo constructor"
                     +" parameter extendedFailInfo is null");
@@ -208,7 +208,7 @@ public class OtherInfo implements ASN1Value {
         } else if( type == PEND ){
             return PendInfo.TAG;
         } else {
-            Assert._assert( type == EXTENDED );
+            assert( type == EXTENDED );
             return ExtendedFailInfo.TAG;
         }
     }
@@ -220,7 +220,7 @@ public class OtherInfo implements ASN1Value {
         } else if( type == PEND ){
             pendInfo.encode(ostream);
         } else {
-            Assert._assert( type == EXTENDED );
+            assert( type == EXTENDED );
             extendedFailInfo.encode(ostream);
         }
     }
@@ -263,7 +263,7 @@ public class OtherInfo implements ASN1Value {
             } else if( c.getTag().equals(PendInfo.TAG) ) {
                 return new OtherInfo(PEND, null, (PendInfo) c.getValue(), null);
             } else {
-                Assert._assert( c.getTag().equals(ExtendedFailInfo.TAG) );
+                assert( c.getTag().equals(ExtendedFailInfo.TAG) );
                 return new OtherInfo(EXTENDED, null, null, (ExtendedFailInfo) c.getValue());
             }
         }

--- a/org/mozilla/jss/pkix/cmc/PKIData.java
+++ b/org/mozilla/jss/pkix/cmc/PKIData.java
@@ -135,7 +135,7 @@ public class PKIData implements ASN1Value {
         {
             SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
 
-            Assert._assert(seq.size() == 4);
+            assert(seq.size() == 4);
 
             return new PKIData(
                             (SEQUENCE)      seq.elementAt(0),

--- a/org/mozilla/jss/pkix/cmc/PendInfo.java
+++ b/org/mozilla/jss/pkix/cmc/PendInfo.java
@@ -128,7 +128,7 @@ public class PendInfo implements ASN1Value {
         {
             SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
 
-            Assert._assert(seq.size() == 2);
+            assert(seq.size() == 2);
 
             return new PendInfo(
                             (OCTET_STRING)      seq.elementAt(0),

--- a/org/mozilla/jss/pkix/cmc/ResponseBody.java
+++ b/org/mozilla/jss/pkix/cmc/ResponseBody.java
@@ -125,7 +125,7 @@ public class ResponseBody implements ASN1Value {
         {
             SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
 
-            Assert._assert(seq.size() == 3);
+            assert(seq.size() == 3);
 
             return new ResponseBody(
                             (SEQUENCE)      seq.elementAt(0),

--- a/org/mozilla/jss/pkix/cmc/TaggedAttribute.java
+++ b/org/mozilla/jss/pkix/cmc/TaggedAttribute.java
@@ -50,7 +50,7 @@ public class TaggedAttribute implements ASN1Value {
 
     public TaggedAttribute(INTEGER bodyPartID, OBJECT_IDENTIFIER type, SET values) {
         sequence = new SEQUENCE();
-        Assert._assert(bodyPartID.compareTo(BODYIDMAX) <= 0);
+        assert(bodyPartID.compareTo(BODYIDMAX) <= 0);
         this.bodyPartID = bodyPartID;
         sequence.addElement(bodyPartID);
         this.type = type;
@@ -61,7 +61,7 @@ public class TaggedAttribute implements ASN1Value {
 
     public TaggedAttribute(INTEGER bodyPartID, OBJECT_IDENTIFIER type, ASN1Value value) {
         sequence = new SEQUENCE();
-        Assert._assert(bodyPartID.compareTo(BODYIDMAX) <= 0);
+        assert(bodyPartID.compareTo(BODYIDMAX) <= 0);
         this.bodyPartID = bodyPartID;
         sequence.addElement(bodyPartID);
         this.type = type;
@@ -145,7 +145,7 @@ public class TaggedAttribute implements ASN1Value {
 			SEQUENCE seq = (SEQUENCE) seqt.decode(implicit, istream);
 
 			// The template should have enforced this
-			Assert._assert(seq.size() == 3);
+			assert(seq.size() == 3);
 
 			return new TaggedAttribute(
                             (INTEGER)      seq.elementAt(0),

--- a/org/mozilla/jss/pkix/cmc/TaggedCertificationRequest.java
+++ b/org/mozilla/jss/pkix/cmc/TaggedCertificationRequest.java
@@ -51,7 +51,7 @@ public class TaggedCertificationRequest implements ASN1Value {
      */
     public TaggedCertificationRequest(INTEGER bodyPartID, CertificationRequest certificationRequest) {
         sequence = new SEQUENCE();
-        Assert._assert(bodyPartID.compareTo(BODYIDMAX) <= 0);
+        assert(bodyPartID.compareTo(BODYIDMAX) <= 0);
         this.bodyPartID = bodyPartID;
         sequence.addElement(bodyPartID);
         this.certificationRequest = certificationRequest;
@@ -120,7 +120,7 @@ public class TaggedCertificationRequest implements ASN1Value {
         {
             SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
 
-            Assert._assert(seq.size() == 2);
+            assert(seq.size() == 2);
 
             return new TaggedCertificationRequest(
                             (INTEGER)      seq.elementAt(0),

--- a/org/mozilla/jss/pkix/cmc/TaggedRequest.java
+++ b/org/mozilla/jss/pkix/cmc/TaggedRequest.java
@@ -134,7 +134,7 @@ public class TaggedRequest implements ASN1Value {
         } else if( type == CRMF ){
             return Tag.get(1);
         } else {
-            Assert._assert( type == OTHER );
+            assert( type == OTHER );
             return Tag.get(2);
         }
     }
@@ -152,7 +152,7 @@ public class TaggedRequest implements ASN1Value {
             //EXPLICIT e = new EXPLICIT( Tag.get(1), crm );
             //e.encode(ostream);
         } else {
-            Assert._assert( type == OTHER );
+            assert( type == OTHER );
             orm.encode(Tag.get(2), ostream);
             // a CHOICE must be explicitly tagged
             //EXPLICIT e = new EXPLICIT( Tag.get(2), orm );
@@ -217,7 +217,7 @@ public class TaggedRequest implements ASN1Value {
                 //            e.getContent(), null );
                 return new TaggedRequest(CRMF, null, (CertReqMsg) c.getValue() , null);
             } else {
-                Assert._assert( c.getTag().equals(Tag.get(2)) );
+                assert( c.getTag().equals(Tag.get(2)) );
                 //EXPLICIT e = (EXPLICIT) c.getValue();
                 //return new TaggedRequest(OTHER, null,
                 //            (CertReqMsg) e.getContent() );

--- a/org/mozilla/jss/pkix/cmmf/CertOrEncCert.java
+++ b/org/mozilla/jss/pkix/cmmf/CertOrEncCert.java
@@ -44,7 +44,7 @@ public class CertOrEncCert implements ASN1Value {
     public void encode(Tag implicitTag, OutputStream ostream)
         throws IOException
     {
-        Assert._assert( implicitTag.equals(TAG) );
+        assert( implicitTag.equals(TAG) );
         ostream.write(encoding);
     }
 }

--- a/org/mozilla/jss/pkix/cmmf/CertResponse.java
+++ b/org/mozilla/jss/pkix/cmmf/CertResponse.java
@@ -51,7 +51,7 @@ public class CertResponse implements ASN1Value {
      * the certifiedKeyPair field is present.
      */
     public CertifiedKeyPair getCertifiedKeyPair() {
-        Assert._assert(certifiedKeyPair!=null);
+        assert(certifiedKeyPair!=null);
         return certifiedKeyPair;
     }
 

--- a/org/mozilla/jss/pkix/cms/ContentInfo.java
+++ b/org/mozilla/jss/pkix/cms/ContentInfo.java
@@ -225,7 +225,7 @@ public class ContentInfo implements ASN1Value {
             throws IOException, InvalidBERException
             {
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag,istream);
-                Assert._assert(seq.size() == 2);
+                assert(seq.size() == 2);
                 ASN1Value content;
 
                 if( seq.elementAt(1) == null ) {

--- a/org/mozilla/jss/pkix/cms/DigestInfo.java
+++ b/org/mozilla/jss/pkix/cms/DigestInfo.java
@@ -64,7 +64,7 @@ public class DigestInfo implements ASN1Value {
      */
     private static boolean byteArraysAreSame(byte[] left, byte[] right) {
 
-        Assert._assert(left!=null && right!=null);
+        assert(left!=null && right!=null);
 
         if( left.length != right.length ) {
             return false;

--- a/org/mozilla/jss/pkix/cms/EncapsulatedContentInfo.java
+++ b/org/mozilla/jss/pkix/cms/EncapsulatedContentInfo.java
@@ -128,7 +128,7 @@ public class EncapsulatedContentInfo implements ASN1Value {
             throws IOException, InvalidBERException
             {
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag,istream);
-                Assert._assert(seq.size() == 2);
+                assert(seq.size() == 2);
                 ASN1Value content;
 
                 if( seq.elementAt(1) == null ) {

--- a/org/mozilla/jss/pkix/cms/EncryptedContentInfo.java
+++ b/org/mozilla/jss/pkix/cms/EncryptedContentInfo.java
@@ -331,7 +331,7 @@ public class EncryptedContentInfo implements ASN1Value {
                 seqt.addOptionalElement(new Tag(0), new OCTET_STRING.Template());
 
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag,istream);
-                Assert._assert(seq.size() ==3);
+                assert(seq.size() ==3);
 
                 return new EncryptedContentInfo(
                     (OBJECT_IDENTIFIER)   seq.elementAt(0),

--- a/org/mozilla/jss/pkix/cms/EnvelopedData.java
+++ b/org/mozilla/jss/pkix/cms/EnvelopedData.java
@@ -92,7 +92,7 @@ public class EnvelopedData implements ASN1Value {
                 seqt.addElement(new EncryptedContentInfo.Template());
 
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag,istream);
-                Assert._assert(seq.size() ==3);
+                assert(seq.size() ==3);
 
                 return new EnvelopedData(
                     (INTEGER)               seq.elementAt(0),

--- a/org/mozilla/jss/pkix/cms/IssuerAndSerialNumber.java
+++ b/org/mozilla/jss/pkix/cms/IssuerAndSerialNumber.java
@@ -114,7 +114,7 @@ public class IssuerAndSerialNumber implements ASN1Value {
         {
             SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
 
-            Assert._assert(seq.size() == 2);
+            assert(seq.size() == 2);
 
             return new IssuerAndSerialNumber(
                             (Name)      seq.elementAt(0),

--- a/org/mozilla/jss/pkix/cms/RecipientInfo.java
+++ b/org/mozilla/jss/pkix/cms/RecipientInfo.java
@@ -60,9 +60,9 @@ public class RecipientInfo implements ASN1Value {
 			   AlgorithmIdentifier keyEncryptionAlgorithmID,
 			   OCTET_STRING encryptedKey) {
 
-	Assert._assert(issuerAndSerialNumber != null);
-	Assert._assert(keyEncryptionAlgorithmID != null);
-	Assert._assert(encryptedKey != null);
+	assert(issuerAndSerialNumber != null);
+	assert(keyEncryptionAlgorithmID != null);
+	assert(encryptedKey != null);
 
 
         this.version = version;
@@ -117,7 +117,7 @@ public class RecipientInfo implements ASN1Value {
                 seqt.addElement(new OCTET_STRING.Template());
 
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag,istream);
-                Assert._assert(seq.size() ==4);
+                assert(seq.size() ==4);
 
                 return new RecipientInfo(
                     (INTEGER)               seq.elementAt(0),

--- a/org/mozilla/jss/pkix/cms/SignedData.java
+++ b/org/mozilla/jss/pkix/cms/SignedData.java
@@ -382,7 +382,7 @@ public class SignedData implements ASN1Value {
             throws IOException, InvalidBERException
             {
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
-                Assert._assert(seq.size() == 6);
+                assert(seq.size() == 6);
 
                 return new SignedData(
                     (INTEGER)     seq.elementAt(0),

--- a/org/mozilla/jss/pkix/cms/SignerIdentifier.java
+++ b/org/mozilla/jss/pkix/cms/SignerIdentifier.java
@@ -109,7 +109,7 @@ public class SignerIdentifier implements ASN1Value {
         if( type == SUBJECT_KEY_IDENTIFIER ) {
             return Tag.get(0);
         } else {
-            Assert._assert( type == ISSUER_AND_SERIALNUMBER );
+            assert( type == ISSUER_AND_SERIALNUMBER );
             return IssuerAndSerialNumber.TAG;
         }
     }
@@ -122,7 +122,7 @@ public class SignerIdentifier implements ASN1Value {
             //e.encode(ostream);
             subjectKeyIdentifier.encode(Tag.get(0), ostream);
         } else {
-            Assert._assert( type == ISSUER_AND_SERIALNUMBER );
+            assert( type == ISSUER_AND_SERIALNUMBER );
             issuerAndSerialNumber.encode(ostream);
         }
     }
@@ -166,7 +166,7 @@ public class SignerIdentifier implements ASN1Value {
             if( c.getTag() == SEQUENCE.TAG ) {
                 return createIssuerAndSerialNumber( (IssuerAndSerialNumber) c.getValue() );
             } else {
-                Assert._assert( c.getTag().equals(Tag.get(0)) );
+                assert( c.getTag().equals(Tag.get(0)) );
                 //EXPLICIT e = (EXPLICIT) c.getValue();
 				//ASN1Value dski =  e.getContent();
 				//OCTET_STRING ski = (OCTET_STRING) e.getContent();

--- a/org/mozilla/jss/pkix/cms/SignerInfo.java
+++ b/org/mozilla/jss/pkix/cms/SignerInfo.java
@@ -227,7 +227,7 @@ public class SignerInfo implements ASN1Value {
 
         if( signedAttributes != null ) 
         {
-            Assert._assert( signedAttributes.size() >= 2 );
+            assert( signedAttributes.size() >= 2 );
             this.signedAttributes = signedAttributes;
         }
 
@@ -346,7 +346,7 @@ public class SignerInfo implements ASN1Value {
 				issuerAndSerialNumber.getSerialNumber()  );
 			verify(messageDigest, contentType, cert.getPublicKey());
 		} else {
-            Assert._assert(
+            assert(
 						  signerIdentifier.getType().equals(SignerIdentifier.SUBJECT_KEY_IDENTIFIER) );
 
 			// XXX Do we have method to get key using keyIdentifier
@@ -653,7 +653,7 @@ public class SignerInfo implements ASN1Value {
      */
     private static boolean byteArraysAreSame(byte[] left, byte[] right) {
 
-        Assert._assert(left!=null && right!=null);
+        assert(left!=null && right!=null);
 
         if( left.length != right.length ) {
             return false;
@@ -758,7 +758,7 @@ public class SignerInfo implements ASN1Value {
             throws IOException, InvalidBERException
             {
                 SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag,istream);
-                Assert._assert(seq.size() == 7);
+                assert(seq.size() == 7);
 
                 return new SignerInfo(
                     (INTEGER)                   seq.elementAt(0),

--- a/org/mozilla/jss/pkix/crmf/CertReqMsg.java
+++ b/org/mozilla/jss/pkix/crmf/CertReqMsg.java
@@ -63,7 +63,7 @@ public class CertReqMsg implements ASN1Value {
      * field is present.
      */
     public SEQUENCE getRegInfo() {
-        Assert._assert(regInfo != null);
+        assert(regInfo != null);
         return regInfo;
     }
     private SEQUENCE regInfo;
@@ -80,7 +80,7 @@ public class CertReqMsg implements ASN1Value {
      * field is present.
      */
     public ProofOfPossession getPop() {
-        Assert._assert(pop != null);
+        assert(pop != null);
         return pop;
     }
     private ProofOfPossession pop = null;

--- a/org/mozilla/jss/pkix/crmf/EncryptedKey.java
+++ b/org/mozilla/jss/pkix/crmf/EncryptedKey.java
@@ -94,14 +94,14 @@ public class EncryptedKey implements ASN1Value {
             throws IOException {
 
         // no IMPLICIT tags allowed on ANY
-        Assert._assert( getTag().equals(implicitTag));
+        assert( getTag().equals(implicitTag));
 
         if( type == ENCRYPTED_VALUE ) {
-            Assert._assert( encryptedValue != null );
+            assert( encryptedValue != null );
             encryptedValue.encode(implicitTag, ostream);
         } else {
-            Assert._assert(type == ENVELOPED_DATA);
-            Assert._assert(envelopedData != null);
+            assert(type == ENVELOPED_DATA);
+            assert(envelopedData != null);
             envelopedData.encode(implicitTag, ostream);
         }
     }
@@ -138,7 +138,7 @@ public class EncryptedKey implements ASN1Value {
             if( choice.getTag().equals(SEQUENCE.TAG) ) {
                 return new EncryptedKey( (EncryptedValue) choice.getValue() );
             } else {
-                Assert._assert( choice.getTag().equals(new Tag(0)) );
+                assert( choice.getTag().equals(new Tag(0)) );
                 return new EncryptedKey( (ANY) choice.getValue() );
             }
 

--- a/org/mozilla/jss/pkix/crmf/PKIArchiveOptions.java
+++ b/org/mozilla/jss/pkix/crmf/PKIArchiveOptions.java
@@ -57,7 +57,7 @@ public class PKIArchiveOptions implements ASN1Value {
      * is <code>ENCRYPTED_PRIV_KEY</code>.
      */
     public EncryptedKey getEncryptedKey( ) {
-        Assert._assert(type == ENCRYPTED_PRIV_KEY);
+        assert(type == ENCRYPTED_PRIV_KEY);
         return encryptedPrivKey;
     }
 
@@ -65,7 +65,7 @@ public class PKIArchiveOptions implements ASN1Value {
      * Returns the key gen parameters. Should only be called if the type
      * is <code>KEY_GEN_PARAMETERS</code>.
     public byte[] getKeyGenParameters( ) {
-        Assert._assert(type == KEY_GEN_PARAMETERS);
+        assert(type == KEY_GEN_PARAMETERS);
         return keyGenParameters;
     }
 
@@ -76,7 +76,7 @@ public class PKIArchiveOptions implements ASN1Value {
      * <code>ARCHIVE_REM_GEN_PRIV_KEY</code>.
      */
     public boolean getArchiveRemGenPrivKey( ) {
-        Assert._assert( type == ARCHIVE_REM_GEN_PRIV_KEY );
+        assert( type == ARCHIVE_REM_GEN_PRIV_KEY );
         return archiveRemGenPrivKey;
     }
 
@@ -126,7 +126,7 @@ public class PKIArchiveOptions implements ASN1Value {
         throws IOException
     {
         // no implicit tags on a CHOICE
-        Assert._assert( implicitTag.equals(tag) );
+        assert( implicitTag.equals(tag) );
 
         if( type == ENCRYPTED_PRIV_KEY ) {
             // CHOICEs are always EXPLICITly tagged
@@ -135,7 +135,7 @@ public class PKIArchiveOptions implements ASN1Value {
         } else if( type == KEY_GEN_PARAMETERS ) {
             keyGenParameters.encode(tag, ostream);
         } else {
-            Assert._assert( type == ARCHIVE_REM_GEN_PRIV_KEY );
+            assert( type == ARCHIVE_REM_GEN_PRIV_KEY );
             (new BOOLEAN(archiveRemGenPrivKey)).encode(tag, ostream);
         }
     }

--- a/org/mozilla/jss/pkix/crmf/POPOPrivKey.java
+++ b/org/mozilla/jss/pkix/crmf/POPOPrivKey.java
@@ -147,7 +147,7 @@ public class POPOPrivKey implements ASN1Value {
         } else if(type == SUBSEQUENT_MESSAGE) {
             return Tag.get(1);
         } else {
-            Assert._assert(type == DHMAC);
+            assert(type == DHMAC);
             return Tag.get(2);
         }
     }
@@ -158,7 +158,7 @@ public class POPOPrivKey implements ASN1Value {
         } else if(type == SUBSEQUENT_MESSAGE) {
             subsequentMessage.encode(Tag.get(1), ostream);
         } else {
-            Assert._assert(type == DHMAC);
+            assert(type == DHMAC);
             dhMAC.encode(Tag.get(2), ostream);
         }
     }
@@ -225,7 +225,7 @@ public class POPOPrivKey implements ASN1Value {
                 }
                 return createSubsequentMessage( i );
             } else {
-                Assert._assert( chosen.equals(Tag.get(2)) );
+                assert( chosen.equals(Tag.get(2)) );
                 return createDhMAC( (BIT_STRING) choice.getValue() );
             }
         }

--- a/org/mozilla/jss/pkix/crmf/ProofOfPossession.java
+++ b/org/mozilla/jss/pkix/crmf/ProofOfPossession.java
@@ -151,7 +151,7 @@ public class ProofOfPossession implements ASN1Value {
         } else if( type == KEY_ENCIPHERMENT ) {
             return Tag.get(2);
         } else {
-            Assert._assert( type == KEY_AGREEMENT );
+            assert( type == KEY_AGREEMENT );
             return Tag.get(3);
         }
     }
@@ -167,7 +167,7 @@ public class ProofOfPossession implements ASN1Value {
             EXPLICIT e = new EXPLICIT( Tag.get(2), keyEncipherment );
             e.encode(ostream);
         } else {
-            Assert._assert( type == KEY_AGREEMENT );
+            assert( type == KEY_AGREEMENT );
             // a CHOICE must be explicitly tagged
             EXPLICIT e = new EXPLICIT( Tag.get(3), keyAgreement );
             e.encode(ostream);
@@ -176,7 +176,7 @@ public class ProofOfPossession implements ASN1Value {
 
     public void encode(Tag implicitTag, OutputStream ostream)
             throws IOException {
-        Assert._assert(implicitTag.equals(getTag()));
+        assert(implicitTag.equals(getTag()));
         encode(ostream);
     }
 
@@ -216,7 +216,7 @@ public class ProofOfPossession implements ASN1Value {
                 EXPLICIT e = (EXPLICIT) c.getValue();
                 return createKeyEncipherment( (POPOPrivKey) e.getContent() );
             } else {
-                Assert._assert( c.getTag().equals(Tag.get(3)) );
+                assert( c.getTag().equals(Tag.get(3)) );
                 EXPLICIT e = (EXPLICIT) c.getValue();
                 return createKeyAgreement( (POPOPrivKey) e.getContent() );
             }

--- a/org/mozilla/jss/pkix/primitive/AVA.java
+++ b/org/mozilla/jss/pkix/primitive/AVA.java
@@ -101,7 +101,7 @@ public static class Template implements ASN1Template {
         SEQUENCE seq = (SEQUENCE) seqt.decode(implicit, istream);
 
         // The template should have enforced this
-        Assert._assert(seq.size() == 2);
+        assert(seq.size() == 2);
 
         return new AVA( (OBJECT_IDENTIFIER) seq.elementAt(0),
                                             seq.elementAt(1) );

--- a/org/mozilla/jss/pkix/primitive/AlgorithmIdentifier.java
+++ b/org/mozilla/jss/pkix/primitive/AlgorithmIdentifier.java
@@ -100,7 +100,7 @@ public static class Template implements ASN1Template {
         SEQUENCE seq = (SEQUENCE) seqt.decode(implicit, istream);
 
         // the template should have enforced this
-        Assert._assert( seq.size() == 2 );
+        assert( seq.size() == 2 );
 
         OBJECT_IDENTIFIER algOID = (OBJECT_IDENTIFIER)seq.elementAt(0);
 

--- a/org/mozilla/jss/pkix/primitive/Attribute.java
+++ b/org/mozilla/jss/pkix/primitive/Attribute.java
@@ -105,7 +105,7 @@ public static class Template implements ASN1Template {
         SEQUENCE seq = (SEQUENCE) seqt.decode(implicit, istream);
 
         // The template should have enforced this
-        Assert._assert(seq.size() == 2);
+        assert(seq.size() == 2);
 
         return new Attribute( (OBJECT_IDENTIFIER) seq.elementAt(0),
                               (SET)               seq.elementAt(1));

--- a/org/mozilla/jss/pkix/primitive/DirectoryString.java
+++ b/org/mozilla/jss/pkix/primitive/DirectoryString.java
@@ -155,7 +155,7 @@ public class DirectoryString implements ASN1Value {
         public ASN1Value decode(Tag implicitTag, InputStream istream)
             throws IOException, InvalidBERException
         {
-            Assert._assert( tagMatch(implicitTag) );
+            assert( tagMatch(implicitTag) );
             return decode(istream);
         }
     }

--- a/org/mozilla/jss/provider/java/security/KeyFactorySpi1_2.java
+++ b/org/mozilla/jss/provider/java/security/KeyFactorySpi1_2.java
@@ -184,7 +184,7 @@ public class KeyFactorySpi1_2 extends java.security.KeyFactorySpi
             // we need to chop off a leading zero byte
             if( y.bitLength() % 8 == 0 ) {
                 byte[] newBA = new byte[yBA.length-1];
-                Assert._assert(newBA.length >= 0);
+                assert(newBA.length >= 0);
                 System.arraycopy(yBA, 1, newBA, 0, newBA.length);
                 yBA = newBA;
             }

--- a/org/mozilla/jss/provider/javax/crypto/JSSCipherSpi.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSCipherSpi.java
@@ -158,7 +158,7 @@ class JSSCipherSpi extends javax.crypto.CipherSpi {
                 cipher.initDecrypt(symkey, params);
             }
         } else {
-            Assert._assert(
+            assert(
                 opmode==Cipher.WRAP_MODE || opmode==Cipher.UNWRAP_MODE);
             wrapAlg = KeyWrapAlgorithm.fromString(buf.toString());
             blockSize = wrapAlg.getBlockSize();
@@ -169,7 +169,7 @@ class JSSCipherSpi extends javax.crypto.CipherSpi {
                 if( opmode == Cipher.WRAP_MODE ) {
                     params = generateAlgParams(wrapAlg, blockSize);
                 } else {
-                    Assert._assert(opmode == Cipher.UNWRAP_MODE);
+                    assert(opmode == Cipher.UNWRAP_MODE);
                     params = null;
                 }
             }
@@ -193,7 +193,7 @@ class JSSCipherSpi extends javax.crypto.CipherSpi {
                 if( opmode == Cipher.WRAP_MODE ) {
                     wrapper.initWrap( sk.key, params );
                 } else {
-                    Assert._assert(opmode==Cipher.UNWRAP_MODE);
+                    assert(opmode==Cipher.UNWRAP_MODE);
                     wrapper.initUnwrap( sk.key, params );
                 }
             } else {

--- a/org/mozilla/jss/tests/TestKeyGen.java
+++ b/org/mozilla/jss/tests/TestKeyGen.java
@@ -78,7 +78,7 @@ public class TestKeyGen {
             try {
                 kpg.initialize(512);
                 keyPair = kpg.genKeyPair();
-                Assert._assert( keyPair.getPublic() instanceof RSAPublicKey);
+                assert( keyPair.getPublic() instanceof RSAPublicKey);
                 rsaPubKey = (RSAPublicKey) keyPair.getPublic();
                 System.out.println("Generated 512-bit RSA KeyPair!");
                 System.out.println("Modulus: "+rsaPubKey.getModulus());
@@ -98,7 +98,7 @@ public class TestKeyGen {
             try {
                 kpg.initialize(1024);
                 keyPair = kpg.genKeyPair();
-                Assert._assert( keyPair.getPublic() instanceof RSAPublicKey);
+                assert( keyPair.getPublic() instanceof RSAPublicKey);
                 rsaPubKey = (RSAPublicKey) keyPair.getPublic();
                 System.out.println("Generated 1024-bit RSA KeyPair!");
                 System.out.println("Modulus: "+rsaPubKey.getModulus());
@@ -119,7 +119,7 @@ public class TestKeyGen {
                 rsaParams = new RSAParameterSpec(512, BigInteger.valueOf(3));
                 kpg.initialize(rsaParams);
                 keyPair = kpg.genKeyPair();
-                Assert._assert( keyPair.getPublic() instanceof RSAPublicKey);
+                assert( keyPair.getPublic() instanceof RSAPublicKey);
                 rsaPubKey = (RSAPublicKey) keyPair.getPublic();
                 System.out.println("Generated 512-bit RSA KeyPair with public exponent=3!");
                 System.out.println("Modulus: "+rsaPubKey.getModulus());
@@ -140,7 +140,7 @@ public class TestKeyGen {
             try {
                 kpg.initialize(512);
                 keyPair = kpg.genKeyPair();
-                Assert._assert( keyPair.getPublic() instanceof DSAPublicKey);
+                assert( keyPair.getPublic() instanceof DSAPublicKey);
                 dsaPubKey = (DSAPublicKey) keyPair.getPublic();
                 System.out.println("Generated 512-bit DSA KeyPair!");
                 dsaParams = dsaPubKey.getParams();
@@ -163,7 +163,7 @@ public class TestKeyGen {
             try {
                 kpg.initialize(PK11KeyPairGenerator.PQG1024);
                 keyPair = kpg.genKeyPair();
-                Assert._assert( keyPair.getPublic() instanceof DSAPublicKey);
+                assert( keyPair.getPublic() instanceof DSAPublicKey);
                 dsaPubKey = (DSAPublicKey) keyPair.getPublic();
                 System.out.println("Generated 1024-bit DSA KeyPair with PQG params!");
                 dsaParams = dsaPubKey.getParams();

--- a/org/mozilla/jss/tests/UTF8ConverterTest.java
+++ b/org/mozilla/jss/tests/UTF8ConverterTest.java
@@ -50,12 +50,12 @@ public class UTF8ConverterTest {
         }
         System.out.println();
 
-        Assert._assert(utf8 != null);
+        assert(utf8 != null);
 
-        Assert._assert(utf8.length == output.length);
+        assert(utf8.length == output.length);
 
         for(int i=0; i<output.length; i++) {
-            Assert._assert(utf8[i] == output[i]);
+            assert(utf8[i] == output[i]);
         }
     }
 

--- a/org/mozilla/jss/util/Assert.java
+++ b/org/mozilla/jss/util/Assert.java
@@ -15,7 +15,9 @@ public class Assert {
      * throwing an AssertionException.
      *
      * @param cond The condition that is being tested.
+     * @deprecated The assert keyword should be used instead.
      */
+    @Deprecated
     public static void _assert(boolean cond) {
         if(!cond) {
             throw new org.mozilla.jss.util.AssertionException(
@@ -29,7 +31,9 @@ public class Assert {
      *
      * @param cond The condition that is being tested.
      * @param msg A message describing what is wrong if the condition is false.
+     * @deprecated The assert keyword should be used instead.
      */
+    @Deprecated
 	public static void _assert(boolean cond, String msg) {
 		if(!cond) {
 			throw new org.mozilla.jss.util.AssertionException(msg);

--- a/org/mozilla/jss/util/Base64InputStream.java
+++ b/org/mozilla/jss/util/Base64InputStream.java
@@ -155,7 +155,7 @@ public class Base64InputStream extends FilterInputStream {
                 return -1;
                 //break;
               default:
-                Assert._assert(false);
+                assert(false);
                 break;
             }
         }
@@ -187,10 +187,10 @@ public class Base64InputStream extends FilterInputStream {
                 }
             }
             if( cur == WOULD_BLOCK ) {
-                Assert._assert(count>0);
+                assert(count>0);
                 return count;
             }
-            Assert._assert( cur >= 0 && cur <= 255);
+            assert( cur >= 0 && cur <= 255);
             b[off+(count++)] = (byte) cur;
         }
         return count;

--- a/org/mozilla/jss/util/Base64OutputStream.java
+++ b/org/mozilla/jss/util/Base64OutputStream.java
@@ -39,7 +39,7 @@ public class Base64OutputStream extends FilterOutputStream {
 	public Base64OutputStream(PrintStream out, int quadsPerLine) {
 		this(out);
 		doLineBreaks = true;
-		Assert._assert(quadsPerLine>0, "quadsPerLine must be > 0");
+		assert(quadsPerLine > 0);
 		charsPerLine = quadsPerLine*4;
 	}
 		
@@ -53,10 +53,10 @@ public class Base64OutputStream extends FilterOutputStream {
 					((PrintStream)out).println();
 					charsOnLine=0;
 				}
-				Assert._assert(charsOnLine < charsPerLine);
+				assert(charsOnLine < charsPerLine);
 			}
 		}
-		Assert._assert(inputCount < 3);
+		assert(inputCount < 3);
 	}
 
 	/**

--- a/org/mozilla/jss/util/NativeProxy.java
+++ b/org/mozilla/jss/util/NativeProxy.java
@@ -34,7 +34,7 @@ public abstract class NativeProxy
      * NativeProxy instance acts as a proxy for that native data structure.
      */
     public NativeProxy(byte[] pointer) {
-		Assert._assert(pointer!=null);
+		assert(pointer!=null);
         registryIndex = register();
         mPointer = pointer;
     }
@@ -150,7 +150,7 @@ public abstract class NativeProxy
         Long element;
 
         element = registry.remove(Lindex);
-        Assert._assert(element != null);
+        assert(element != null);
     }
 
     /**

--- a/org/mozilla/jss/util/Password.java
+++ b/org/mozilla/jss/util/Password.java
@@ -224,7 +224,7 @@ public class Password implements PasswordCallback, Cloneable,
 	public static byte[] charToByte(char[] charArray)
 	{
 		byte[] byteArray;
-		Assert._assert(charArray != null);
+		assert(charArray != null);
 		try {
 			byteArray = UTF8Converter.UnicodeToUTF8NullTerm(charArray);
 		} catch(CharConversionException e) {
@@ -242,7 +242,7 @@ public class Password implements PasswordCallback, Cloneable,
      * <code>null</code> must not be passed in.
 	 */
 	public static void wipeBytes(byte[] byteArray) {
-		Assert._assert(byteArray != null);
+		assert(byteArray != null);
 		UTF8Converter.wipeBytes(byteArray);
 	}
 
@@ -252,7 +252,7 @@ public class Password implements PasswordCallback, Cloneable,
 	 */
 	public static void wipeChars(char[] charArray) {
 		int i;
-		Assert._assert(charArray != null);
+		assert(charArray != null);
 		for(i=0; i < charArray.length; i++) {
 			charArray[i] = 0;
 		}

--- a/org/mozilla/jss/util/PasswordCallbackInfo.java
+++ b/org/mozilla/jss/util/PasswordCallbackInfo.java
@@ -16,7 +16,7 @@ public class PasswordCallbackInfo {
      *      <code>TOKEN</code>) that is being logged into.
      */
 	public PasswordCallbackInfo(String name, int type) {
-		Assert._assert(type==FILE || type==TOKEN);
+		assert(type==FILE || type==TOKEN);
 		this.name = name;
 		this.type = type;
 	}

--- a/org/mozilla/jss/util/UTF8Converter.java
+++ b/org/mozilla/jss/util/UTF8Converter.java
@@ -71,7 +71,7 @@ public class UTF8Converter {
 		int ucs4; // UCS4 encoding of a character
 		boolean failed = true;
 
-		Assert._assert(unicode != null);
+		assert(unicode != null);
 		if(unicode == null) {
 			return null;
 		}
@@ -205,7 +205,7 @@ public class UTF8Converter {
 	public static void wipeBytes(byte[] array) {
 		int i;
 
-		Assert._assert(array != null);
+		assert(array != null);
 		if(array == null) {
 			return;
 		}
@@ -270,7 +270,7 @@ public class UTF8Converter {
 		System.out.println("Maximum buffer size test:");
 		unicode = new char[] {'\uffff', '\uffff', '\uffff', '\uffff'};
 		utf8 = UnicodeToUTF8(unicode);
-		Assert._assert(utf8.length == 12);
+		assert(utf8.length == 12);
 		System.out.println("8 bytes of unicode --> "+utf8.length+
 			" bytes of utf8\n");
 
@@ -280,8 +280,8 @@ public class UTF8Converter {
 		System.out.println("Empty input test:");
 		unicode = new char[0];
 		utf8 = UnicodeToUTF8(unicode);
-		Assert._assert(utf8 != null);
-		Assert._assert(utf8.length == 0);
+		assert(utf8 != null);
+		assert(utf8.length == 0);
 		System.out.println("given 0 bytes Unicode, produces 0 length utf8\n");
 
 		//


### PR DESCRIPTION
Assert._assert is probably a relic from an older era. The class
incorrectly identifies them as "C-style assertions": the assert keyword
is actually closer to "C-style assertions" as they require the explicit
flag "-ea" (or "-enableassertions") to be passed to the JVM, similar to
how DEBUG needs to be defined for assert(...) to work in C.
    
In two places, where Assert._assert(false, msg) was called, I've instead
chosen to directly raise an org.mozilla.jss.util.AssertionException.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`
