### PR TITLE
Add CryptoManager.ImportDERCert(...)

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -397,6 +397,7 @@ Java_org_mozilla_jss_nss_Buffer_Free;
 JSS_4.6.2 {
     global:
 Java_org_mozilla_jss_pkcs11_PK11PrivKey_getPublicKey;
+Java_org_mozilla_jss_CryptoManager_importDERCertNative;
     local:
         *;
 };

--- a/org/mozilla/jss/CertificateUsage.java
+++ b/org/mozilla/jss/CertificateUsage.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 public final class CertificateUsage {
 
     private int usage;
+    private int value;
     private String name;
 
     // certificateUsage, these must be kept in sync with nss/lib/certdb/certt.h
@@ -28,18 +29,36 @@ public final class CertificateUsage {
     private static final int certificateUsageProtectedObjectSigner = 0x0200;
     private static final int certificateUsageStatusResponder = 0x0400;
     private static final int certificateUsageAnyCA = 0x0800;
+    private static final int certificateUsageIPsec = 0x1000;
+
+    // SECCertUsage enum values
+    private static final int certUsageSSLClient = 0;
+    private static final int certUsageSSLServer = 1;
+    private static final int certUsageSSLServerWithStepUp = 2;
+    private static final int certUsageSSLCA = 3;
+    private static final int certUsageEmailSigner = 4;
+    private static final int certUsageEmailRecipient = 5;
+    private static final int certUsageObjectSigner = 6;
+    private static final int certUsageUserCertImport = 7;
+    private static final int certUsageVerifyCA = 8;
+    private static final int certUsageProtectedObjectSigner = 9;
+    private static final int certUsageStatusResponder = 10;
+    private static final int certUsageAnyCA = 11;
+    private static final int certUsageIPsec = 12;
 
     static private ArrayList<CertificateUsage> list = new ArrayList<>();
 
     private CertificateUsage() {
     }
 
-    private CertificateUsage(int usage, String name) {
+    private CertificateUsage(int usage, int value, String name) {
         this.usage = usage;
+        this.value = value;
         this.name =  name;
         list.add(this);
 
     }
+
     public int getUsage() {
         return usage;
     }
@@ -48,23 +67,29 @@ public final class CertificateUsage {
         return list.iterator();
 
     }
+
     public String toString() {
         return name;
     }
 
-    public static final CertificateUsage CheckAllUsages = new CertificateUsage(certificateUsageCheckAllUsages, "CheckAllUsages");
-    public static final CertificateUsage SSLClient = new CertificateUsage(certificateUsageSSLClient, "SSLClient");
-    public static final CertificateUsage SSLServer = new CertificateUsage(certificateUsageSSLServer, "SSLServer");
-    public static final CertificateUsage SSLServerWithStepUp = new CertificateUsage(certificateUsageSSLServerWithStepUp, "SSLServerWithStepUp");
-    public static final CertificateUsage SSLCA = new CertificateUsage(certificateUsageSSLCA, "SSLCA");
-    public static final CertificateUsage EmailSigner = new CertificateUsage(certificateUsageEmailSigner, "EmailSigner");
-    public static final CertificateUsage EmailRecipient = new CertificateUsage(certificateUsageEmailRecipient, "EmailRecipient");
-    public static final CertificateUsage ObjectSigner = new CertificateUsage(certificateUsageObjectSigner, "ObjectSigner");
-    public static final CertificateUsage UserCertImport = new CertificateUsage(certificateUsageUserCertImport, "UserCertImport");
-    public static final CertificateUsage VerifyCA = new CertificateUsage(certificateUsageVerifyCA, "VerifyCA");
-    public static final CertificateUsage ProtectedObjectSigner = new CertificateUsage(certificateUsageProtectedObjectSigner, "ProtectedObjectSigner");
-    public static final CertificateUsage StatusResponder = new CertificateUsage(certificateUsageStatusResponder, "StatusResponder");
-    public static final CertificateUsage AnyCA = new CertificateUsage(certificateUsageAnyCA, "AnyCA");
+    public int getEnumValue() {
+        return value;
+    }
+
+    public static final CertificateUsage CheckAllUsages = new CertificateUsage(certificateUsageCheckAllUsages, -1, "CheckAllUsages");
+    public static final CertificateUsage SSLClient = new CertificateUsage(certificateUsageSSLClient, certUsageSSLClient, "SSLClient");
+    public static final CertificateUsage SSLServer = new CertificateUsage(certificateUsageSSLServer, certUsageSSLServer, "SSLServer");
+    public static final CertificateUsage SSLServerWithStepUp = new CertificateUsage(certificateUsageSSLServerWithStepUp, certUsageSSLServerWithStepUp, "SSLServerWithStepUp");
+    public static final CertificateUsage SSLCA = new CertificateUsage(certificateUsageSSLCA, certUsageSSLCA, "SSLCA");
+    public static final CertificateUsage EmailSigner = new CertificateUsage(certificateUsageEmailSigner, certUsageEmailSigner, "EmailSigner");
+    public static final CertificateUsage EmailRecipient = new CertificateUsage(certificateUsageEmailRecipient, certUsageEmailRecipient, "EmailRecipient");
+    public static final CertificateUsage ObjectSigner = new CertificateUsage(certificateUsageObjectSigner, certUsageObjectSigner, "ObjectSigner");
+    public static final CertificateUsage UserCertImport = new CertificateUsage(certificateUsageUserCertImport, certUsageUserCertImport, "UserCertImport");
+    public static final CertificateUsage VerifyCA = new CertificateUsage(certificateUsageVerifyCA, certUsageVerifyCA, "VerifyCA");
+    public static final CertificateUsage ProtectedObjectSigner = new CertificateUsage(certificateUsageProtectedObjectSigner, certUsageProtectedObjectSigner, "ProtectedObjectSigner");
+    public static final CertificateUsage StatusResponder = new CertificateUsage(certificateUsageStatusResponder, certUsageStatusResponder, "StatusResponder");
+    public static final CertificateUsage AnyCA = new CertificateUsage(certificateUsageAnyCA, certUsageAnyCA, "AnyCA");
+    public static final CertificateUsage IPsec = new CertificateUsage(certificateUsageIPsec, certUsageIPsec, "IPsec");
 
     /*
             The folllowing usages cannot be verified:

--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -741,6 +741,17 @@ public final class CryptoManager implements TokenSupplier
         }
     }
 
+    /**
+     * Imports a single DER-encoded certificate into the permanent or temporary
+     * certificate database.
+     */
+    public X509Certificate importDERCert(byte[] cert, CertificateUsage usage,
+                                         boolean permanent, String nickname) {
+        return importDERCertNative(cert, usage.getEnumValue(), permanent, nickname);
+    }
+
+    private native X509Certificate importDERCertNative(byte[] cert, int usage, boolean permanent, String nickname);
+
     private native InternalCertificate
         importCertToPermNative(X509Certificate cert, String nickname)
         throws TokenException;

--- a/org/mozilla/jss/tests/X509CertTest.java
+++ b/org/mozilla/jss/tests/X509CertTest.java
@@ -17,10 +17,12 @@ import java.security.interfaces.ECPrivateKey;
 import java.util.Calendar;
 import java.util.Date;
 
+import org.mozilla.jss.CertificateUsage;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.KeyPairAlgorithm;
 import org.mozilla.jss.crypto.KeyPairGenerator;
+import org.mozilla.jss.crypto.X509Certificate;
 import org.mozilla.jss.netscape.security.util.BigInt;
 import org.mozilla.jss.netscape.security.util.DerValue;
 import org.mozilla.jss.netscape.security.x509.AlgorithmId;
@@ -39,6 +41,8 @@ import org.mozilla.jss.netscape.security.x509.X509Key;
 import org.mozilla.jss.pkcs11.PK11ECPublicKey;
 import org.mozilla.jss.util.PasswordCallback;
 
+import org.apache.commons.codec.binary.Base64;
+
 public class X509CertTest {
 
     public static String subjectDN = "CN = 8a99f98342b97d130142ba2cc30f07d3";
@@ -53,7 +57,6 @@ public class X509CertTest {
 
         String dbdir = args[0];
         String passwordfile = args[1];
-
 
         Date notBefore = new Date();
         Calendar cal = Calendar.getInstance();
@@ -71,6 +74,8 @@ public class X509CertTest {
 
         testEC(token, notBefore, notAfter);
         testRSA(token, notBefore, notAfter);
+
+        testImport();
     }
 
     public static void testEC(CryptoToken token, Date notBefore, Date notAfter) throws Exception {
@@ -82,7 +87,6 @@ public class X509CertTest {
         KeyPair keypairCA = gen.genKeyPair();
         testKeys(keypairCA);
         PublicKey pubCA = keypairCA.getPublic();
-
 
         gen.initialize(gen.getCurveCodeByName("secp521r1"));
         KeyPair keypairUser = gen.genKeyPair();
@@ -205,5 +209,32 @@ public class X509CertTest {
             xKey = X509Key.parse(new DerValue(encoded));
         }
         return xKey;
+    }
+
+    public static void testImport() throws Exception {
+        CryptoManager cryptoManager = CryptoManager.getInstance();
+        byte[] cert = Base64.decodeBase64(
+            "MIIDRjCCAi6gAwIBAgIJAMHiDXjnZ1J6MA0GCSqGSIb3DQEBCwUAMDgxEDAOBgNV" +
+            "BAoMB0VYQU1QTEUxJDAiBgNVBAMMG1Jvb3QgQ0EgU2lnbmluZyBDZXJ0aWZpY2F0" +
+            "ZTAeFw0xOTAzMDUxNzQzMjFaFw0yMDAzMDQxNzQzMjFaMDgxEDAOBgNVBAoMB0VY" +
+            "QU1QTEUxJDAiBgNVBAMMG1Jvb3QgQ0EgU2lnbmluZyBDZXJ0aWZpY2F0ZTCCASIw" +
+            "DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMDv7ovkD+JVEdlLncYDnhzbLOz2" +
+            "c3D37fobufnHHNwNOwfLZj8WdBCzwGJv+XGF+D2JIcKyYwYPR+HOg+xClhuuVleE" +
+            "gMVvgxM+HcpM4heyBD2QczNo1dfXQRBy2AXvRn8Byh+Q6zbN7VoNu8ZaMQOxZx9m" +
+            "EAiDZ7WxHVrEp2a4QrI6I9gKY6SyEHRzVT48JElLFokwhkMpF8vhgtj0Xxr5EEIY" +
+            "yCMOzvZLtpeyH8PUri3Cv/hX1RZKjWqKLSJSKirnZLhZoEEzXtsOmoeeZBeRiabi" +
+            "dPLsxqPfWFx4+BC7t5Vw5FaIt2mPh+q6bjZipO4uWz/p4a9wpqakuzgNsYUCAwEA" +
+            "AaNTMFEwHQYDVR0OBBYEFCvlfY9OzAVsYpJEoqr7QfguO9v5MB8GA1UdIwQYMBaA" +
+            "FCvlfY9OzAVsYpJEoqr7QfguO9v5MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcN" +
+            "AQELBQADggEBAHB1lWjT6bP1jAkk6eTVwBU2pGoGoYMGV3fWQGOmWQP5T7+nHKkU" +
+            "jNMRACoC2hFlypwX8qQ70V5O4U+qrnxDP3EaT1zPsOB0x4DIIrpFgudL9EqnSbJ0" +
+            "kvSz3awwO8x/Nvx7TatCncmTw9c14eqek2puhcQWvxHzWkaDHd9WxPrZJFftbSsn" +
+            "ZGK2A/ybDCnUA5BDeCSDb5gufTd8gbS4wS1NwYcbbrQyHnLJlFcIF4aLkbYuX1bn" +
+            "cYp8pQv3pZ3C/ofA+yBJvPELTaHjDC40MTdjFFfMQTPZswBX2iimoGQ/ProBGg7+" +
+            "rLg2uk5AHff3oo/V1X0SSzo3IpvHh0jhg9I="
+        );
+
+        X509Certificate ret = cryptoManager.importDERCert(cert, CertificateUsage.SSLCA, false, null);
+        assert(ret != null);
     }
 }


### PR DESCRIPTION
ImportDERCert differs from other calls in that it allows importing a
certificate temporarily, without putting it in the permanent trust
store. This lets you import (and trust) an intermediate CA certificate
without permanently storing it, and use it to validate a leaf
certificate.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`