### PR TITLE
Support freeing SSLFDProxy resources

### DIFF
--- a/org/mozilla/jss/nss/PR.java
+++ b/org/mozilla/jss/nss/PR.java
@@ -73,6 +73,18 @@ public class PR {
     public static native int Close(PRFDProxy fd);
 
     /**
+     * Close an existing SSLFDProxy.
+     *
+     * See also: org.mozilla.jss.nss.PR.Close
+     *           org.mozilla.jss.nss.SSLFD.releaseNativeResources
+     */
+    public static int Close(SSLFDProxy fd) throws Exception {
+        int ret = PR.Close((PRFDProxy) fd);
+        fd.close();
+        return ret;
+    }
+
+    /**
      * Shutdown an existing PRFDProxy.
      * This is usually used with TCP modes.
      *

--- a/org/mozilla/jss/tests/TestRawSSL.java
+++ b/org/mozilla/jss/tests/TestRawSSL.java
@@ -9,7 +9,7 @@ import org.mozilla.jss.nss.SecurityStatusResult;
 import org.mozilla.jss.ssl.SSLCipher;
 
 public class TestRawSSL {
-    public static void TestSSLImportFD() {
+    public static void TestSSLImportFD() throws Exception {
         PRFDProxy fd = PR.NewTCPSocket();
         assert(fd != null);
 
@@ -78,7 +78,7 @@ public class TestRawSSL {
         assert(PR.Close(ssl_fd) == PR.SUCCESS);
     }
 
-    public static void TestSSLSetURL() {
+    public static void TestSSLSetURL() throws Exception {
         PRFDProxy fd = PR.NewTCPSocket();
         assert(fd != null);
 
@@ -90,7 +90,7 @@ public class TestRawSSL {
         assert(PR.Close(ssl_fd) == PR.SUCCESS);
     }
 
-    public static void TestSSLSecurityStatus() {
+    public static void TestSSLSecurityStatus() throws Exception {
         PRFDProxy fd = PR.NewTCPSocket();
         assert(fd != null);
 
@@ -103,7 +103,7 @@ public class TestRawSSL {
         assert(PR.Close(ssl_fd) == PR.SUCCESS);
     }
 
-    public static void TestSSLResetHandshake() {
+    public static void TestSSLResetHandshake() throws Exception {
         PRFDProxy fd = PR.NewTCPSocket();
         assert(fd != null);
 


### PR DESCRIPTION
`SSLFDProxies` might have additional resources associated with them
besides just the `PRFileDesc` pointer. This form of `PR.Close(...)` will
first close the underlying `PRFileDesc` and then call `fd.close()`
explicitly, to handle any other resources.

@edewata Does this generally look like a sane decision? SSL-wrapped `PRFileDesc`'s otherwise behave like  `PRFileDesc`'s, since they implement the `PRFileDesc` interface thingy; you'd mostly interact with their fd-facing portion with NSPR calls. Only the SSL-specific stuff (cipher types, callbacks, &c) are handled by NSS. We're looking to do something similar, except at a higher level. Since we can't give NSS data to hold (and have a callback process freeing that data when `PR_Close(...)` is called on the underlying socket), we have to attach it to `SSLFDProxy` and then have a mechanism for handling freeing it. That data is on the `SSLFDProxy` class and not on the underlying `PRFileDesc`, so there's no use-after-free bug. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`