### PR TITLE
Add run_test.sh, common_roots.sh

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -13,6 +13,9 @@ macro(jss_config)
 
     # Configure java-related flags
     jss_config_java()
+
+    # Template auto-generated files
+    jss_config_template()
 endmacro()
 
 macro(jss_config_version MAJOR MINOR PATCH BETA)
@@ -45,16 +48,6 @@ macro(jss_config_version MAJOR MINOR PATCH BETA)
         set(JSS_VERSION "${JSS_VERSION} beta ${JSS_VERSION_BETA}")
         set(JSS_VERSION_STR "${JSS_VERSION_STR}_b${JSS_VERSION_BETA}")
     endif()
-
-    # Template files
-    configure_file(
-        "${PROJECT_SOURCE_DIR}/org/mozilla/jss/util/jssver.h.in"
-        "${PROJECT_SOURCE_DIR}/org/mozilla/jss/util/jssver.h"
-    )
-    configure_file(
-        "${PROJECT_SOURCE_DIR}/lib/MANIFEST.MF.in"
-        "${CMAKE_BINARY_DIR}/MANIFEST.MF"
-    )
 endmacro()
 
 macro(jss_config_outputs)
@@ -325,4 +318,20 @@ macro(jss_config_java)
     set(JSS_BASE_PORT 2876)
     math(EXPR JSS_TEST_PORT_CLIENTAUTH ${JSS_BASE_PORT}+0)
     math(EXPR JSS_TEST_PORT_CLIENTAUTH_FIPS ${JSS_BASE_PORT}+1)
+endmacro()
+
+macro(jss_config_template)
+    # Template files
+    configure_file(
+        "${PROJECT_SOURCE_DIR}/org/mozilla/jss/util/jssver.h.in"
+        "${PROJECT_SOURCE_DIR}/org/mozilla/jss/util/jssver.h"
+    )
+    configure_file(
+        "${PROJECT_SOURCE_DIR}/lib/MANIFEST.MF.in"
+        "${CMAKE_BINARY_DIR}/MANIFEST.MF"
+    )
+    configure_file(
+        "${PROJECT_SOURCE_DIR}/tools/run_test.sh.in"
+        "${CMAKE_BINARY_DIR}/run_test.sh"
+    )
 endmacro()

--- a/tools/common_roots.sh
+++ b/tools/common_roots.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This script reads the contents of the OS CA bundle store,
+#   /usr/share/pki/ca-trust-source/ca-bundle.trust.p11-kit
+# and places the contained CAs into the specified NSS DB.
+#
+# This NSS DB is used by various JSS tests that aren't enabled
+# by default because they require an active internet connection.
+
+nssdb="$1"
+
+if [ -z "$nssdb" ] && [ -e "build" ]; then
+    nssdb="build/results/cadb"
+elif [ -z "$nssdb" ] && [ -e "../build" ]; then
+    nssdb="../build/results/cadb"
+elif [ -z "$nssdb" ] || [ "x$nssdb" == "x--help" ]; then
+    echo "Usage: $0 [/path/to/nssdb]" 1>&2
+    echo "" 1>&2
+    echo "Must provide path to NSS DB!" 1>&2
+    exit 1
+fi
+
+if [ -e "$nssdb" ]; then
+    rm -rf "$nssdb"
+fi
+
+mkdir -p "$nssdb"
+echo "" > "$nssdb/password.txt"
+certutil -N -d "$nssdb" -f "$nssdb/password.txt"
+
+trust extract --format=pem-bundle  --filter=ca-anchors "$nssdb/complete.pem"
+
+# From: https://serverfault.com/questions/391396/how-to-split-a-pem-file
+csplit -f "$nssdb/individual-" "$nssdb/complete.pem" '/-----BEGIN CERTIFICATE-----/' '{*}'
+
+for cert in "$nssdb"/individual*; do
+    certutil -A -a -i "$cert" -n "$cert" -t CT,C,C -d "$nssdb" -f "$nssdb/password.txt"
+done

--- a/tools/run_test.sh.in
+++ b/tools/run_test.sh.in
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This utility gets templated to build/run_test.sh to help with running a
+# single test after building JSS. This gives the caller more flexibility
+# with command line arguments and ensures that the correct build artifacts
+# get used.
+
+export LD_LIBRARY_PATH="${CMAKE_BINARY_DIR}"
+
+if [ "$1" == "--gdb" ]; then
+    shift
+    gdb --args "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="${CMAKE_BINARY_DIR}" "$@"
+else
+    "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="${CMAKE_BINARY_DIR}" "$@"
+fi


### PR DESCRIPTION
This introduces two utilities:

 - `run_test.sh`, which gets templated by CMake, allowing you to run a single test after building JSS (in the correct context with all the required libraries and a correct `classpath`). This includes support for running the test under `gdb`.
 - `common_roots.sh`, which installs all root certificates trusted by the OS into a local NSS DB.
