### PR TITLE
Fix callback alert handling

### DIFF
--- a/org/mozilla/jss/ssl/callbacks.c
+++ b/org/mozilla/jss/ssl/callbacks.c
@@ -313,8 +313,8 @@ JSSL_AlertReceivedCallback(const PRFileDesc *fd, void *arg, const SSLAlert *aler
     PR_ASSERT(env != NULL);
 
     /* Fast return when assumptions are incorrect. */
-    if (socket != NULL || socket->socketObject != NULL ||
-            rc != JNI_OK || env != NULL) {
+    if (socket == NULL || socket->socketObject == NULL ||
+            rc != JNI_OK || env == NULL) {
         return;
     }
 
@@ -379,8 +379,8 @@ JSSL_AlertSentCallback(const PRFileDesc *fd, void *arg, const SSLAlert *alert)
     PR_ASSERT(env != NULL);
 
     /* Fast return when assumptions are incorrect. */
-    if (socket != NULL || socket->socketObject != NULL ||
-            rc != JNI_OK || env != NULL) {
+    if (socket == NULL || socket->socketObject == NULL ||
+            rc != JNI_OK || env == NULL) {
         return;
     }
 


### PR DESCRIPTION
In 871231d20f6e6956134c670d57087f121ffe0563 I incorrectly handled an
unused variable warning, where rc is unused when compiling outside of
debug mode. As part of this fix, I incorrectly returned based on the
same values we were asserting -- for 3 of the 4 values. Instead, I
should've returned when these conditionals were negated.

Candidate to backport to `v4.5.x`. Not necessary to backport to `v4.4.x` to my knowledge. 

@geetikakay Do you mind checking the resulting build to see if this happens to fix the SSLAlert issue you were mentioning in a [previous BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1733651)?

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`