### PR TITLE
Release v4.5.4

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -2,7 +2,7 @@ macro(jss_config)
     # Set the current JSS release number. Arguments are:
     #   MAJOR MINOR PATCH BETA
     # When BETA is zero, it isn't a beta release.
-    jss_config_version(4 5 3 0)
+    jss_config_version(4 5 4 0)
 
     # Configure output directories
     jss_config_outputs()

--- a/jss.spec
+++ b/jss.spec
@@ -6,7 +6,7 @@ Summary:        Java Security Services (JSS)
 URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
-Version:        4.5.3
+Version:        4.5.4
 Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
 # global         _phase -a1
 


### PR DESCRIPTION
This version of JSS has a security fix:

 - CVE-2019-14823: Fix root certificate validation when using Leaf and
   Chain OCSP mode. Note that unlike the v4.6.x or v4.4.x series, the
   previous v4.5.3 release was not impacted.

This version of JSS also has a few enhancements over v4.5.3:

 - Backporting @Dessa's JUnit CMake typo fix
 - Adding HSM support for PKCS#11 AES KeyWrap/Padding (by @ladycfu)
 - OCSP checking for leaf and chain (by @jmagne)

Thanks to all who contributed to this release!

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`