### PR TITLE
Increase size of async io buffer in TestBufferPRFD

### DIFF
--- a/org/mozilla/jss/tests/TestBufferPRFD.c
+++ b/org/mozilla/jss/tests/TestBufferPRFD.c
@@ -292,8 +292,8 @@ int main(int argc, char** argv)
      * took access (or created access itself), we'd need to get access to
      * them befor giving it to NSS, as NSS wraps our PRFileDesc in one of
      * their PRFileDescs, removing our access to fd->secret. */
-    j_buffer *c_read_buf = jb_alloc(2048);
-    j_buffer *c_write_buf = jb_alloc(2048);
+    j_buffer *c_read_buf = jb_alloc(4096);
+    j_buffer *c_write_buf = jb_alloc(4096);
 
     PRFileDesc *c_nspr = newBufferPRFileDesc(c_read_buf, c_write_buf,
         (uint8_t*) "localhost", 9);


### PR DESCRIPTION
NSS on s390x seems to ignore the semantics of async io/`EWOULDBLOCK`:
rather than retrying the failing write, it drops the data and refuses to
continue. This manifests itself as RSA-based TLS handshakes failing,
because the certificate and associated packets exceeded the size of the
internal buffer (2048).

Bumping the buffer for the tests to 4096 plasters over the issue (so
long as we only include one certificate and not the entire chain).

redhat-bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1730109

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`