### PR TITLE
WIP: OCSP-sensitive TrustManager

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -397,6 +397,7 @@ Java_org_mozilla_jss_nss_Buffer_Free;
 JSS_4.6.2 {
     global:
 Java_org_mozilla_jss_pkcs11_PK11PrivKey_getPublicKey;
+Java_org_mozilla_jss_CryptoManager_importDERCertNative;
     local:
         *;
 };

--- a/org/mozilla/jss/CertificateUsage.java
+++ b/org/mozilla/jss/CertificateUsage.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 public final class CertificateUsage {
 
     private int usage;
+    private int value;
     private String name;
 
     // certificateUsage, these must be kept in sync with nss/lib/certdb/certt.h
@@ -28,18 +29,36 @@ public final class CertificateUsage {
     private static final int certificateUsageProtectedObjectSigner = 0x0200;
     private static final int certificateUsageStatusResponder = 0x0400;
     private static final int certificateUsageAnyCA = 0x0800;
+    private static final int certificateUsageIPsec = 0x1000;
+
+    // SECCertUsage enum values
+    private static final int certUsageSSLClient = 0;
+    private static final int certUsageSSLServer = 1;
+    private static final int certUsageSSLServerWithStepUp = 2;
+    private static final int certUsageSSLCA = 3;
+    private static final int certUsageEmailSigner = 4;
+    private static final int certUsageEmailRecipient = 5;
+    private static final int certUsageObjectSigner = 6;
+    private static final int certUsageUserCertImport = 7;
+    private static final int certUsageVerifyCA = 8;
+    private static final int certUsageProtectedObjectSigner = 9;
+    private static final int certUsageStatusResponder = 10;
+    private static final int certUsageAnyCA = 11;
+    private static final int certUsageIPsec = 12;
 
     static private ArrayList<CertificateUsage> list = new ArrayList<>();
 
     private CertificateUsage() {
     }
 
-    private CertificateUsage(int usage, String name) {
+    private CertificateUsage(int usage, int value, String name) {
         this.usage = usage;
+        this.value = value;
         this.name =  name;
         list.add(this);
 
     }
+
     public int getUsage() {
         return usage;
     }
@@ -48,23 +67,29 @@ public final class CertificateUsage {
         return list.iterator();
 
     }
+
     public String toString() {
         return name;
     }
 
-    public static final CertificateUsage CheckAllUsages = new CertificateUsage(certificateUsageCheckAllUsages, "CheckAllUsages");
-    public static final CertificateUsage SSLClient = new CertificateUsage(certificateUsageSSLClient, "SSLClient");
-    public static final CertificateUsage SSLServer = new CertificateUsage(certificateUsageSSLServer, "SSLServer");
-    public static final CertificateUsage SSLServerWithStepUp = new CertificateUsage(certificateUsageSSLServerWithStepUp, "SSLServerWithStepUp");
-    public static final CertificateUsage SSLCA = new CertificateUsage(certificateUsageSSLCA, "SSLCA");
-    public static final CertificateUsage EmailSigner = new CertificateUsage(certificateUsageEmailSigner, "EmailSigner");
-    public static final CertificateUsage EmailRecipient = new CertificateUsage(certificateUsageEmailRecipient, "EmailRecipient");
-    public static final CertificateUsage ObjectSigner = new CertificateUsage(certificateUsageObjectSigner, "ObjectSigner");
-    public static final CertificateUsage UserCertImport = new CertificateUsage(certificateUsageUserCertImport, "UserCertImport");
-    public static final CertificateUsage VerifyCA = new CertificateUsage(certificateUsageVerifyCA, "VerifyCA");
-    public static final CertificateUsage ProtectedObjectSigner = new CertificateUsage(certificateUsageProtectedObjectSigner, "ProtectedObjectSigner");
-    public static final CertificateUsage StatusResponder = new CertificateUsage(certificateUsageStatusResponder, "StatusResponder");
-    public static final CertificateUsage AnyCA = new CertificateUsage(certificateUsageAnyCA, "AnyCA");
+    public int getEnumValue() {
+        return value;
+    }
+
+    public static final CertificateUsage CheckAllUsages = new CertificateUsage(certificateUsageCheckAllUsages, -1, "CheckAllUsages");
+    public static final CertificateUsage SSLClient = new CertificateUsage(certificateUsageSSLClient, certUsageSSLClient, "SSLClient");
+    public static final CertificateUsage SSLServer = new CertificateUsage(certificateUsageSSLServer, certUsageSSLServer, "SSLServer");
+    public static final CertificateUsage SSLServerWithStepUp = new CertificateUsage(certificateUsageSSLServerWithStepUp, certUsageSSLServerWithStepUp, "SSLServerWithStepUp");
+    public static final CertificateUsage SSLCA = new CertificateUsage(certificateUsageSSLCA, certUsageSSLCA, "SSLCA");
+    public static final CertificateUsage EmailSigner = new CertificateUsage(certificateUsageEmailSigner, certUsageEmailSigner, "EmailSigner");
+    public static final CertificateUsage EmailRecipient = new CertificateUsage(certificateUsageEmailRecipient, certUsageEmailRecipient, "EmailRecipient");
+    public static final CertificateUsage ObjectSigner = new CertificateUsage(certificateUsageObjectSigner, certUsageObjectSigner, "ObjectSigner");
+    public static final CertificateUsage UserCertImport = new CertificateUsage(certificateUsageUserCertImport, certUsageUserCertImport, "UserCertImport");
+    public static final CertificateUsage VerifyCA = new CertificateUsage(certificateUsageVerifyCA, certUsageVerifyCA, "VerifyCA");
+    public static final CertificateUsage ProtectedObjectSigner = new CertificateUsage(certificateUsageProtectedObjectSigner, certUsageProtectedObjectSigner, "ProtectedObjectSigner");
+    public static final CertificateUsage StatusResponder = new CertificateUsage(certificateUsageStatusResponder, certUsageStatusResponder, "StatusResponder");
+    public static final CertificateUsage AnyCA = new CertificateUsage(certificateUsageAnyCA, certUsageAnyCA, "AnyCA");
+    public static final CertificateUsage IPsec = new CertificateUsage(certificateUsageIPsec, certUsageIPsec, "IPsec");
 
     /*
             The folllowing usages cannot be verified:

--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -737,6 +737,17 @@ public final class CryptoManager implements TokenSupplier
         }
     }
 
+    /**
+     * Imports a single DER-encoded certificate into the permanent or temporary
+     * certificate database.
+     */
+    public X509Certificate importDERCert(byte[] cert, CertificateUsage usage,
+                                         boolean permanent, String nickname) {
+        return importDERCertNative(cert, usage.getEnumValue(), permanent, nickname);
+    }
+
+    private native X509Certificate importDERCertNative(byte[] cert, int usage, boolean permanent, String nickname);
+
     private native InternalCertificate
         importCertToPermNative(X509Certificate cert, String nickname)
         throws TokenException;

--- a/org/mozilla/jss/provider/javax/crypto/JSSOCSPTrustManager.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSOCSPTrustManager.java
@@ -1,0 +1,122 @@
+package org.mozilla.jss.provider.javax.crypto;
+
+import java.security.cert.CertificateException;
+
+import javax.net.ssl.X509TrustManager;
+
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.CertificateUsage;
+import org.mozilla.jss.crypto.X509Certificate;
+import org.mozilla.jss.netscape.security.util.Cert;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/* In the below, X509Certificate refers to org.mozilla.jss.crypto.X509Certificate,
+ * which implements the java.security.cert.X509Certificate interface. However,
+ * the latter is required as an input parameter to the overridden methods. */
+
+public class JSSOCSPTrustManager implements X509TrustManager {
+    final static Logger logger = LoggerFactory.getLogger(JSSTrustManager.class);
+
+    public static CryptoManager cm;
+
+    public void initCryptoManager() throws Exception {
+        if (cm == null) {
+            // Technically this could throw a NotInitializedException. However
+            // in most cases, creating the JSSProvider requires creating the
+            // CryptoManager, so such an exception is an indication of an
+            // unsupported usage of the JSSProvider interface.
+            cm = CryptoManager.getInstance();
+        }
+    }
+
+    public X509Certificate[] downcastChain(java.security.cert.X509Certificate[] chain, boolean isClient) throws Exception {
+        // Create NSS-backed certificates via importDERCert.
+        int cert_index = 0;
+        X509Certificate[] jssChain = new X509Certificate[chain.length - 1];
+        for (cert_index = 0; cert_index < chain.length - 1; cert_index++) {
+            if (chain[cert_index] instanceof X509Certificate) {
+                // We already have a working NSS-backed certificate, so no
+                // need to convert it.
+                jssChain[cert_index] = (X509Certificate) chain[cert_index];
+            } else {
+                // These all are SSL (Intermediate) CA certificates. We don't
+                // want to store them permanently or give them a nickname.
+                byte[] der = chain[cert_index].getEncoded();
+                jssChain[cert_index] = cm.importDERCert(der, CertificateUsage.SSLCA, false, null);
+            }
+        }
+
+        if (chain[cert_index] instanceof X509Certificate) {
+            jssChain[cert_index] = (X509Certificate) chain[cert_index];
+        } else {
+            // These all are SSL (Intermediate) CA certificates. We don't
+            // want to store them permanently or give them a nickname.
+            byte[] der = chain[cert_index].getEncoded();
+            CertificateUsage usage = CertificateUsage.SSLServer;
+            if (isClient) {
+                usage = CertificateUsage.SSLClient;
+            }
+            jssChain[cert_index] = cm.importDERCert(der, usage, false, null);
+        }
+
+        return jssChain;
+    }
+
+    public void checkTrusted(java.security.cert.X509Certificate[] chain, boolean isClient) throws Exception {
+        // Make sure we have a useful reference to the CryptoManager.
+        initCryptoManager();
+
+        // Sort the chain from root -> leaf. This enforces that the very last
+        // certificate is the one we care most about validating (with the
+        // others being stepping stones on the way). Additionally, this
+        // guarantees that all other certificates in the chain should be CA
+        // certificates and the last one either being a SSLClient or a SSLServer
+        // certificate, depending on the value of isClient.
+        chain = Cert.sortCertificateChain(chain);
+
+        // Get references to CERTCertificate for the sorted chain.
+        X509Certificate[] jssChain = downcastChain(chain, isClient);
+    }
+
+    @Override
+    public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+        try {
+            checkTrusted(chain, true);
+        } catch (CertificateException e) {
+            logger.warn("JSSOCSPTrustManager: Invalid SSL server certificate: " + e);
+            throw e;
+        } catch (Exception e) {
+            logger.warn("JSSOCSPTrustManager: Unable to validate SSL server certificate: " + e);
+            throw new CertificateException(e);
+        }
+    }
+
+    @Override
+    public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+        try {
+            checkTrusted(chain, true);
+        } catch (CertificateException e) {
+            logger.warn("JSSOCSPTrustManager: Invalid SSL server certificate: " + e);
+            throw e;
+        } catch (Exception e) {
+            logger.warn("JSSOCSPTrustManager: Unable to validate SSL server certificate: " + e);
+            throw new CertificateException(e);
+        }
+    }
+
+    @Override
+    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+        /* Punt the problem to the regular JSSTrustManager.
+         *
+         * We have a mismatch between the Java and NSS interfaces here: the
+         * underlying call we're using for NSS checks both the internal trust
+         * store and what we pass in the NSS DB. However, NSS doesn't expose
+         * the internally trusted certificates under the CERTCertificate
+         * interface we need to construct certificates.
+         */
+        JSSTrustManager jtm = new JSSTrustManager();
+        return jtm.getAcceptedIssuers();
+    }
+}

--- a/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
@@ -166,6 +166,9 @@ public class JSSTrustManager implements X509TrustManager {
 
     @Override
     public X509Certificate[] getAcceptedIssuers() {
+        /* Note: due to how this is implemented, the list of accepted issuers
+         * is limited only to those in the NSS DB attached to this instance of
+         * CryptoManager. It is unlikely that we'll get access to them. */
 
         logger.debug("JSSTrustManager: getAcceptedIssuers():");
 

--- a/org/mozilla/jss/tests/X509CertTest.java
+++ b/org/mozilla/jss/tests/X509CertTest.java
@@ -17,10 +17,12 @@ import java.security.interfaces.ECPrivateKey;
 import java.util.Calendar;
 import java.util.Date;
 
+import org.mozilla.jss.CertificateUsage;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.KeyPairAlgorithm;
 import org.mozilla.jss.crypto.KeyPairGenerator;
+import org.mozilla.jss.crypto.X509Certificate;
 import org.mozilla.jss.netscape.security.util.BigInt;
 import org.mozilla.jss.netscape.security.util.DerValue;
 import org.mozilla.jss.netscape.security.x509.AlgorithmId;
@@ -39,6 +41,8 @@ import org.mozilla.jss.netscape.security.x509.X509Key;
 import org.mozilla.jss.pkcs11.PK11ECPublicKey;
 import org.mozilla.jss.util.PasswordCallback;
 
+import org.apache.commons.codec.binary.Base64;
+
 public class X509CertTest {
 
     public static String subjectDN = "CN = 8a99f98342b97d130142ba2cc30f07d3";
@@ -53,7 +57,6 @@ public class X509CertTest {
 
         String dbdir = args[0];
         String passwordfile = args[1];
-
 
         Date notBefore = new Date();
         Calendar cal = Calendar.getInstance();
@@ -71,6 +74,8 @@ public class X509CertTest {
 
         testEC(token, notBefore, notAfter);
         testRSA(token, notBefore, notAfter);
+
+        testImport();
     }
 
     public static void testEC(CryptoToken token, Date notBefore, Date notAfter) throws Exception {
@@ -82,7 +87,6 @@ public class X509CertTest {
         KeyPair keypairCA = gen.genKeyPair();
         testKeys(keypairCA);
         PublicKey pubCA = keypairCA.getPublic();
-
 
         gen.initialize(gen.getCurveCodeByName("secp521r1"));
         KeyPair keypairUser = gen.genKeyPair();
@@ -205,5 +209,32 @@ public class X509CertTest {
             xKey = X509Key.parse(new DerValue(encoded));
         }
         return xKey;
+    }
+
+    public static void testImport() throws Exception {
+        CryptoManager cryptoManager = CryptoManager.getInstance();
+        byte[] cert = Base64.decodeBase64(
+            "MIIDRjCCAi6gAwIBAgIJAMHiDXjnZ1J6MA0GCSqGSIb3DQEBCwUAMDgxEDAOBgNV" +
+            "BAoMB0VYQU1QTEUxJDAiBgNVBAMMG1Jvb3QgQ0EgU2lnbmluZyBDZXJ0aWZpY2F0" +
+            "ZTAeFw0xOTAzMDUxNzQzMjFaFw0yMDAzMDQxNzQzMjFaMDgxEDAOBgNVBAoMB0VY" +
+            "QU1QTEUxJDAiBgNVBAMMG1Jvb3QgQ0EgU2lnbmluZyBDZXJ0aWZpY2F0ZTCCASIw" +
+            "DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMDv7ovkD+JVEdlLncYDnhzbLOz2" +
+            "c3D37fobufnHHNwNOwfLZj8WdBCzwGJv+XGF+D2JIcKyYwYPR+HOg+xClhuuVleE" +
+            "gMVvgxM+HcpM4heyBD2QczNo1dfXQRBy2AXvRn8Byh+Q6zbN7VoNu8ZaMQOxZx9m" +
+            "EAiDZ7WxHVrEp2a4QrI6I9gKY6SyEHRzVT48JElLFokwhkMpF8vhgtj0Xxr5EEIY" +
+            "yCMOzvZLtpeyH8PUri3Cv/hX1RZKjWqKLSJSKirnZLhZoEEzXtsOmoeeZBeRiabi" +
+            "dPLsxqPfWFx4+BC7t5Vw5FaIt2mPh+q6bjZipO4uWz/p4a9wpqakuzgNsYUCAwEA" +
+            "AaNTMFEwHQYDVR0OBBYEFCvlfY9OzAVsYpJEoqr7QfguO9v5MB8GA1UdIwQYMBaA" +
+            "FCvlfY9OzAVsYpJEoqr7QfguO9v5MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcN" +
+            "AQELBQADggEBAHB1lWjT6bP1jAkk6eTVwBU2pGoGoYMGV3fWQGOmWQP5T7+nHKkU" +
+            "jNMRACoC2hFlypwX8qQ70V5O4U+qrnxDP3EaT1zPsOB0x4DIIrpFgudL9EqnSbJ0" +
+            "kvSz3awwO8x/Nvx7TatCncmTw9c14eqek2puhcQWvxHzWkaDHd9WxPrZJFftbSsn" +
+            "ZGK2A/ybDCnUA5BDeCSDb5gufTd8gbS4wS1NwYcbbrQyHnLJlFcIF4aLkbYuX1bn" +
+            "cYp8pQv3pZ3C/ofA+yBJvPELTaHjDC40MTdjFFfMQTPZswBX2iimoGQ/ProBGg7+" +
+            "rLg2uk5AHff3oo/V1X0SSzo3IpvHh0jhg9I="
+        );
+
+        X509Certificate ret = cryptoManager.importDERCert(cert, CertificateUsage.SSLCA, false, null);
+        assert(ret != null);
     }
 }


### PR DESCRIPTION
Opening this as WIP PR -- some portions might get split into other, smaller PRs, else we might drop this in favor of another approach.

This approach assumes we wish to fully integrate into the Java ecosystem. We introduce a TrustManager that understands OCSP policy and can downcast java.X509Certificates into jss.X509Certificates. This lets us run full OCSP-checking against them.

The upside of this PR is that it integrates nicely into other SSLEngines if they understand TrustManager and need to support OCSP checking. 

The downside of this PR is that we need to call from Java, through JNI, to NSS to configure a callback to check the TrustManager. Going backwards, when the callback fires, we need to call from NSS's callback into Java, get the TrustManager instance somehow, and report back the status. This all seems slow and complicated. Alternatively, we could add a null handler that always reports success and do the work in the SSLEngine directly on the extracted certificates. However this means we might not be able to send a badcert alert. 

Some work should be done to make this more configurable (chain, leaf, chain and leaf, neither -- for both OCSP and CRL). Perhaps we want to make this the default TrustManager and make the other one a basic version.