### PR TITLE
Native proxy improvements

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -399,6 +399,7 @@ JSS_4.6.2 {
 Java_org_mozilla_jss_pkcs11_PK11PrivKey_getPublicKey;
 Java_org_mozilla_jss_CryptoManager_importDERCertNative;
 Java_org_mozilla_jss_nss_SSL_AttachClientCertCallback;
+Java_org_mozilla_jss_CryptoManager_getJSSDebug;
     local:
         *;
 };

--- a/org/mozilla/jss/CryptoManager.c
+++ b/org/mozilla/jss/CryptoManager.c
@@ -1025,3 +1025,13 @@ Java_org_mozilla_jss_CryptoManager_getJSSPatchVersion(
     return JSS_VPATCH;
 }
 
+JNIEXPORT jboolean JNICALL
+Java_org_mozilla_jss_CryptoManager_getJSSDebug(JNIEnv *env, jobject this)
+{
+#ifdef DEBUG
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+

--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -995,11 +995,14 @@ public final class CryptoManager implements TokenSupplier
     public native static int getJSSMajorVersion();
     public native static int getJSSMinorVersion();
     public native static int getJSSPatchVersion();
+    private native static boolean getJSSDebug();
 
     public static final String
     JAR_JSS_VERSION     = "JSS_VERSION = JSS_" + getJSSMajorVersion() +
                           "_" + getJSSMinorVersion() +
                           "_" + getJSSPatchVersion();
+
+    public static final boolean JSS_DEBUG = getJSSDebug();
 
     // Hashtable is synchronized.
     private Hashtable<Thread, CryptoToken> perThreadTokenTable = new Hashtable<>();

--- a/org/mozilla/jss/nss/Buffer.c
+++ b/org/mozilla/jss/nss/Buffer.c
@@ -180,4 +180,5 @@ Java_org_mozilla_jss_nss_Buffer_Free(JNIEnv *env, jclass clazz, jobject buf)
     }
 
     jb_free(real_buf);
+    JSS_clearPtrFromProxy(env, buf);
 }

--- a/org/mozilla/jss/nss/BufferProxy.java
+++ b/org/mozilla/jss/nss/BufferProxy.java
@@ -5,7 +5,15 @@ public class BufferProxy extends org.mozilla.jss.util.NativeProxy {
         super(pointer);
     }
 
-    protected native void releaseNativeResources();
+    /**
+     * It is usually better to call org.mozilla.jss.nss.Buffer.Free(...)
+     * instead.
+     *
+     * But this does it for you.
+     */
+    protected void releaseNativeResources() {
+        Buffer.Free(this);
+    }
 
     protected void finalize() throws Throwable {
         super.finalize();

--- a/org/mozilla/jss/nss/PR.c
+++ b/org/mozilla/jss/nss/PR.c
@@ -99,7 +99,12 @@ Java_org_mozilla_jss_nss_PR_Close(JNIEnv *env, jclass clazz, jobject fd)
         return PR_FAILURE;
     }
 
-    return PR_Close(real_fd);
+    PRStatus ret = PR_Close(real_fd);
+    if (ret == PR_SUCCESS) {
+        JSS_clearPtrFromProxy(env, fd);
+    }
+
+    return ret;
 }
 
 JNIEXPORT int JNICALL

--- a/org/mozilla/jss/util/jssutil.h
+++ b/org/mozilla/jss/util/jssutil.h
@@ -125,6 +125,18 @@ JSS_getPtrFromProxy(JNIEnv *env, jobject nativeProxy, void **ptr);
 
 /***********************************************************************
 **
+** J S S _ c l e a r P t r F r o m P r o x y
+**
+** Given a NativeProxy, clear the value of the pointer stored in it. This
+** helps to ensure that a double free doesn't occur.
+**
+** Returns: PR_SUCCESS on success, PR_FAILURE if an exception was thrown.
+*/
+PRStatus
+JSS_clearPtrFromProxy(JNIEnv *env, jobject nativeProxy);
+
+/***********************************************************************
+**
 ** J S S _ g e t P t r F r o m P r o x y O w n e r
 **
 ** Given an object which contains a NativeProxy, extract the pointer


### PR DESCRIPTION
I thought about this while I was implementing SSLAlert handling, so I figured I'd attempt it here.

We extend the default NativeProxy implementation in three directions:

 - Make it `AutoCloseable`,
 - Add a `clear()` method which supports clearing the value of the
   pointer without calling `releaseNativeResources(...)`, and
 - Save a stack trace when assertions are enabled.

By implementing `AutoCloseable`, we enable the common Java pattern of
try-with-resources:

    try (NativeProxy item = ...) {
        ...
    }

and have the item automatically be closed (in our case, `finalized(...)`)
at the end of its life cycle. We've added additional logic to prevent
double-free bugs.

Additionally, by adding `clear(...)`, we both add protection from
double-free bugs and enable resource cleanup from native handlers that
removes entries in `NativeProxy`'s internal tracking.

Lastly, we save stack traces when assertions are enabled in the JVM and 
JSS is built in `DEBUG` mode (with `DEBUG` defined).


We enable its use on Buffers and PRFDProxys. The latter is an interesting case since NativeProxy still thinks these `PRFileDesc`'s leak on creation due to our use of `SSL.ImportFD(...)` (which subsumes the socket, meaning we don't have to close it, and it handles closing it for us internally). We could get around that by providing a single "Create PRFileDesc and import FD" method, but... 