### PR TITLE
Capture PRErrorCode <-> Exception mappings

### DIFF
--- a/org/mozilla/jss/util/jss_exceptions.h
+++ b/org/mozilla/jss/util/jss_exceptions.h
@@ -12,6 +12,7 @@
 
 PR_BEGIN_EXTERN_C
 
+#define JAVA_LANG_EXCEPTION "java/lang/Exception"
 
 #define ALREADY_INITIALIZED_EXCEPTION "org/mozilla/jss/crypto/AlreadyInitializedException"
 
@@ -28,6 +29,14 @@ PR_BEGIN_EXTERN_C
 #define CERTIFICATE_EXCEPTION "java/security/cert/CertificateException"
 
 #define CERTIFICATE_ENCODING_EXCEPTION "java/security/cert/CertificateEncodingException"
+
+#define CERTIFICATE_EXPIRED_EXCEPTION "java/security/cert/CertificateExpiredException"
+
+#define CERTIFICATE_NOT_YET_VALID_EXCEPTION "java/security/cert/CertificateNotYetValidException"
+
+#define CERTIFICATE_PARSING_EXCEPTION "java/security/cert/CertificateParsingException"
+
+#define CERTIFICATE_REVOKED_EXCEPTION "java/security/cert/CertificateRevokedException"
 
 #define CRL_IMPORT_EXCEPTION "org/mozilla/jss/CRLImportException"
 

--- a/org/mozilla/jss/util/jssutil.h
+++ b/org/mozilla/jss/util/jssutil.h
@@ -365,6 +365,43 @@ void JSS_DerefJString(JNIEnv *env, jstring str, const char *ref);
 jobjectArray JSS_PK11_WrapCertToChain(JNIEnv *env, CERTCertificate *cert,
                                       SECCertUsage certUsage);
 
+/************************************************************************
+** JSS_ExceptionToSECStatus
+**
+** When the JNI has thrown a known exception, convert this to a SECStatus
+** code and set the appropriate PRErrorCode.
+**
+** The supported exceptions are:
+**  - CertificateException
+**
+*/
+SECStatus JSS_ExceptionToSECStatus(JNIEnv *env);
+
+/************************************************************************
+** JSS_SECStatusToException
+**
+** Convert a failing SECStatus and PRErrorCode combination into a raised
+** JNI exception.
+**
+** The supported exceptions are:
+**  - CertificateException
+**
+*/
+void JSS_SECStatusToException(JNIEnv *env, SECStatus result, PRErrorCode code);
+
+/************************************************************************
+** JSS_SECStatusToException
+**
+** Convert a failing SECStatus and PRErrorCode combination into a raised
+** JNI exception with the specified message.
+**
+** The supported exceptions are:
+**  - CertificateException
+**
+*/
+void JSS_SECStatusToExceptionMessage(JNIEnv *env, SECStatus result,
+                                     PRErrorCode code, const char *message);
+
 PR_END_EXTERN_C
 
 #endif


### PR DESCRIPTION
Often we'll need to take a `PRErrorCode` and raise it as a Java Exception
(via the JNI interface) of the proper type. Other times, we'll need to
take a raised Java Exception and return it as the correct
(`SECStatus`, `PRErrorCode`) pair.

We introduce `JSS_ExceptionToSECStatus` and `JSS_SECStatusToException` to
handle this. The latter has a *Message form, which takes an error
message to raise with the exception.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`