### PR TITLE
Remove unnecessary assert in PK11MessageDigest.c

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11MessageDigest.c
+++ b/org/mozilla/jss/pkcs11/PK11MessageDigest.c
@@ -120,7 +120,6 @@ Java_org_mozilla_jss_pkcs11_PK11MessageDigest_update
 
     if (!JSS_RefByteArray(env, inbufBA, &bytes, &length) ||
             length < offset+len) {
-        ASSERT_OUTOFMEM(env);
         goto finish;
     }
 


### PR DESCRIPTION
This `ASSERT_OUTOFMEM(env)` is incorrect for two reasons:

 1. When `JSS_RefByteArray` detects a zero-length result, it returns
    false but doesn't throw an exception. It is up to the caller to
    handle that as they wish. In our case, we can safely skip the
    `PK11_DigestOp` call.
 2. When `length < offset+len` (and `JSS_RefByteArray` exits
    successfully), we won't have thrown an exception.

This only shows up in debug builds; release builds aren't affected.


This bug was detected by CI after merging the CMAC changes (#259).

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`