### PR TITLE
Make sandbox build fully debug

### DIFF
--- a/tools/Dockerfiles/fedora_sandbox
+++ b/tools/Dockerfiles/fedora_sandbox
@@ -35,7 +35,7 @@ CMD true \
         && rm -rf build \
         && mkdir build \
         && cd build \
-        && cmake .. \
+        && CFLAGS="-Wall -Wextra -Werror -Og -ggdb" cmake -DCMAKE_BUILD_TYPE=Debug .. \
         && make all \
         && ctest --output-on-failure \
         && true


### PR DESCRIPTION
Since we're building NSS in debug mode by default, we should also build
JSS in debug mode here. This will be our only build with CMake release
type DEBUG and debug CFLAGS.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`