### PR TITLE
Support ECGenParameterSpec in PK11KeyPairGenerator

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.java
+++ b/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.java
@@ -5,6 +5,7 @@
 package org.mozilla.jss.pkcs11;
 
 import java.math.BigInteger;
+import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidParameterException;
 import java.security.KeyPair;
@@ -12,6 +13,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.DSAParameterSpec;
+import java.security.spec.ECGenParameterSpec;
 import java.util.Hashtable;
 
 import org.mozilla.jss.asn1.ASN1Util;
@@ -21,6 +23,7 @@ import org.mozilla.jss.crypto.PQGParams;
 import org.mozilla.jss.crypto.RSAParameterSpec;
 import org.mozilla.jss.crypto.TokenException;
 import org.mozilla.jss.util.Assert;
+import org.mozilla.jss.util.ECCurve;
 
 /**
  * A Key Pair Generator implemented using PKCS #11.
@@ -429,16 +432,26 @@ public final class PK11KeyPairGenerator
                 throw new InvalidAlgorithmParameterException();
             }
         } else {
-            assert( algorithm == KeyPairAlgorithm.EC);
-            // requires JAVA 1.5
-            // if(! (params instanceof ECParameterSpec) ) {
-            //   throw new InvalidAlgorithmParameterException();
-            //}
-            // requires JAVA 1.5
-            if(! (params instanceof PK11ParameterSpec) ) {
-               throw new InvalidAlgorithmParameterException();
+            assert(algorithm == KeyPairAlgorithm.EC);
+            if (params instanceof ECGenParameterSpec) {
+                ECGenParameterSpec standard_params = (ECGenParameterSpec)params;
+                String curve_name = standard_params.getName();
+                ECCurve curve = ECCurve.fromName(curve_name);
+                if (curve == null) {
+                    throw new InvalidAlgorithmParameterException("Unable to find curve with the given name: " + curve_name);
+                }
+
+                OBJECT_IDENTIFIER[] oid = curve.getOIDs();
+                assert(oid.length >= 1);
+
+                byte[] encoded_oid = ASN1Util.encode(oid[0]);
+                params = new PK11ParameterSpec(encoded_oid);
             }
-	} // future add support for X509EncodedSpec
+
+            if (!(params instanceof PK11ParameterSpec)) {
+                throw new InvalidAlgorithmParameterException("Expected params to either be an instance of ECGenParameterSpec or PK11ParameterSpec!");
+            }
+        } // future add support for X509EncodedSpec
 
         this.params = params;
     }

--- a/org/mozilla/jss/util/ECCurve.java
+++ b/org/mozilla/jss/util/ECCurve.java
@@ -158,4 +158,16 @@ public enum ECCurve {
 
         return null;
     }
+
+    public static ECCurve fromName(String name) {
+        for (ECCurve curve : ECCurve.values()) {
+            for (String curve_name : curve.names) {
+                if (curve_name.equalsIgnoreCase(name)) {
+                    return curve;
+                }
+            }
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
~Based on #230. Will be rebased once that gets reviewed and merged.~

The standard Java interface for EC key pair generation only includes a
name. Use the ECCurve enum to resolve this to an OID for use by NSS.
    
A similar patch was initially proposed by Andrew Helgeson (@ZuluForce)
in upstream issue https://github.com/dogtagpki/jss/issues/226.
    
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`