### PR TITLE
Finish creating SymmetricKeys from byte arrays

### DIFF
--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -210,6 +210,12 @@ public final class JSSProvider extends java.security.Provider {
             "org.mozilla.jss.provider.javax.crypto.JSSSecretKeyFactorySpi$HmacSHA1");
         put("SecretKeyFactory.PBAHmacSHA1",
             "org.mozilla.jss.provider.javax.crypto.JSSSecretKeyFactorySpi$PBAHmacSHA1");
+        put("SecretKeyFactory.HmacSHA256",
+            "org.mozilla.jss.provider.javax.crypto.JSSSecretKeyFactorySpi$HmacSHA256");
+        put("SecretKeyFactory.HmacSHA384",
+            "org.mozilla.jss.provider.javax.crypto.JSSSecretKeyFactorySpi$HmacSHA384");
+        put("SecretKeyFactory.HmacSHA512",
+            "org.mozilla.jss.provider.javax.crypto.JSSSecretKeyFactorySpi$HmacSHA512");
         put("SecretKeyFactory.PBEWithMD5AndDES",
             "org.mozilla.jss.provider.javax.crypto.JSSSecretKeyFactorySpi$PBE_MD5_DES_CBC");
         put("SecretKeyFactory.PBEWithSHA1AndDES",

--- a/org/mozilla/jss/crypto/PKCS11Algorithm.java
+++ b/org/mozilla/jss/crypto/PKCS11Algorithm.java
@@ -22,7 +22,10 @@ public enum PKCS11Algorithm {
     CKM_RC2_KEY_GEN (Algorithm.CKM_RC2_KEY_GEN, PKCS11Constants.CKM_RC2_KEY_GEN),
     CKM_RC4_KEY_GEN (Algorithm.CKM_RC4_KEY_GEN, PKCS11Constants.CKM_RC4_KEY_GEN),
     CKM_RSA_PKCS_KEY_PAIR_GEN (Algorithm.CKM_RSA_PKCS_KEY_PAIR_GEN, PKCS11Constants.CKM_RSA_PKCS_KEY_PAIR_GEN),
-    CKM_SHA_1_HMAC (Algorithm.CKM_SHA_1_HMAC, PKCS11Constants.CKM_SHA_1_HMAC);
+    CKM_SHA_1_HMAC (Algorithm.CKM_SHA_1_HMAC, PKCS11Constants.CKM_SHA_1_HMAC),
+    CKM_SHA_256_HMAC (Algorithm.CKM_SHA256_HMAC, PKCS11Constants.CKM_SHA256_HMAC),
+    CKM_SHA_384_HMAC (Algorithm.CKM_SHA384_HMAC, PKCS11Constants.CKM_SHA384_HMAC),
+    CKM_SHA_512_HMAC (Algorithm.CKM_SHA512_HMAC, PKCS11Constants.CKM_SHA512_HMAC);
 
     // Value from Algorithm's constant -- this is an index into Algorithm's
     // table.

--- a/org/mozilla/jss/crypto/SymmetricKey.java
+++ b/org/mozilla/jss/crypto/SymmetricKey.java
@@ -13,6 +13,9 @@ public interface SymmetricKey extends javax.crypto.SecretKey {
     public static final Type RC4 = Type.RC4;
     public static final Type RC2 = Type.RC2;
     public static final Type SHA1_HMAC = Type.SHA1_HMAC;
+    public static final Type SHA256_HMAC = Type.SHA256_HMAC;
+    public static final Type SHA384_HMAC = Type.SHA384_HMAC;
+    public static final Type SHA512_HMAC = Type.SHA512_HMAC;
     public static final Type AES = Type.AES;
 
     public Type getType();

--- a/org/mozilla/jss/crypto/SymmetricKey.java
+++ b/org/mozilla/jss/crypto/SymmetricKey.java
@@ -6,6 +6,8 @@ package org.mozilla.jss.crypto;
 import java.security.NoSuchAlgorithmException;
 import java.util.Hashtable;
 
+import org.mozilla.jss.pkcs11.PKCS11Constants;
+
 public interface SymmetricKey extends javax.crypto.SecretKey {
 
     public static final Type DES = Type.DES;
@@ -112,18 +114,24 @@ public interface SymmetricKey extends javax.crypto.SecretKey {
      */
     public final static class Usage {
         private Usage() { }
-        private Usage(int val) { this.val = val;}
+        private Usage(int val, long pk11_val) {
+            this.val = val;
+            this.pk11_val = pk11_val;
+        }
+
         private int val;
+        private long pk11_val;
 
         public int getVal() { return val; }
+        public long getPKCS11Constant() { return pk11_val; }
 
         // these enums must match the JSS_symkeyUsage list in Algorithm.c
         // and the opFlagForUsage list in PK11KeyGenerator.java
-        public static final Usage ENCRYPT = new Usage(0);
-        public static final Usage DECRYPT = new Usage(1);
-        public static final Usage WRAP = new Usage(2);
-        public static final Usage UNWRAP = new Usage(3);
-        public static final Usage SIGN = new Usage(4);
-        public static final Usage VERIFY = new Usage(5);
+        public static final Usage ENCRYPT = new Usage(0, PKCS11Constants.CKA_ENCRYPT);
+        public static final Usage DECRYPT = new Usage(1, PKCS11Constants.CKA_DECRYPT);
+        public static final Usage WRAP = new Usage(2, PKCS11Constants.CKA_WRAP);
+        public static final Usage UNWRAP = new Usage(3, PKCS11Constants.CKA_UNWRAP);
+        public static final Usage SIGN = new Usage(4, PKCS11Constants.CKA_SIGN);
+        public static final Usage VERIFY = new Usage(5, PKCS11Constants.CKA_VERIFY);
     }
 }

--- a/org/mozilla/jss/crypto/SymmetricKey.java
+++ b/org/mozilla/jss/crypto/SymmetricKey.java
@@ -53,40 +53,47 @@ public interface SymmetricKey extends javax.crypto.SecretKey {
         // all names converted to lowercase for case insensitivity
         private static Hashtable<String, Type> nameMap = new Hashtable<>();
 
-        private String name;
+        private String[] names;
         private KeyGenAlgorithm keyGenAlg;
         private Type() { }
-        private Type(String name, KeyGenAlgorithm keyGenAlg) {
-            this.name = name;
+        private Type(String[] names, KeyGenAlgorithm keyGenAlg) {
+            this.names = names;
             this.keyGenAlg = keyGenAlg;
-            nameMap.put(name.toLowerCase(), this);
+
+            for (String name : names) {
+                nameMap.put(name.toLowerCase(), this);
+            }
         }
-        public static final Type DES = new Type("DES", KeyGenAlgorithm.DES);
+        public static final Type DES = new Type(new String[]{ "DES" }, KeyGenAlgorithm.DES);
         public static final Type DES3 =
-            new Type("DESede", KeyGenAlgorithm.DES3);
+            new Type(new String[] { "DESede", "TDES", "3DES", "DES3" }, KeyGenAlgorithm.DES3);
         public static final Type DESede = DES3;
-        public static final Type RC4 = new Type("RC4", KeyGenAlgorithm.RC4);
-        public static final Type RC2 = new Type("RC2", KeyGenAlgorithm.RC2);
-        public static final Type SHA1_HMAC = new Type("SHA1_HMAC",
+        public static final Type RC4 = new Type(new String[]{ "RC4" }, KeyGenAlgorithm.RC4);
+        public static final Type RC2 = new Type(new String[]{ "RC2" }, KeyGenAlgorithm.RC2);
+        public static final Type SHA1_HMAC = new Type(new String[]{ "SHA1_HMAC", "SHA1-HMAC", "SHA1HMAC", "HMAC_SHA1", "HMAC-SHA1", "HMACSHA1" },
             KeyGenAlgorithm.SHA1_HMAC);
-        public static final Type SHA256_HMAC = new Type("SHA256_HMAC",
+        public static final Type SHA256_HMAC = new Type(new String[]{ "SHA256_HMAC", "SHA256-HMAC", "SHA256HMAC", "HMAC_SHA256", "HMAC-SHA256", "HMACSHA256" },
             KeyGenAlgorithm.SHA256_HMAC);
-        public static final Type SHA384_HMAC = new Type("SHA384_HMAC",
+        public static final Type SHA384_HMAC = new Type(new String[]{ "SHA384_HMAC", "SHA384-HMAC", "SHA384HMAC", "HMAC_SHA384", "HMAC-SHA384", "HMACSHA384" },
             KeyGenAlgorithm.SHA384_HMAC);
-        public static final Type SHA512_HMAC = new Type("SHA512_HMAC",
+        public static final Type SHA512_HMAC = new Type(new String[]{ "SHA512_HMAC", "SHA512-HMAC", "SHA512HMAC", "HMAC_SHA512", "HMAC-SHA512", "HMACSHA512" },
             KeyGenAlgorithm.SHA512_HMAC);
-        public static final Type PBA_SHA1_HMAC = new Type("PBA_SHA1_HMAC",
+        public static final Type PBA_SHA1_HMAC = new Type(new String[]{ "PBA_SHA1_HMAC" },
             KeyGenAlgorithm.PBA_SHA1_HMAC);
-        public static final Type AES = new Type("AES", KeyGenAlgorithm.AES);
+        public static final Type AES = new Type(new String[]{ "AES" }, KeyGenAlgorithm.AES);
 
 
         public String toString() {
-            return name;
+            return names[0];
+        }
+
+        public String[] getAliases() {
+            return names;
         }
 
         public KeyGenAlgorithm getKeyGenAlg() throws NoSuchAlgorithmException {
             if( keyGenAlg == null ) {
-                throw new NoSuchAlgorithmException(name);
+                throw new NoSuchAlgorithmException(names[0]);
             }
             return keyGenAlg;
         }

--- a/org/mozilla/jss/provider/javax/crypto/JSSSecretKeyFactorySpi.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSSecretKeyFactorySpi.java
@@ -398,21 +398,33 @@ class JSSSecretKeyFactorySpi extends SecretKeyFactorySpi {
         }
     }
 
-    /**
-     * @deprecated This class name is misleading. This algorithm
-     * is used for generating Password-Based Authentication keys
-     * for use with HmacSHA1. Use PBAHmacSHA1 instead.
-     */
-    @Deprecated
     public static class HmacSHA1 extends JSSSecretKeyFactorySpi {
         public HmacSHA1() {
-            super(KeyGenAlgorithm.PBA_SHA1_HMAC);
+            super(KeyGenAlgorithm.SHA1_HMAC);
         }
     }
 
     public static class PBAHmacSHA1 extends JSSSecretKeyFactorySpi {
         public PBAHmacSHA1() {
             super(KeyGenAlgorithm.PBA_SHA1_HMAC);
+        }
+    }
+
+    public static class HmacSHA256 extends JSSSecretKeyFactorySpi {
+        public HmacSHA256() {
+            super(KeyGenAlgorithm.SHA256_HMAC);
+        }
+    }
+
+    public static class HmacSHA384 extends JSSSecretKeyFactorySpi {
+        public HmacSHA384() {
+            super(KeyGenAlgorithm.SHA384_HMAC);
+        }
+    }
+
+    public static class HmacSHA512 extends JSSSecretKeyFactorySpi {
+        public HmacSHA512() {
+            super(KeyGenAlgorithm.SHA512_HMAC);
         }
     }
 


### PR DESCRIPTION
In the course of #259, I wanted to finish creating a `PK11SymKey` from a byte array. In doing so, I realized that, when we specify a [`SecretKeySpec`](https://docs.oracle.com/javase/7/docs/api/javax/crypto/spec/SecretKeySpec.html), we do the import correctly already in our [`SecretKeyFactory`](https://docs.oracle.com/javase/7/docs/api/javax/crypto/SecretKeyFactory.html) implementation, [`JSSSecretKeyFactorySpi`](https://github.com/dogtagpki/jss/blob/master/org/mozilla/jss/provider/javax/crypto/JSSSecretKeyFactorySpi.java). However, what is missing is support for a few newer HMAC variants.

This PR does the following things:

 - Finishes adding support for SHA2 variants. This includes adding missing class stubs using the right constants.
 - Allows mapping for `SymmetricKey.Usage` to `PKCS11Constants` values. This is currently unused, but could be used in the future. 
 - Adds support for multiple names in `SymmetricKey.Types`... mostly for HMAC. Otherwise, you'd pass one name to `SecretKeyFactory` and another to `SecretKeySpec`.
 - Updates the tests to use the simplified import structure.