### PR TITLE
Remove misleading indentation in ssl/callbacks.c

### DIFF
--- a/org/mozilla/jss/ssl/callbacks.c
+++ b/org/mozilla/jss/ssl/callbacks.c
@@ -497,9 +497,11 @@ JSSL_DefaultCertAuthCallback(void *arg, PRFileDesc *fd, PRBool checkSig,
      */
 
     if ( rv != SECSuccess || isServer )  {
-        if (peerCert) CERT_DestroyCertificate(peerCert);
-            return (int)rv;
+        if (peerCert) {
+            CERT_DestroyCertificate(peerCert);
         }
+        return (int)rv;
+    }
 
     /* cert is OK.  This is the client side of an SSL connection.
      * Now check the name field in the cert against the desired hostname.


### PR DESCRIPTION
This fixes three things while we're here:

 - Misleading indentation
 - Trailing whitespace
 - Unnecessary NULL checks prior to destroy

Signed-off-by: Alexander Scheel <ascheel@redhat.com>