### PR TITLE
Introduce GlobalRefProxy

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -400,6 +400,7 @@ Java_org_mozilla_jss_pkcs11_PK11PrivKey_getPublicKey;
 Java_org_mozilla_jss_CryptoManager_importDERCertNative;
 Java_org_mozilla_jss_nss_SSL_AttachClientCertCallback;
 Java_org_mozilla_jss_CryptoManager_getJSSDebug;
+Java_org_mozilla_jss_util_GlobalRefProxy_releaseNativeResources;
     local:
         *;
 };

--- a/org/mozilla/jss/util/GlobalRefProxy.c
+++ b/org/mozilla/jss/util/GlobalRefProxy.c
@@ -1,0 +1,70 @@
+#include <nspr.h>
+#include <nss.h>
+#include <jni.h>
+
+#include "java_ids.h"
+#include "jssutil.h"
+
+jobject
+JSS_PR_wrapGlobalRef(JNIEnv *env, jobject *ref)
+{
+    jbyteArray pointer = NULL;
+    jclass proxyClass;
+    jmethodID constructor;
+    jobject refObj = NULL;
+
+    PR_ASSERT(env != NULL && ref != NULL && *ref != NULL);
+
+    /* Convert pointer to byte array. */
+    pointer = JSS_ptrToByteArray(env, *ref);
+
+    /* Lookup the class and constructor. */
+    proxyClass = (*env)->FindClass(env, GLOBAL_REF_PROXY_CLASS_NAME);
+    if (proxyClass == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+
+    constructor = (*env)->GetMethodID(env, proxyClass,
+                                      PLAIN_CONSTRUCTOR,
+                                      GLOBAL_REF_CONSTRUCTOR_SIG);
+    if (constructor == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+
+    /* Call the constructor. */
+    refObj = (*env)->NewObject(env, proxyClass, constructor, pointer);
+
+finish:
+    if (refObj == NULL && *ref != NULL) {
+        /* Something didn't work, so free resources. */
+        (*env)->DeleteGlobalRef(env, *ref);
+    }
+
+    *ref = NULL;
+
+    PR_ASSERT(refObj || (*env)->ExceptionOccurred(env));
+    return refObj;
+}
+
+PRStatus
+JSS_PR_getGlobalRef(JNIEnv *env, jobject ref_proxy, jobject *ref)
+{
+    return JSS_getPtrFromProxy(env, ref_proxy, (void**)ref);
+}
+
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_util_GlobalRefProxy_releaseNativeResources
+    (JNIEnv *env, jobject this)
+{
+    jobject ref;
+
+    PR_ASSERT(env != NULL && this != NULL);
+
+    if (JSS_PR_getGlobalRef(env, this, &ref) != PR_SUCCESS) {
+        return;
+    }
+
+    (*env)->DeleteGlobalRef(env, ref);
+}

--- a/org/mozilla/jss/util/GlobalRefProxy.h
+++ b/org/mozilla/jss/util/GlobalRefProxy.h
@@ -1,0 +1,9 @@
+#include <nspr.h>
+#include <nss.h>
+#include <jni.h>
+
+#pragma once
+
+jobject JSS_PR_wrapGlobalRef(JNIEnv *env, jobject *ref);
+
+PRStatus JSS_PR_getGlobalRef(JNIEnv *env, jobject ref_proxy, jobject *ref);

--- a/org/mozilla/jss/util/GlobalRefProxy.java
+++ b/org/mozilla/jss/util/GlobalRefProxy.java
@@ -1,0 +1,9 @@
+package org.mozilla.jss.util;
+
+public class GlobalRefProxy extends NativeProxy {
+    public GlobalRefProxy(byte[] pointer) {
+        super(pointer);
+    }
+
+    protected native void releaseNativeResources();
+}

--- a/org/mozilla/jss/util/java_ids.h
+++ b/org/mozilla/jss/util/java_ids.h
@@ -393,6 +393,7 @@ PR_BEGIN_EXTERN_C
 #define SSLFD_PROXY_CONSTRUCTOR_SIG "([B)V"
 #define SSLFD_PROXY_CLIENT_CERT_FIELD "clientCert"
 #define SSLFD_PROXY_CLIENT_CERT_SIG "Lorg/mozilla/jss/pkcs11/PK11Cert;"
+#define SSLFD_PROXY_EVENT_LIST_SIG "Ljava/util/ArrayList;"
 
 /*
  * SecurityStatusResult
@@ -405,6 +406,12 @@ PR_BEGIN_EXTERN_C
  */
 #define BUFFER_PROXY_CLASS_NAME "org/mozilla/jss/nss/BufferProxy"
 #define BUFFER_PROXY_CONSTRUCTOR_SIG "([B)V"
+
+/*
+ * GlobalRefProxy
+ */
+#define GLOBAL_REF_PROXY_CLASS_NAME "org/mozilla/jss/util/GlobalRefProxy"
+#define GLOBAL_REF_CONSTRUCTOR_SIG "([B)V"
 
 PR_END_EXTERN_C
 


### PR DESCRIPTION
Java JNI has the notion of a global reference to an object, instead of
the traditional local reference created by the JVM when calling any
JNI'd function. Since all global references have the same type (`jobject`)
and release handler (`(*env)->DeleteGlobalRef(...)`), it makes sense to
track these as a single JNI type.

This ensures that these resources are released, allowing the referenced
object to be garbage collected.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`