### PR TITLE
Native TrustManager

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -429,6 +429,7 @@ Java_org_mozilla_jss_crypto_KBKDFOptionalCounterParam_releaseNativeResources;
 Java_org_mozilla_jss_crypto_Policy_getRSAMinimumKeySize;
 Java_org_mozilla_jss_crypto_Policy_getDHMinimumKeySize;
 Java_org_mozilla_jss_crypto_Policy_getDSAMinimumKeySize;
+Java_org_mozilla_jss_nss_SSL_ConfigJSSDefaultCertAuthCallback;
     local:
         *;
 };

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -467,6 +467,21 @@ Java_org_mozilla_jss_nss_SSL_EnableAlertLoggingNative(JNIEnv *env, jclass clazz,
 }
 
 JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_ConfigJSSDefaultCertAuthCallback(JNIEnv *env, jclass clazz,
+    jobject fd)
+{
+    PRFileDesc *real_fd = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    return SSL_AuthCertificateHook(real_fd, JSSL_DefaultCertAuthCallback, NULL);
+}
+
+JNIEXPORT jint JNICALL
 Java_org_mozilla_jss_nss_SSL_getSSLRequestCertificate(JNIEnv *env, jclass clazz)
 {
     return SSL_REQUEST_CERTIFICATE;

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -209,6 +209,15 @@ public class SSL {
     /* Internal helper for EnableAlertLogging method. */
     private static native int EnableAlertLoggingNative(SSLFDProxy fd);
 
+    /**
+     * Use the default JSS certificate checking handler (which understands CryptoManager
+     * OCSP status).
+     *
+     * See also: SSL_AuthCertificateHook in /usr/include/nss3/ssl.h and
+     *           JSSL_DefaultCertAuthCallback in jss/ssl/callbacks.c
+     */
+    public static native int ConfigJSSDefaultCertAuthCallback(SSLFDProxy fd);
+
     /* Internal methods for querying constants. */
     private static native int getSSLRequestCertificate();
     private static native int getSSLRequireCertificate();

--- a/org/mozilla/jss/provider/javax/crypto/JSSNativeTrustManager.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSNativeTrustManager.java
@@ -1,0 +1,40 @@
+package org.mozilla.jss.provider.javax.crypto;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * JSSNativeTrustManager is a JSSEngine TrustManager utilizing existing native
+ * certificate checking functionality of NSS and JSS, compatible with the old
+ * SSLSocket checks.
+ *
+ * Note: This class isn't compatible with external (non-JSS) SSLEngines.
+ *
+ * The only configuration possible is in CryptoManager's OCSP Policy, which
+ * this obeys. No other configuration is possible. This is more performant
+ * than other TrustManagers, because it saves a JNI call and handles the NSS
+ * callback directly.
+ */
+public class JSSNativeTrustManager implements X509TrustManager {
+    private String error_msg = getClass().getName() + " should not be used "
+                             + "directly! Please use it with JSSEngine. Note "
+                             + "that this TrustManager must be the only one "
+                             + "passed to JSSEngine.";
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] certChain, String authType) throws CertificateException {
+        throw new RuntimeException(error_msg);
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] certChain, String authType) throws CertificateException {
+        throw new RuntimeException(error_msg);
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        throw new RuntimeException(error_msg);
+    }
+}


### PR DESCRIPTION
~Opening this as a WIP PR. This PR is fairly self-contained unlike #248.~

This approach assumes we wish to use the already-existing OCSP validation logic in [`JSSL_DefaultCertAuthCallback`](https://github.com/dogtagpki/jss/blob/master/org/mozilla/jss/ssl/callbacks.c#L464). To do so we add a dummy TrustManager class which doesn't do validation, but which we can use in the SSLEngine as a sentinel for using this validation (note that we can use `NULL` to use the default NSS certificate validation, which is again something different, or use `NULL` to choose a sane default and create a separate class for default NSS validation). 

The upside of this PR is that it doesn't involve invoking Java from the NSS callback, which means it is more performant than other solutions. All other solutions require several JNI calls (one from the callback handler into the TrustManager, and another from 

The downside is this TrustManager is very specific to our SSLEngine and won't work if we try and use it anywhere else (e.g., in PKI for some reason, outside of SSLEngine, to directly validate certs).

The work to make this more configurable would all live in the CryptoManager. In an ideal world, I would not really happy with defaulting to no CRL checking though. This'd align nicely with the existing OCSP Policy options. 