### PR TITLE
Two minor javadoc improvements

### DIFF
--- a/org/mozilla/jss/netscape/security/extensions/GenericASN1Extension.java
+++ b/org/mozilla/jss/netscape/security/extensions/GenericASN1Extension.java
@@ -175,6 +175,11 @@ public class GenericASN1Extension extends Extension
      * Create a GenericASN1Extension with the value and oid.
      * The criticality is set to false.
      *
+     * @param name the name of this extension
+     * @param oid the object identifier of this extension
+     * @param pattern to use for encoding this extension
+     * @param critical true if the extension should be treated as critical
+     * @param config additional configuration for this extension
      */
     public GenericASN1Extension(String name, String oid, String pattern, boolean critical,
             Hashtable<String, String> config)

--- a/org/mozilla/jss/netscape/security/util/DerOutputStream.java
+++ b/org/mozilla/jss/netscape/security/util/DerOutputStream.java
@@ -100,15 +100,15 @@ public class DerOutputStream
      * @param tag the DER value of the context-specific tag that replaces
      *            original tag of the value in the output , such as in
      *
-     *            <pre>
-     * 	<em> [N] IMPLICIT </em>
+       <pre>
+     *  {@literal <field>} [N] IMPLICIT {@literal <type>}
      * </pre>
      *
-     *            For example, <em>FooLength [1] IMPLICIT INTEGER</em>, with value=4;
-     *            would be encoded as "81 01 04" whereas in explicit
-     *            tagging it would be encoded as "A1 03 02 01 04".
-     *            Notice that the tag is A1 and not 81, this is because with
-     *            explicit tagging the form is always constructed.
+     * For example, <em>FooLength [1] IMPLICIT INTEGER</em>, with value=4;
+     * would be encoded as "81 01 04" whereas in explicit
+     * tagging it would be encoded as "A1 03 02 01 04".
+     * Notice that the tag is A1 and not 81, this is because with
+     * explicit tagging the form is always constructed.
      * @param value original value being implicitly tagged
      */
     public void writeImplicit(byte tag, DerOutputStream value)


### PR DESCRIPTION
One documents parameters that were removed from a previous PR because
they didn't match the function signature. I've readded those. The other
re-adds two placeholders for clarity, using @literal this time.

Minor fixups from #247. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`