### PR TITLE
Add SSL Storage class, SSLFDProxy

### DIFF
--- a/org/mozilla/jss/nss/PRFDProxy.c
+++ b/org/mozilla/jss/nss/PRFDProxy.c
@@ -5,8 +5,8 @@
 #include "jssutil.h"
 #include "PRFDProxy.h"
 
-jobject
-JSS_PR_wrapPRFDProxy(JNIEnv *env, PRFileDesc **fd)
+static jobject
+JSS_PR_wrapFDProxy(JNIEnv *env, PRFileDesc **fd, const char *className, const char *conSig)
 {
     jbyteArray pointer = NULL;
     jclass proxyClass;
@@ -19,14 +19,14 @@ JSS_PR_wrapPRFDProxy(JNIEnv *env, PRFileDesc **fd)
     pointer = JSS_ptrToByteArray(env, *fd);
 
     /* Lookup the class and constructor */
-    proxyClass = (*env)->FindClass(env, PRFD_PROXY_CLASS_NAME);
+    proxyClass = (*env)->FindClass(env, className);
     if(proxyClass == NULL) {
         ASSERT_OUTOFMEM(env);
         goto finish;
     }
     constructor = (*env)->GetMethodID(env, proxyClass,
                             PLAIN_CONSTRUCTOR,
-                            PRFD_PROXY_CONSTRUCTOR_SIG);
+                            conSig);
     if(constructor == NULL) {
         ASSERT_OUTOFMEM(env);
         goto finish;
@@ -45,6 +45,18 @@ finish:
 
     PR_ASSERT(fdObj || (*env)->ExceptionOccurred(env));
     return fdObj;
+}
+
+jobject
+JSS_PR_wrapPRFDProxy(JNIEnv *env, PRFileDesc **fd)
+{
+    return JSS_PR_wrapFDProxy(env, fd, PRFD_PROXY_CLASS_NAME, PRFD_PROXY_CONSTRUCTOR_SIG);
+}
+
+jobject
+JSS_PR_wrapSSLFDProxy(JNIEnv *env, PRFileDesc **fd)
+{
+    return JSS_PR_wrapFDProxy(env, fd, SSLFD_PROXY_CLASS_NAME, SSLFD_PROXY_CONSTRUCTOR_SIG);
 }
 
 PRStatus

--- a/org/mozilla/jss/nss/PRFDProxy.h
+++ b/org/mozilla/jss/nss/PRFDProxy.h
@@ -6,5 +6,8 @@
 /* Wrap a C/NSPR PRFileDesc into a Java PRFDProxy, closing the fd on error. */
 jobject JSS_PR_wrapPRFDProxy(JNIEnv *env, PRFileDesc **fd);
 
+/* Wrap a C/NSPR PRFileDesc into a Java SSLFDProxy, closing the fd on error. */
+jobject JSS_PR_wrapSSLFDProxy(JNIEnv *env, PRFileDesc **fd);
+
 /* Extract the C/NSPR PRFileDesc from an instance of a Java PRFDProxy. */
 PRStatus JSS_PR_getPRFileDesc(JNIEnv *env, jobject prfd_proxy, PRFileDesc **fd);

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -82,7 +82,7 @@ Java_org_mozilla_jss_nss_SSL_ImportFD(JNIEnv *env, jclass clazz, jobject model,
 
     result = SSL_ImportFD(real_model, real_fd);
 
-    return JSS_PR_wrapPRFDProxy(env, &result);
+    return JSS_PR_wrapSSLFDProxy(env, &result);
 }
 
 JNIEXPORT int JNICALL

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -53,7 +53,7 @@ public class SSL {
      *
      * See also: SSL_ImportFD in /usr/include/nss3/ssl.h
      */
-    public static native PRFDProxy ImportFD(PRFDProxy model, PRFDProxy fd);
+    public static native SSLFDProxy ImportFD(PRFDProxy model, PRFDProxy fd);
 
     /**
      * Set the value of a SSL option on the specified PRFileDesc.

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -60,7 +60,7 @@ public class SSL {
      *
      * See also: SSL_OptionSet in /usr/include/nss3/ssl.h
      */
-    public static native int OptionSet(PRFDProxy fd, int option, int val);
+    public static native int OptionSet(SSLFDProxy fd, int option, int val);
 
     /**
      * Get the value of a SSL option on the specified PRFileDesc. Note that
@@ -68,14 +68,14 @@ public class SSL {
      *
      * See also: SSL_OptionGet in /usr/include/nss3/ssl.h
      */
-    public static native int OptionGet(PRFDProxy fd, int option) throws Exception;
+    public static native int OptionGet(SSLFDProxy fd, int option) throws Exception;
 
     /**
      * Set the hostname of a handshake on the specified PRFileDesc.
      *
      * See also: SSL_SetURL in /usr/include/nss3/ssl.h
      */
-    public static native int SetURL(PRFDProxy fd, String url);
+    public static native int SetURL(SSLFDProxy fd, String url);
 
     /**
      * Set the preference for a specific cipher suite on the specified
@@ -83,7 +83,7 @@ public class SSL {
      *
      * See also: SSL_CipherPrefSet in /usr/include/nss3/ssl.h
      */
-    public static native int CipherPrefSet(PRFDProxy fd, int cipher, boolean enabled);
+    public static native int CipherPrefSet(SSLFDProxy fd, int cipher, boolean enabled);
 
     /**
      * Get the preference for a specific cipher suite on the specified
@@ -92,14 +92,14 @@ public class SSL {
      *
      * See also: SSL_CipherPrefGet in /usr/include/nss3/ssl.h
      */
-    public static native boolean CipherPrefGet(PRFDProxy fd, int cipher) throws Exception;
+    public static native boolean CipherPrefGet(SSLFDProxy fd, int cipher) throws Exception;
 
     /**
      * Set the range of TLS versions enabled by this server by SSLVersionRange.
      *
      * See also: SSL_VersionRangeSet in /usr/include/nss3/ssl.h
      */
-    public static int VersionRangeSet(PRFDProxy fd, SSLVersionRange range) {
+    public static int VersionRangeSet(SSLFDProxy fd, SSLVersionRange range) {
         return VersionRangeSetNative(fd, range.getMinEnum(), range.getMaxEnum());
     }
 
@@ -109,35 +109,35 @@ public class SSL {
      *
      * See also: SSL_VersionRangeSet in /usr/include/nss3/ssl.h
      */
-    private static native int VersionRangeSetNative(PRFDProxy fd, int min_ssl, int max_ssl);
+    private static native int VersionRangeSetNative(SSLFDProxy fd, int min_ssl, int max_ssl);
 
     /**
      * Get the range of TLS versions enabled by this server.
      *
      * See also: SSL_VersionRangeSet in /usr/include/nss3/ssl.h
      */
-    public static native SSLVersionRange VersionRangeGet(PRFDProxy fd) throws Exception;
+    public static native SSLVersionRange VersionRangeGet(SSLFDProxy fd) throws Exception;
 
     /**
      * Check the security status of a SSL handshake.
      *
      * See also: SSL_SecurityStatus in /usr/include/nss3/ssl.h
      */
-    public static native SecurityStatusResult SecurityStatus(PRFDProxy fd);
+    public static native SecurityStatusResult SecurityStatus(SSLFDProxy fd);
 
     /**
      * Reset the handshake status, optionally handshaking as a server.
      *
      * See also: SSL_ResetHandshake in /usr/include/nss3/ssl.h
      */
-    public static native int ResetHandshake(PRFDProxy fd, boolean asServer);
+    public static native int ResetHandshake(SSLFDProxy fd, boolean asServer);
 
     /**
      * Force a handshake to occur if not started, else step one.
      *
      * See also: SSL_ForceHandshake in /usr/include/nss3/ssl.h
      */
-    public static native int ForceHandshake(PRFDProxy fd);
+    public static native int ForceHandshake(SSLFDProxy fd);
 
     /**
      * Configure the certificate and private key for a server socket.
@@ -146,7 +146,7 @@ public class SSL {
      * See also: SSL_ConfigSecureServer in /usr/include/nss3/ssl.h
      */
     @Deprecated
-    public static native int ConfigSecureServer(PRFDProxy fd, PK11Cert cert,
+    public static native int ConfigSecureServer(SSLFDProxy fd, PK11Cert cert,
         PK11PrivKey key, int kea);
 
     /**
@@ -155,7 +155,7 @@ public class SSL {
      *
      * See also: SSL_ConfigServerCert in /usr/include/nss3/ssl.h
      */
-    public static native int ConfigServerCert(PRFDProxy fd, PK11Cert cert,
+    public static native int ConfigServerCert(SSLFDProxy fd, PK11Cert cert,
         PK11PrivKey key);
 
     /**
@@ -171,14 +171,14 @@ public class SSL {
      *
      * See also: SSL_PeerCertificate in /usr/include/nss3/ssl.h
      */
-    public static native PK11Cert PeerCertificate(PRFDProxy fd);
+    public static native PK11Cert PeerCertificate(SSLFDProxy fd);
 
     /**
      * Introspect the peer's certificate chain.
      *
      * See also: SSL_PeerCertificateChain in /usr/include/nss3/ssl.h
      */
-    public static native PK11Cert[] PeerCertificateChain(PRFDProxy fd) throws Exception;
+    public static native PK11Cert[] PeerCertificateChain(SSLFDProxy fd) throws Exception;
 
     /* Internal methods for querying constants. */
     private static native int getSSLRequestCertificate();

--- a/org/mozilla/jss/nss/SSLFDProxy.java
+++ b/org/mozilla/jss/nss/SSLFDProxy.java
@@ -1,0 +1,13 @@
+package org.mozilla.jss.nss;
+
+public class SSLFDProxy extends PRFDProxy {
+    public SSLFDProxy(byte[] pointer) {
+        super(pointer);
+    }
+
+    protected native void releaseNativeResources();
+
+    protected void finalize() throws Throwable {
+        super.finalize();
+    }
+}

--- a/org/mozilla/jss/tests/TestBufferPRFD.java
+++ b/org/mozilla/jss/tests/TestBufferPRFD.java
@@ -42,35 +42,35 @@ public class TestBufferPRFD {
         Buffer.Free(right_read);
     }
 
-    public static PRFDProxy Setup_NSS_Client(PRFDProxy fd, String host) throws Exception {
-        fd = SSL.ImportFD(null, fd);
-        assert(fd != null);
+    public static SSLFDProxy Setup_NSS_Client(PRFDProxy fd, String host) throws Exception {
+        SSLFDProxy result = SSL.ImportFD(null, fd);
+        assert(result != null);
 
-        assert(SSL.ResetHandshake(fd, false) == 0);
-        assert(SSL.SetURL(fd, host) == 0);
+        assert(SSL.ResetHandshake(result, false) == 0);
+        assert(SSL.SetURL(result, host) == 0);
 
-        TestSSLVersionGetSet(fd);
+        TestSSLVersionGetSet(result);
 
-        return fd;
+        return result;
     }
 
-    public static PRFDProxy Setup_NSS_Server(PRFDProxy fd, String host,
+    public static SSLFDProxy Setup_NSS_Server(PRFDProxy fd, String host,
         PK11Cert cert, PK11PrivKey key) throws Exception
     {
-        fd = SSL.ImportFD(null, fd);
-        assert(fd != null);
+        SSLFDProxy result = SSL.ImportFD(null, fd);
+        assert(result != null);
 
-        assert(SSL.ConfigServerCert(fd, cert, key) == 0);
+        assert(SSL.ConfigServerCert(result, cert, key) == 0);
         assert(SSL.ConfigServerSessionIDCache(1, 100, 100, null) == 0);
-        assert(SSL.ResetHandshake(fd, true) == 0);
-        assert(SSL.SetURL(fd, host) == 0);
+        assert(SSL.ResetHandshake(result, true) == 0);
+        assert(SSL.SetURL(result, host) == 0);
 
-        TestSSLVersionGetSet(fd);
+        TestSSLVersionGetSet(result);
 
-        return fd;
+        return result;
     }
 
-    public static boolean IsHandshakeFinished(PRFDProxy c_nspr, PRFDProxy s_nspr) {
+    public static boolean IsHandshakeFinished(SSLFDProxy c_nspr, SSLFDProxy s_nspr) {
         SecurityStatusResult c_result = SSL.SecurityStatus(c_nspr);
         SecurityStatusResult s_result = SSL.SecurityStatus(s_nspr);
 
@@ -79,7 +79,7 @@ public class TestBufferPRFD {
         return c_result.on == 1 && s_result.on == 1;
     }
 
-    public static void TestSSLVersionGetSet(PRFDProxy s_nspr) throws Exception {
+    public static void TestSSLVersionGetSet(SSLFDProxy s_nspr) throws Exception {
         SSLVersionRange initial = SSL.VersionRangeGet(s_nspr);
         System.out.println("Initial: (" + initial.getMinVersion() + ":" + initial.getMinEnum() + ", " + initial.getMaxVersion() + ":" + initial.getMaxEnum() + ")");
 
@@ -123,14 +123,14 @@ public class TestBufferPRFD {
         assert(read_buf != null);
         assert(write_buf != null);
 
-        PRFDProxy c_nspr = PR.NewBufferPRFD(read_buf, write_buf, peer_info);
-        PRFDProxy s_nspr = PR.NewBufferPRFD(write_buf, read_buf, peer_info);
+        PRFDProxy c_buffer = PR.NewBufferPRFD(read_buf, write_buf, peer_info);
+        PRFDProxy s_buffer = PR.NewBufferPRFD(write_buf, read_buf, peer_info);
 
-        assert(c_nspr != null);
-        assert(s_nspr != null);
+        assert(c_buffer != null);
+        assert(s_buffer != null);
 
-        c_nspr = Setup_NSS_Client(c_nspr, host);
-        s_nspr = Setup_NSS_Server(s_nspr, host, server_cert, server_key);
+        SSLFDProxy c_nspr = Setup_NSS_Client(c_buffer, host);
+        SSLFDProxy s_nspr = Setup_NSS_Server(s_buffer, host, server_cert, server_key);
 
         assert(c_nspr != null);
         assert(s_nspr != null);

--- a/org/mozilla/jss/tests/TestBufferPRFD.java
+++ b/org/mozilla/jss/tests/TestBufferPRFD.java
@@ -46,8 +46,8 @@ public class TestBufferPRFD {
         SSLFDProxy result = SSL.ImportFD(null, fd);
         assert(result != null);
 
-        assert(SSL.ResetHandshake(result, false) == 0);
-        assert(SSL.SetURL(result, host) == 0);
+        assert(SSL.ResetHandshake(result, false) == SSL.SECSuccess);
+        assert(SSL.SetURL(result, host) == SSL.SECSuccess);
 
         TestSSLVersionGetSet(result);
 
@@ -60,10 +60,10 @@ public class TestBufferPRFD {
         SSLFDProxy result = SSL.ImportFD(null, fd);
         assert(result != null);
 
-        assert(SSL.ConfigServerCert(result, cert, key) == 0);
-        assert(SSL.ConfigServerSessionIDCache(1, 100, 100, null) == 0);
-        assert(SSL.ResetHandshake(result, true) == 0);
-        assert(SSL.SetURL(result, host) == 0);
+        assert(SSL.ConfigServerCert(result, cert, key) == SSL.SECSuccess);
+        assert(SSL.ConfigServerSessionIDCache(1, 100, 100, null) == SSL.SECSuccess);
+        assert(SSL.ResetHandshake(result, true) == SSL.SECSuccess);
+        assert(SSL.SetURL(result, host) == SSL.SECSuccess);
 
         TestSSLVersionGetSet(result);
 
@@ -85,7 +85,7 @@ public class TestBufferPRFD {
 
         SSLVersionRange vrange = new SSLVersionRange(SSLVersion.TLS_1_1, SSLVersion.TLS_1_3);
 
-        assert(SSL.VersionRangeSet(s_nspr, vrange) == 0);
+        assert(SSL.VersionRangeSet(s_nspr, vrange) == SSL.SECSuccess);
 
         SSLVersionRange actual = SSL.VersionRangeGet(s_nspr);
         System.out.println("Actual: (" + actual.getMinVersion() + ":" + actual.getMinEnum() + ", " + actual.getMaxVersion() + ":" + actual.getMaxEnum() + ")");

--- a/org/mozilla/jss/tests/TestRawSSL.java
+++ b/org/mozilla/jss/tests/TestRawSSL.java
@@ -2,6 +2,7 @@ package org.mozilla.jss.tests;
 
 import org.mozilla.jss.nss.PR;
 import org.mozilla.jss.nss.PRFDProxy;
+import org.mozilla.jss.nss.SSLFDProxy;
 import org.mozilla.jss.nss.SSL;
 import org.mozilla.jss.nss.SecurityStatusResult;
 
@@ -12,7 +13,7 @@ public class TestRawSSL {
         PRFDProxy fd = PR.NewTCPSocket();
         assert(fd != null);
 
-        PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
+        SSLFDProxy ssl_fd = SSL.ImportFD(null, fd);
         assert(ssl_fd != null);
 
         assert(PR.Close(ssl_fd) == PR.SUCCESS);
@@ -22,7 +23,7 @@ public class TestRawSSL {
         PRFDProxy fd = PR.NewTCPSocket();
         assert(fd != null);
 
-        PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
+        SSLFDProxy ssl_fd = SSL.ImportFD(null, fd);
         assert(ssl_fd != null);
 
         // 8 == SSL_ENABLE_SSL3; disable it
@@ -53,7 +54,7 @@ public class TestRawSSL {
         PRFDProxy fd = PR.NewTCPSocket();
         assert(fd != null);
 
-        PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
+        SSLFDProxy ssl_fd = SSL.ImportFD(null, fd);
         assert(ssl_fd != null);
 
         int cipher = SSLCipher.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384.getID();
@@ -81,9 +82,7 @@ public class TestRawSSL {
         PRFDProxy fd = PR.NewTCPSocket();
         assert(fd != null);
 
-        assert(SSL.SetURL(fd, "https://google.com") == SSL.SECFailure);
-
-        PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
+        SSLFDProxy ssl_fd = SSL.ImportFD(null, fd);
         assert(ssl_fd != null);
 
         assert(SSL.SetURL(ssl_fd, "https://google.com") == SSL.SECSuccess);
@@ -95,9 +94,7 @@ public class TestRawSSL {
         PRFDProxy fd = PR.NewTCPSocket();
         assert(fd != null);
 
-        assert(SSL.SecurityStatus(fd) == null);
-
-        PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
+        SSLFDProxy ssl_fd = SSL.ImportFD(null, fd);
         assert(ssl_fd != null);
 
         SecurityStatusResult r = SSL.SecurityStatus(ssl_fd);
@@ -110,10 +107,8 @@ public class TestRawSSL {
         PRFDProxy fd = PR.NewTCPSocket();
         assert(fd != null);
 
-        assert(SSL.ResetHandshake(fd, false) == SSL.SECFailure);
-
-        PRFDProxy ssl_fd = SSL.ImportFD(null, fd);
-        assert(SSL.ResetHandshake(fd, false) == SSL.SECSuccess);
+        SSLFDProxy ssl_fd = SSL.ImportFD(null, fd);
+        assert(SSL.ResetHandshake(ssl_fd, false) == SSL.SECSuccess);
 
         assert(PR.Close(ssl_fd) == PR.SUCCESS);
     }

--- a/org/mozilla/jss/util/java_ids.h
+++ b/org/mozilla/jss/util/java_ids.h
@@ -387,6 +387,12 @@ PR_BEGIN_EXTERN_C
 #define PRFD_PROXY_CONSTRUCTOR_SIG "([B)V"
 
 /*
+ * SSLFDProxy
+ */
+#define SSLFD_PROXY_CLASS_NAME "org/mozilla/jss/nss/SSLFDProxy"
+#define SSLFD_PROXY_CONSTRUCTOR_SIG "([B)V"
+
+/*
  * SecurityStatusResult
  */
 #define SECURITY_STATUS_CLASS_NAME "org/mozilla/jss/nss/SecurityStatusResult"


### PR DESCRIPTION
Off of a SSL-enabled `PRFileDesc` created by NSS's `SSL_ImportFD`, we might
want to store various information which would be helpful (and, necessary
to free at the end):

 - Any `TrustManager`s we're using on this connection,
 - Whether or not the handshake has finished,
 - The client certificate, or
 - Additional parameters required for NSS callbacks.

Some of these will be Java-backed values, in which case they should be
added directly to `SSLFDProxy`. Others will be C-backed values, in which
case they should be freed once the SSL Socket is closed.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`