### PR TITLE
Add CMAC to JSS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,9 @@ find_package(JNI REQUIRED)
 # Since we found Java, include UseJava to provide the find_jar function.
 include(UseJava)
 
+# This include is required for the macro check_symbol_exists in jss_config()
+include(CheckSymbolExists)
+
 # Load JSSConfig module; this defines the jss_config() macro which defines
 # JSS-specific configuration values.
 include(JSSConfig)

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -16,6 +16,9 @@ macro(jss_config)
 
     # Template auto-generated files
     jss_config_template()
+
+    # Check symbols to see what tests we run
+    jss_config_symbols()
 endmacro()
 
 macro(jss_config_version MAJOR MINOR PATCH BETA)
@@ -334,4 +337,15 @@ macro(jss_config_template)
         "${PROJECT_SOURCE_DIR}/tools/run_test.sh.in"
         "${CMAKE_BINARY_DIR}/run_test.sh"
     )
+endmacro()
+
+macro(jss_config_symbols)
+    list(APPEND CMAKE_REQUIRED_INCLUDES ${NSPR_INCLUDE_DIRS})
+    list(APPEND CMAKE_REQUIRED_INCLUDES ${NSS_INCLUDE_DIRS})
+    list(JOIN JSS_C_FLAGS " " CMAKE_REQUIRED_FLAGS)
+
+    check_symbol_exists("CKM_AES_CMAC" "nspr.h;nss.h;pkcs11t.h" HAVE_NSS_CMAC)
+    if(NOT HAVE_NSS_CMAC)
+        message(WARNING "Your NSS version doesn't support CMAC; some features of JSS won't work.")
+    endif()
 endmacro()

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -261,6 +261,13 @@ macro(jss_tests)
             COMMAND "org.mozilla.jss.tests.HmacTest" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
             DEPENDS "Setup_DBs"
         )
+        if(HAVE_NSS_CMAC)
+            jss_test_java(
+                NAME "CMAC_Test"
+                COMMAND "org.mozilla.jss.tests.TestCmac" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
+                DEPENDS "Setup_DBs"
+            )
+        endif()
         jss_test_java(
             NAME "Mozilla_JSS_Secret_Key_Generation"
             COMMAND "org.mozilla.jss.tests.JCASymKeyGen" "${RESULTS_NSSDB_OUTPUT_DIR}"

--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -241,11 +241,20 @@ public final class JSSProvider extends java.security.Provider {
         put("Alg.Alias.Mac.Hmac-SHA384", "HmacSHA384");
         put("Mac.HmacSHA512",
             "org.mozilla.jss.provider.javax.crypto.JSSMacSpi$HmacSHA512");
+        put("Mac.CmacAES", "org.mozilla.jss.provider.javax.crypto.JSSMacSpi$CmacAES");
         put("Alg.Alias.Mac.Hmac-SHA512", "HmacSHA512");
         put("Alg.Alias.Mac.SHA-1-HMAC", "HmacSHA1");
         put("Alg.Alias.Mac.SHA-256-HMAC", "HmacSHA256");
         put("Alg.Alias.Mac.SHA-384-HMAC", "HmacSHA384");
         put("Alg.Alias.Mac.SHA-512-HMAC", "HmacSHA512");
+        put("Alg.Alias.Mac.AES-128-CMAC", "CmacAES");
+        put("Alg.Alias.Mac.AES-192-CMAC", "CmacAES");
+        put("Alg.Alias.Mac.AES-256-CMAC", "CmacAES");
+        put("Alg.Alias.Mac.CmacAES128", "CmacAES");
+        put("Alg.Alias.Mac.CmacAES192", "CmacAES");
+        put("Alg.Alias.Mac.CmacAES256", "CmacAES");
+        put("Alg.Alias.Mac.AES_CMAC", "CmacAES");
+        put("Alg.Alias.Mac.CMAC_AES", "CmacAES");
 
 
         /////////////////////////////////////////////////////////////

--- a/org/mozilla/jss/crypto/Algorithm.c
+++ b/org/mozilla/jss/crypto/Algorithm.c
@@ -18,6 +18,11 @@
 static PRStatus
 getAlgInfo(JNIEnv *env, jobject alg, JSS_AlgInfo *info);
 
+/* Helpers to handle differences in NSS versions. */
+#ifndef CKM_AES_CMAC
+#define CKM_AES_CMAC CKM_INVALID_MECHANISM
+#endif
+
 /***********************************************************************
 **
 **  Algorithm indices.  This must be kept in sync with the algorithm
@@ -97,7 +102,10 @@ JSS_AlgInfo JSS_AlgTable[NUM_ALGS] = {
 /* 66 */    {CKM_AES_KEY_WRAP_PAD, PK11_MECH},
 /* 67 */    {CKM_SHA256_HMAC, PK11_MECH},
 /* 68 */    {CKM_SHA384_HMAC, PK11_MECH},
-/* 69 */    {CKM_SHA512_HMAC, PK11_MECH}
+/* 69 */    {CKM_SHA512_HMAC, PK11_MECH},
+
+/* CKM_AES_CMAC is new to NSS; some implementations might not yet have it. */
+/* 70 */    {CKM_AES_CMAC, PK11_MECH}
 /* REMEMBER TO UPDATE NUM_ALGS!!! (in Algorithm.h) */
 };
 

--- a/org/mozilla/jss/crypto/Algorithm.h
+++ b/org/mozilla/jss/crypto/Algorithm.h
@@ -24,7 +24,7 @@ typedef struct JSS_AlgInfoStr {
     JSS_AlgType type;
 } JSS_AlgInfo;
 
-#define NUM_ALGS 70
+#define NUM_ALGS 71
 
 extern JSS_AlgInfo JSS_AlgTable[];
 extern CK_ULONG JSS_symkeyUsage[];

--- a/org/mozilla/jss/crypto/Algorithm.java
+++ b/org/mozilla/jss/crypto/Algorithm.java
@@ -241,4 +241,7 @@ public class Algorithm {
     protected static final int CKM_SHA256_HMAC=67;
     protected static final int CKM_SHA384_HMAC=68;
     protected static final int CKM_SHA512_HMAC=69;
+
+    // PKCS#11 AES-CMAC
+    protected static final int CKM_AES_CMAC=70;
 }

--- a/org/mozilla/jss/crypto/CMACAlgorithm.java
+++ b/org/mozilla/jss/crypto/CMACAlgorithm.java
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.jss.crypto;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.Hashtable;
+
+import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
+
+/**
+ * Algorithms for performing CMACs. These can be used to create
+ * MessageDigests.
+ */
+public class CMACAlgorithm extends DigestAlgorithm {
+
+    protected CMACAlgorithm(int oidIndex, String name, OBJECT_IDENTIFIER oid,
+                            int outputSize) {
+        super(oidIndex, name, oid, outputSize);
+
+        if (oid != null && oidMap.get(oid) == null) {
+            oidMap.put(oid, this);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    // OID mapping
+    ///////////////////////////////////////////////////////////////////////
+    private static Hashtable<OBJECT_IDENTIFIER, CMACAlgorithm> oidMap = new Hashtable<>();
+
+    /**
+     * Looks up the CMAC algorithm with the given OID.
+     *
+     * @param oid OID.
+     * @return CMAC algorithm.
+     * @exception NoSuchAlgorithmException If no registered CMAC algorithm
+     *  has the given OID.
+     */
+    public static CMACAlgorithm fromOID(OBJECT_IDENTIFIER oid)
+        throws NoSuchAlgorithmException
+    {
+        CMACAlgorithm alg = oidMap.get(oid);
+        if (alg == null) {
+            throw new NoSuchAlgorithmException("No such algorithm for OID: " + oid);
+        }
+
+        return alg;
+    }
+
+    /**
+     * CMAC AES-X.  This is a Message Authentication Code that uses a
+     * symmetric key together with the AES cipher to create a form of
+     * signature.
+     *
+     * Note that we pass null for the OID here: neither NIST nor any other
+     * standards body has defined an OID for use with CMAC. Since we use
+     * a PKCS#11 backend and NSS doesn't otherwise define CMAC based on a
+     * SEC OID, we don't strictly need one.
+     *
+     * We've left the fromOID code (and oid parameter in the constructor) as
+     * other projects use them for HMACAlgorith. At such time as an OID is
+     * defined, it can be added here.
+     */
+    public static final CMACAlgorithm AES = new CMACAlgorithm(CKM_AES_CMAC, "AES-CMAC", null, 16);
+    public static final CMACAlgorithm AES128 = AES;
+    public static final CMACAlgorithm AES192 = AES;
+    public static final CMACAlgorithm AES256 = AES;
+}

--- a/org/mozilla/jss/crypto/PKCS11Algorithm.java
+++ b/org/mozilla/jss/crypto/PKCS11Algorithm.java
@@ -25,7 +25,8 @@ public enum PKCS11Algorithm {
     CKM_SHA_1_HMAC (Algorithm.CKM_SHA_1_HMAC, PKCS11Constants.CKM_SHA_1_HMAC),
     CKM_SHA_256_HMAC (Algorithm.CKM_SHA256_HMAC, PKCS11Constants.CKM_SHA256_HMAC),
     CKM_SHA_384_HMAC (Algorithm.CKM_SHA384_HMAC, PKCS11Constants.CKM_SHA384_HMAC),
-    CKM_SHA_512_HMAC (Algorithm.CKM_SHA512_HMAC, PKCS11Constants.CKM_SHA512_HMAC);
+    CKM_SHA_512_HMAC (Algorithm.CKM_SHA512_HMAC, PKCS11Constants.CKM_SHA512_HMAC),
+    CKM_AES_CMAC (Algorithm.CKM_AES_CMAC, PKCS11Constants.CKM_AES_CMAC);
 
     // Value from Algorithm's constant -- this is an index into Algorithm's
     // table.

--- a/org/mozilla/jss/pkcs11/PK11MessageDigest.java
+++ b/org/mozilla/jss/pkcs11/PK11MessageDigest.java
@@ -36,8 +36,8 @@ public final class PK11MessageDigest extends JSSMessageDigest {
         throws DigestException, InvalidKeyException
     {
 
-        if( ! (alg instanceof HMACAlgorithm) ) {
-            throw new DigestException("Digest is not an HMAC digest");
+        if( ! (alg instanceof HMACAlgorithm || alg instanceof CMACAlgorithm) ) {
+            throw new DigestException("Digest is not an HMAC or CMAC digest");
         }
 
         reset();
@@ -90,7 +90,7 @@ public final class PK11MessageDigest extends JSSMessageDigest {
     }
 
     public void reset() throws DigestException {
-        if( ! (alg instanceof HMACAlgorithm) ) {
+        if( ! (alg instanceof HMACAlgorithm || alg instanceof CMACAlgorithm) ) {
             // This is a regular digest, so we have enough information
             // to initialize the context
             this.digestProxy = initDigest(alg);

--- a/org/mozilla/jss/provider/javax/crypto/JSSMacSpi.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSMacSpi.java
@@ -11,7 +11,9 @@ import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.AlgorithmParameterSpec;
 
+import org.mozilla.jss.crypto.CMACAlgorithm;
 import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.crypto.DigestAlgorithm;
 import org.mozilla.jss.crypto.HMACAlgorithm;
 import org.mozilla.jss.crypto.JSSMessageDigest;
 import org.mozilla.jss.crypto.SecretKeyFacade;
@@ -21,9 +23,9 @@ import org.mozilla.jss.crypto.TokenSupplierManager;
 class JSSMacSpi extends javax.crypto.MacSpi {
 
     private JSSMessageDigest digest=null;
-    private HMACAlgorithm alg;
+    private DigestAlgorithm alg;
 
-    protected JSSMacSpi(HMACAlgorithm alg) {
+    protected JSSMacSpi(DigestAlgorithm alg) {
       try {
         this.alg = alg;
         CryptoToken token =
@@ -116,4 +118,9 @@ class JSSMacSpi extends javax.crypto.MacSpi {
         }
     }
 
+    public static class CmacAES extends JSSMacSpi {
+        public CmacAES() {
+            super(CMACAlgorithm.AES);
+        }
+    }
 }

--- a/org/mozilla/jss/tests/TestCmac.java
+++ b/org/mozilla/jss/tests/TestCmac.java
@@ -1,0 +1,89 @@
+package org.mozilla.jss.tests;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.security.Key;
+
+import javax.crypto.*;
+import javax.crypto.spec.*;
+
+import org.mozilla.jss.*;
+import org.mozilla.jss.crypto.*;
+import org.mozilla.jss.util.*;
+
+public class TestCmac {
+    private static final byte[] NIST_128 = Base64.getDecoder().decode("K34VFiiu0qar9xWICc9PPA==");
+    private static final byte[] NIST_192 = Base64.getDecoder().decode("jnOw99oOZFLIEPMrgJB55WL46tJSLGt7");
+    private static final byte[] NIST_256 = Base64.getDecoder().decode("YD3rEBXKcb4rc67whX13gR81LAc7YQjXLZgQowkU3/Q=");
+
+    public static void main(String[] args) throws Exception {
+        CryptoManager.initialize(args[0]);
+        CryptoManager cm = CryptoManager.getInstance();
+        CryptoToken tok = cm.getInternalKeyStorageToken();
+        PasswordCallback cb = new FilePasswordCallback(args[1]);
+        tok.login(cb);
+
+        testNISTExamples();
+    }
+
+    /*
+     * The following test vectors come from NIST's Examples with Intermediate
+     * Values page:
+     * https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
+     *
+     * These are the same vectors utilized by NSS in:
+     * gtests/freebl_gtest/cmac_unittests.cc
+     *
+     * These same vectors are also found in FRC 4493, Section 4.
+     */
+    public static void testNISTExamples() throws Exception {
+        byte[] all_input = Base64.getDecoder().decode("a8G+4i5An5bpPX4Rc5MXKq4tilceA6ycnrdvrEWvjlEwyBxGo1zkEeX7wRkaClLv9p8kRd9PmxetK0F75mw3EA==");
+        int[] input_lengths = new int[] { 0, 16, 20, 64};
+
+        byte[][] all_expected = new byte[][] {
+            Base64.getDecoder().decode("ux1pKelZNyh/o30Sm3VnRg=="),
+            Base64.getDecoder().decode("BwoWtGtNQUT3m92d0EoofA=="),
+            Base64.getDecoder().decode("fYVEnqbqGcgjp794g3363g=="),
+            Base64.getDecoder().decode("UfC+v347nZL8SXQXeTY8/g=="),
+            Base64.getDecoder().decode("0X3fRq2qzeUxysSD3nqTZw=="),
+            Base64.getDecoder().decode("npmnvzHnEJAGYvZeYXxRhA=="),
+            Base64.getDecoder().decode("PXXBlO2WBwREqfp+x0Ds+A=="),
+            Base64.getDecoder().decode("odXfDu15D3lNd1iWWfOaEQ=="),
+            Base64.getDecoder().decode("Aoli9ht7+J78a1UfRmfZgw=="),
+            Base64.getDecoder().decode("KKcCP0Uuj4K9S/KNjDfDXA=="),
+            Base64.getDecoder().decode("FWcn3Ah4lEoCPB/gO61tkw=="),
+            Base64.getDecoder().decode("4ZkhkFSfbtVpaiwFbDFUEA==")
+        };
+
+        for (int i = 0; i < all_expected.length; i++) {
+            byte[] key = getKey(i);
+            byte[] input = Arrays.copyOf(all_input, input_lengths[i % input_lengths.length]);
+            byte[] expected = all_expected[i];
+
+            testCMAC(key, input, expected);
+        }
+    }
+
+    public static byte[] getKey(int index) {
+        if (index < 4) {
+            return NIST_128;
+        } else if (index < 8) {
+            return NIST_192;
+        } else if (index < 12) {
+            return NIST_256;
+        }
+
+        return null;
+    }
+
+    public static void testCMAC(byte[] key_bytes, byte[] input, byte[] expected) throws Exception {
+        Mac mac = Mac.getInstance("AES_CMAC", "Mozilla-JSS");
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("AES", "Mozilla-JSS");
+        Key key = factory.generateSecret(new SecretKeySpec(key_bytes, "AES"));
+        mac.init(key);
+
+        byte[] actual = mac.doFinal(input);
+
+        assert(Arrays.equals(actual, expected));
+    }
+}


### PR DESCRIPTION
~This is WIP as it depends on #258 being merged. This series will be rebased afterwards. The commits will be squashed and rewritten.~

This adds initial support for CMAC to the JSS Provider interface. This depends on a recent enough NSS that includes [CMAC](https://bugzilla.mozilla.org/show_bug.cgi?id=1570501) support in PKCS#11. ~Thus CI will fail until I introduce a new instance with Sandboxed NSS builds.~

I've added build time support for CMAC. What this means is that JSS only needs a rebuild in order to take advantage of CMAC support in NSS. Otherwise, it'll ignore the non-existence of CMAC and not run the applicable test from the test suite. CMAC will still be defined in the JSS provider though.

You can see this via checking the output of CI: currently there are 66 tests without CMAC, 1 CMAC test. So only `fedora_sandbox` CI image will have 67 test cases. 