### PR TITLE
Fix build on older CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ find_package(NSS REQUIRED)
 find_package(Java REQUIRED)
 find_package(JNI REQUIRED)
 
+# Shims for older CMake versions without useful features.
+include(Shims)
+
 # Since we found Java, include UseJava to provide the find_jar function.
 include(UseJava)
 

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -342,7 +342,7 @@ endmacro()
 macro(jss_config_symbols)
     list(APPEND CMAKE_REQUIRED_INCLUDES ${NSPR_INCLUDE_DIRS})
     list(APPEND CMAKE_REQUIRED_INCLUDES ${NSS_INCLUDE_DIRS})
-    list(JOIN JSS_C_FLAGS " " CMAKE_REQUIRED_FLAGS)
+    jss_list_join(JSS_C_FLAGS " " CMAKE_REQUIRED_FLAGS)
 
     check_symbol_exists("CKM_AES_CMAC" "nspr.h;nss.h;pkcs11t.h" HAVE_NSS_CMAC)
     if(NOT HAVE_NSS_CMAC)

--- a/cmake/Shims.cmake
+++ b/cmake/Shims.cmake
@@ -1,0 +1,15 @@
+# LIST(JOIN ...) was introduced in CMake verison 3.12
+macro(jss_list_join LIST_ SEPARATOR_ VAR_)
+    if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+        set("${VAR_}" "")
+        foreach(ELEMENT ${${LIST_}})
+            message(STATUS "ELEM: ${ELEMENT}")
+            set("${VAR_}" "${${VAR_}}${SEPARATOR_}${ELEMENT}")
+        endforeach()
+        string(LENGTH "${SEPARATOR_}" JSS_LIST_JOIN_SEPARATOR_LENGTH)
+        string(SUBSTRING "${${VAR_}}" ${JSS_LIST_JOIN_SEPARATOR_LENGTH} -1 "${VAR_}")
+    else()
+        list(JOIN ${LIST_} ${SEPARATOR_} ${VAR_})
+    endif()
+endmacro()
+


### PR DESCRIPTION
On CMake versions less than 3.12.0 (shipped July 17, 2018), the
`list(...)` helper lacks the `JOIN` subcommand. We use this for joining the
C compiler flags into `CMAKE_REQUIRED_FLAGS` for symbol detection.

This introduces a shim for older systems lacking these useful macros,
including RHEL 8.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`