### PR TITLE
Add Fedora rawhide based sandbox builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
     - stage: extra
       env: BASE_IMAGE="fedora_rawhide"
     - stage: extra
+      env: BASE_IMAGE="fedora_sandbox"
+    - stage: extra
       env: BASE_IMAGE="fast_finish"
       script:
         - "true"
@@ -47,3 +49,5 @@ matrix:
       env: BASE_IMAGE="fedora_29_jdk11"
     - stage: extra
       env: BASE_IMAGE="fedora_rawhide"
+    - stage: extra
+      env: BASE_IMAGE="fedora_sandbox"

--- a/tools/Dockerfiles/fedora_sandbox
+++ b/tools/Dockerfiles/fedora_sandbox
@@ -1,0 +1,41 @@
+FROM fedora:rawhide
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build cmake \
+                          glassfish-jaxb-api nss-tools apache-commons-codec \
+                          apache-commons-lang gcc-c++ jpackage-utils slf4j \
+                          zlib-devel perl slf4j-jdk14 junit ninja-build \
+                          gyp gtest mercurial \
+        && dnf build-dep nss nspr jss -y \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Download and build NSPR and NSS
+RUN true \
+        && cd /home/sandbox \
+        && hg clone https://hg.mozilla.org/projects/nspr \
+        && hg clone https://hg.mozilla.org/projects/nss \
+        && cd nss \
+        && ./build.sh --enable-fips --enable-libpkix \
+        && true
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && export SANDBOX=1 \
+        && rm -rf build \
+        && mkdir build \
+        && cd build \
+        && cmake .. \
+        && make all \
+        && ctest --output-on-failure \
+        && true


### PR DESCRIPTION
This tests the latest upstream NSPR and NSS from Mozilla, on the latest
Fedora rawhide container, and ensures that we can build and pass our
current test suite.

We also add the `fedora_sandbox` image as a required test in Travis. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`