### PR TITLE
Support using SymmetricKey in JSSMacSpi

### DIFF
--- a/org/mozilla/jss/provider/javax/crypto/JSSMacSpi.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSMacSpi.java
@@ -15,6 +15,7 @@ import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.HMACAlgorithm;
 import org.mozilla.jss.crypto.JSSMessageDigest;
 import org.mozilla.jss.crypto.SecretKeyFacade;
+import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.TokenRuntimeException;
 import org.mozilla.jss.crypto.TokenSupplierManager;
 
@@ -45,11 +46,17 @@ class JSSMacSpi extends javax.crypto.MacSpi {
         throws InvalidKeyException, InvalidAlgorithmParameterException
     {
       try {
-        if( ! (key instanceof SecretKeyFacade) ) {
-            throw new InvalidKeyException("Must use a JSS key");
+        SymmetricKey real_key;
+        if (key instanceof SecretKeyFacade) {
+            SecretKeyFacade facade = (SecretKeyFacade)key;
+            real_key = facade.key;
+        } else if (key instanceof SymmetricKey) {
+            real_key = (SymmetricKey)key;
+        } else {
+            throw new InvalidKeyException("Must use a key created by JSS! Try exporting the key data and importing it via SecretKeyFactory.");
         }
-        SecretKeyFacade facade = (SecretKeyFacade)key;
-        digest.initHMAC(facade.key);
+
+        digest.initHMAC(real_key);
       } catch(DigestException de) {
         throw new InvalidKeyException(
             "DigestException: " + de.getMessage());


### PR DESCRIPTION
`JSSMacSpi` differs from `JSSCipherSpi` in that it requires the caller to
pass a `SecretKeyFacade` instance (which merely wraps a `SymmetricKey`) and
are typically created by `SecretKeyFactory`. However, the caller might
have an existing `SymmetricKey` and wish to use that with `JSSMacSpi`; check
for that case and handle it gracefully. Unlike `JSSCipherSpi`, we don't
use the `SecretKeyFactory` to clone the underlying key.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`