### PR TITLE
SSLAlertEvent enhancements

### DIFF
--- a/org/mozilla/jss/ssl/SSLAlertEvent.java
+++ b/org/mozilla/jss/ssl/SSLAlertEvent.java
@@ -6,6 +6,8 @@ package org.mozilla.jss.ssl;
 
 import java.util.EventObject;
 
+import org.mozilla.jss.nss.SSLFDProxy;
+
 public class SSLAlertEvent extends EventObject {
 
     private static final long serialVersionUID = 1L;
@@ -34,8 +36,30 @@ public class SSLAlertEvent extends EventObject {
         setDescription(description);
     }
 
+    public SSLAlertEvent(SSLFDProxy proxy) {
+        super(proxy);
+    }
+
+    public SSLAlertEvent(SSLFDProxy proxy, int level, int description) {
+        super(proxy);
+
+        setLevel(level);
+        setDescription(description);
+    }
+
+    public SSLAlertEvent(SSLFDProxy proxy, SSLAlertLevel level, SSLAlertDescription description) {
+        super(proxy);
+
+        setLevel(level);
+        setDescription(description);
+    }
+
     public SSLSocket getSocket() {
         return (SSLSocket)getSource();
+    }
+
+    public SSLFDProxy getFileDesc() {
+        return (SSLFDProxy)getSource();
     }
 
     public int getLevel() {
@@ -72,5 +96,9 @@ public class SSLAlertEvent extends EventObject {
     public void setDescription(SSLAlertDescription description) {
         this.descriptionEnum = description;
         this.description = description.getID();
+    }
+
+    public String toString() {
+        return this.levelEnum + ": " + this.descriptionEnum;
     }
 }

--- a/org/mozilla/jss/ssl/SSLAlertEvent.java
+++ b/org/mozilla/jss/ssl/SSLAlertEvent.java
@@ -13,8 +13,25 @@ public class SSLAlertEvent extends EventObject {
     int level;
     int description;
 
+    SSLAlertLevel levelEnum;
+    SSLAlertDescription descriptionEnum;
+
     public SSLAlertEvent(SSLSocket socket) {
         super(socket);
+    }
+
+    public SSLAlertEvent(SSLSocket socket, int level, int description) {
+        super(socket);
+
+        setLevel(level);
+        setDescription(description);
+    }
+
+    public SSLAlertEvent(SSLSocket socket, SSLAlertLevel level, SSLAlertDescription description) {
+        super(socket);
+
+        setLevel(level);
+        setDescription(description);
     }
 
     public SSLSocket getSocket() {
@@ -25,15 +42,35 @@ public class SSLAlertEvent extends EventObject {
         return level;
     }
 
+    public SSLAlertLevel getLevelEnum() {
+        return levelEnum;
+    }
+
     public void setLevel(int level) {
         this.level = level;
+        this.levelEnum = SSLAlertLevel.valueOf(level);
+    }
+
+    public void setLevel(SSLAlertLevel level) {
+        this.levelEnum = level;
+        this.level = level.getID();
     }
 
     public int getDescription() {
         return description;
     }
 
+    public SSLAlertDescription getDescriptionEnum() {
+        return descriptionEnum;
+    }
+
     public void setDescription(int description) {
         this.description = description;
+        this.descriptionEnum = SSLAlertDescription.valueOf(description);
+    }
+
+    public void setDescription(SSLAlertDescription description) {
+        this.descriptionEnum = description;
+        this.description = description.getID();
     }
 }

--- a/org/mozilla/jss/ssl/callbacks.c
+++ b/org/mozilla/jss/ssl/callbacks.c
@@ -301,7 +301,7 @@ JSSL_AlertReceivedCallback(const PRFileDesc *fd, void *arg, const SSLAlert *aler
     jint rc;
     JNIEnv *env;
     jclass socketClass, eventClass;
-    jmethodID eventConstructor, eventSetLevel, eventSetDescription;
+    jmethodID eventConstructor;
     jobject event;
     jmethodID fireEvent;
 
@@ -326,25 +326,11 @@ JSSL_AlertReceivedCallback(const PRFileDesc *fd, void *arg, const SSLAlert *aler
     eventClass = (*env)->FindClass(env, SSL_ALERT_EVENT_CLASS);
     PR_ASSERT(eventClass != NULL);
 
-    eventConstructor = (*env)->GetMethodID(env, eventClass, "<init>", "(L" SSLSOCKET_CLASS ";)V");
+    eventConstructor = (*env)->GetMethodID(env, eventClass, "<init>", "(L" SSLSOCKET_CLASS ";II)V");
     PR_ASSERT(eventConstructor != NULL);
 
-    event = (*env)->NewObject(env, eventClass, eventConstructor, socket->socketObject);
+    event = (*env)->NewObject(env, eventClass, eventConstructor, socket->socketObject, (int)alert->level, (int)alert->description);
     PR_ASSERT(event != NULL);
-
-    /* event.setLevel(level); */
-
-    eventSetLevel = (*env)->GetMethodID(env, eventClass, "setLevel", "(I)V");
-    PR_ASSERT(eventSetLevel != NULL);
-
-    (*env)->CallVoidMethod(env, event, eventSetLevel, (int)alert->level);
-
-    /* event.setDescription(description); */
-
-    eventSetDescription = (*env)->GetMethodID(env, eventClass, "setDescription", "(I)V");
-    PR_ASSERT(eventSetDescription != NULL);
-
-    (*env)->CallVoidMethod(env, event, eventSetDescription, alert->description);
 
     /* socket.fireAlertReceivedEvent(event); */
 


### PR DESCRIPTION
These three commits are various improvements we'd like for `SSLAlertEvent`. `SSLAlertEvent` is a subclass of [`java.util.EventObject`](https://docs.oracle.com/javase/8/docs/api/java/util/EventObject.html). 

 - A [common pattern](https://github.com/dogtagpki/pki/blob/master/base/server/src/org/dogtagpki/server/PKIClientSocketListener.java#L106-L109) in PKI is to enable the `SSLAlert` handler for a `SSLSocket`, and then read the parameters via their Enums instead of directly from their int values. I think we might as well store the Enums on the alert when we can. 
 - We simplify construction such that we only need one JNI call (the constructor) instead of three (constructor, `setLevel`, and `setDescription`).
 - We use the simplified constructor.
 - We also let the `SSLAlertEvent` store `SSLFDProxy` objects instead of just `SSLSocket` objects. We assume the caller knows which type of object they're getting the event from (because presumably, they created it).

Long term (#243), we'd like to unify it so that a new `SSLSocket` will use a `SSLFDProxy` under the covers. 