### PR TITLE
Release v4.6.2

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -2,7 +2,7 @@ macro(jss_config)
     # Set the current JSS release number. Arguments are:
     #   MAJOR MINOR PATCH BETA
     # When BETA is zero, it isn't a beta release.
-    jss_config_version(4 6 1 0)
+    jss_config_version(4 6 2 0)
 
     # Configure output directories
     jss_config_outputs()

--- a/jss.spec
+++ b/jss.spec
@@ -6,7 +6,7 @@ Summary:        Java Security Services (JSS)
 URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
-Version:        4.6.1
+Version:        4.6.2
 Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
 # global         _phase -a1
 


### PR DESCRIPTION
This version of JSS has a security fix:

 - CVE-2019-14823: Fix root certificate validation when using Leaf and
   Chain OCSP mode

This version of JSS also has a few enhancements over v4.6.1:

 - Fixing JSS internal deprecation warnings by @emaldona
 - Fixing javadoc builds by @stanislavlevin
 - Introduce a new InitializationValue, installJSSProviderFirst, to
   support favoring other cryptographic providers.
 - Add support for CMAC as a Mac algorithm from JSSProvider; note that
   this requires JSS to be compiled with a NSS release which also
   supports CMAC (3.47+).
 - Various improvements to the Key APIs.

Thanks to everyone who contributed to this release!

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`