### PR TITLE
Add exit(1) in failure case of TestBufferPRFD

### DIFF
--- a/org/mozilla/jss/tests/TestBufferPRFD.c
+++ b/org/mozilla/jss/tests/TestBufferPRFD.c
@@ -340,6 +340,7 @@ int main(int argc, char** argv)
         count += 1;
         if (count >= 40) {
             fprintf(stderr, "error: unable to make progress after %d steps!\n", count);
+            exit(1);
         }
     }
 


### PR DESCRIPTION
Fixes `std::bad_alloc` when building on s390x, where TestBufferPRFD wouldn't exit due to NSS bug. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`