### PR TITLE
SSL Client Certificates

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -398,6 +398,7 @@ JSS_4.6.2 {
     global:
 Java_org_mozilla_jss_pkcs11_PK11PrivKey_getPublicKey;
 Java_org_mozilla_jss_CryptoManager_importDERCertNative;
+Java_org_mozilla_jss_nss_SSL_AttachClientCertCallback;
     local:
         *;
 };

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -180,6 +180,14 @@ public class SSL {
      */
     public static native PK11Cert[] PeerCertificateChain(SSLFDProxy fd) throws Exception;
 
+    /**
+     * Use client authentication; set client certificate from SSLFDProxy.
+     *
+     * See also: SSL_GetClientAuthDataHook in /usr/include/nss3/ssl.h,
+     *           org.mozilla.jss.nss.SSLFDProxy.SetClientCert(...)
+     */
+    public static native int AttachClientCertCallback(SSLFDProxy fd) throws Exception;
+
     /* Internal methods for querying constants. */
     private static native int getSSLRequestCertificate();
     private static native int getSSLRequireCertificate();

--- a/org/mozilla/jss/nss/SSLFDProxy.c
+++ b/org/mozilla/jss/nss/SSLFDProxy.c
@@ -1,0 +1,86 @@
+#include <nspr.h>
+#include <nss.h>
+#include <ssl.h>
+#include <pk11pub.h>
+#include <jni.h>
+
+#include "java_ids.h"
+#include "jssutil.h"
+#include "pk11util.h"
+#include "SSLFDProxy.h"
+
+PRStatus
+JSS_NSS_getSSLClientCert(JNIEnv *env, jobject sslfd_proxy, CERTCertificate **cert)
+{
+    jclass sslfdProxyClass;
+    jfieldID certField;
+    jobject certProxy;
+
+    PR_ASSERT(env != NULL && sslfd_proxy != NULL && cert != NULL);
+
+    /* Resolve the clientCert field on a SSLFDProxy object. */
+    sslfdProxyClass = (*env)->GetObjectClass(env, sslfd_proxy);
+    if (sslfdProxyClass == NULL) {
+        return PR_FAILURE;
+    }
+
+    certField = (*env)->GetFieldID(env, sslfdProxyClass,
+                                   SSLFD_PROXY_CLIENT_CERT_FIELD,
+                                   SSLFD_PROXY_CLIENT_CERT_SIG);
+    if (certField == NULL) {
+        return PR_FAILURE;
+    }
+
+    certProxy = (*env)->GetObjectField(env, sslfd_proxy, certField);
+
+    if (certProxy == NULL) {
+        *cert = NULL;
+        return PR_SUCCESS;
+    }
+
+    /* Get the underlying CERTCertificate pointer from the clientCert
+     * (of type PK11Cert) object. */
+    return JSS_PK11_getCertPtr(env, certProxy, cert);
+}
+
+SECStatus
+JSSL_SSLFDCertSelectionCallback(void *arg,
+                                PRFileDesc *fd,
+                                CERTDistNames *caNames,
+                                CERTCertificate **pRetCert,
+                                SECKEYPrivateKey **pRetKey)
+{
+    CERTCertificate *cert = arg;
+    PK11SlotList *slotList;
+    PK11SlotListElement *slotElement;
+    SECKEYPrivateKey *privkey = NULL;
+
+    /* Certificate selection for client auth requires that we pass both the
+     * certificate (in *pRetCert) and its key (in *pRetKey). We iterate over
+     * all slots that the certificate is in, looking for a private key in
+     * any of them. Once found, we return the private key. */
+    slotList = PK11_GetAllSlotsForCert(cert, NULL /* unused arg */);
+    if (slotList == NULL) {
+        return SECFailure;
+    }
+
+    for (slotElement = slotList->head; slotElement; slotElement = slotElement->next) {
+        privkey = PK11_FindPrivateKeyFromCert(slotElement->slot, cert, NULL /* pinarg */);
+        if (privkey != NULL) {
+            break;
+        }
+    }
+
+    /* Always free the slot list. */
+    PK11_FreeSlotList(slotList);
+
+    /* If the certificate isn't found, return SECFailure. */
+    if (privkey == NULL) {
+        return SECFailure;
+    }
+
+    *pRetCert = cert;
+    *pRetKey = privkey;
+    return SECSuccess;
+}
+

--- a/org/mozilla/jss/nss/SSLFDProxy.h
+++ b/org/mozilla/jss/nss/SSLFDProxy.h
@@ -1,0 +1,14 @@
+#include <nspr.h>
+#include <nss.h>
+#include <jni.h>
+
+#pragma once
+
+PRStatus JSS_NSS_getSSLClientCert(JNIEnv *env, jobject sslfd_proxy, CERTCertificate **cert);
+
+SECStatus
+JSSL_SSLFDCertSelectionCallback(void *arg,
+                                PRFileDesc *fd,
+                                CERTDistNames *caNames,
+                                CERTCertificate **pRetCert,
+                                SECKEYPrivateKey **pRetKey);

--- a/org/mozilla/jss/nss/SSLFDProxy.java
+++ b/org/mozilla/jss/nss/SSLFDProxy.java
@@ -1,8 +1,23 @@
 package org.mozilla.jss.nss;
 
+import java.lang.IllegalArgumentException;
+
+import org.mozilla.jss.crypto.X509Certificate;
+import org.mozilla.jss.pkcs11.PK11Cert;
+
 public class SSLFDProxy extends PRFDProxy {
+    public PK11Cert clientCert;
+
     public SSLFDProxy(byte[] pointer) {
         super(pointer);
+    }
+
+    public void SetClientCert(X509Certificate cert) throws IllegalArgumentException {
+        if (!(cert instanceof PK11Cert)) {
+            throw new IllegalArgumentException("Unable to cast given certificate to PK11Cert: " + cert.getClass().getName());
+        }
+
+        clientCert = (PK11Cert)cert;
     }
 
     protected native void releaseNativeResources();

--- a/org/mozilla/jss/util/java_ids.h
+++ b/org/mozilla/jss/util/java_ids.h
@@ -391,6 +391,8 @@ PR_BEGIN_EXTERN_C
  */
 #define SSLFD_PROXY_CLASS_NAME "org/mozilla/jss/nss/SSLFDProxy"
 #define SSLFD_PROXY_CONSTRUCTOR_SIG "([B)V"
+#define SSLFD_PROXY_CLIENT_CERT_FIELD "clientCert"
+#define SSLFD_PROXY_CLIENT_CERT_SIG "Lorg/mozilla/jss/pkcs11/PK11Cert;"
 
 /*
  * SecurityStatusResult


### PR DESCRIPTION
This PR adds support for SSL client certificates in `org.mozilla.jss.nss`, which will eventually enable their use in the SSLEngine (#150). In particular, we:

 - Add a new field to `SSLFDProxy`, `clientCert`,
 - Add a setter,
 - Add a new callback, `JSSL_SSLFDCertSelectionCallback` which returns the single cert we've already selected for use. 

Later enhancements can add other certificate selection mechanisms, but this should interact well with our current SSLEngine design. 