### PR TITLE
Support favoring other Cryptographic Providers

### DIFF
--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -522,8 +522,12 @@ public final class CryptoManager implements TokenSupplier
         logger.debug("Loaded " + kt);
 
         if( values.installJSSProvider ) {
-            int position = java.security.Security.insertProviderAt(
-                            new JSSProvider(), 1);
+            int insert_position = 1;
+            if (!values.installJSSProviderFirst) {
+                insert_position = java.security.Security.getProviders().length + 1;
+            }
+
+            int position = java.security.Security.insertProviderAt(new JSSProvider(), insert_position);
             if (position < 0) {
                 logger.warn("JSS provider is already installed");
             }

--- a/org/mozilla/jss/InitializationValues.java
+++ b/org/mozilla/jss/InitializationValues.java
@@ -402,6 +402,11 @@ public final class InitializationValues {
     public boolean removeSunProvider = false;
 
     /**
+     * Whether or not to initialize the JSS provider first. Default is true.
+     */
+    public boolean installJSSProviderFirst = true;
+
+    /**
      * If <code>true</code>, none of the underlying NSS components will
      * be initialized. Only the Java portions of JSS will be
      * initialized. This should only be used if NSS has been initialized


### PR DESCRIPTION
We're previously given the option to either install the JSS provider or
not, and optionally to remove the Sun Provider. Users can re-order the
providers later if they want, but the most common other option will be
to only use JSS for specified operations. To achieve this, we put JSS as
the very last provider. Hence, add:

    installJSSProviderFirst = true

as a new value in InitializationValues.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`