### PR TITLE
Wrap a certificate with chain to jobjectArray

### DIFF
--- a/org/mozilla/jss/util/jssutil.c
+++ b/org/mozilla/jss/util/jssutil.c
@@ -11,6 +11,10 @@
 #include "jss_bigint.h"
 #include "jss_exceptions.h"
 #include "java_ids.h"
+#include "nss.h"
+#include "cert.h"
+#include "certt.h"
+#include "pk11util.h"
 
 
 /***********************************************************************
@@ -748,6 +752,24 @@ void JSS_DerefJString(JNIEnv *env, jstring str, const char *ref) {
     if (str != NULL && ref != NULL) {
         (*env)->ReleaseStringUTFChars(env, str, ref);
     }
+}
+
+/************************************************************************
+** JSS_PK11_WrapCertToChain
+**
+** See jssutil.h for more information.
+**
+*/
+jobjectArray JSS_PK11_WrapCertToChain(JNIEnv *env, CERTCertificate *cert, SECCertUsage certUsage) {
+    CERTCertList *chain = CERT_GetCertChainFromCert(cert, PR_Now(), certUsage);
+
+    // The only failure cases here are when we're out of memory; in which
+    // case, there's not much more for us to do but return NULL.
+    if (chain == NULL) {
+        return NULL;
+    }
+
+    return JSS_PK11_wrapCertChain(env, &chain);
 }
 
 /*

--- a/org/mozilla/jss/util/jssutil.h
+++ b/org/mozilla/jss/util/jssutil.h
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 #include <stdbool.h>
 
+#include <certt.h>
 #include <nspr.h>
 #include <jni.h>
 #include <secitem.h>
@@ -353,6 +354,16 @@ const char *JSS_RefJString(JNIEnv *env, jstring str);
 **
 */
 void JSS_DerefJString(JNIEnv *env, jstring str, const char *ref);
+
+/************************************************************************
+** JSS_PK11_WrapCertToChain
+**
+** Inquires about the certificate chain for cert, and returns the full or
+** partial as a jobjectArray for use in JNI'd code.
+**
+*/
+jobjectArray JSS_PK11_WrapCertToChain(JNIEnv *env, CERTCertificate *cert,
+                                      SECCertUsage certUsage);
 
 PR_END_EXTERN_C
 


### PR DESCRIPTION
Sometimes we have only a single `CERTCertificate` but wish to inquire
about as much of its chain as we can, and return the result as a
`jobjectArray` to pass back to Java. This is helpful when we've gotten a
`CERTCertificate` from NSS and we need to check it against a `TrustManager`
instance.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`