### PR TITLE
Switch to suggesting default-jdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project has the following dependencies:
     - Minimum version: 3.30
     - A c and c++ compiler such as [gcc](ttps://gcc.gnu.org/)
     - [zlib](https://zlib.net/)
- - [OpenJDK 1.8.0](https://openjdk.java.net/)
+ - [OpenJDK 1.8.0 or newer](https://openjdk.java.net/)
  - [CMake](https://cmake.org/)
  - [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/)
  - [Apache Commons Codec](https://commons.apache.org/proper/commons-codec/)
@@ -45,7 +45,7 @@ To install these dependencies on Debian, execute the following:
 
     sudo apt-get install build-essential libcommons-codec-java \
                          libcommons-lang-java libnss3-dev libslf4j-java \
-                         openjdk-8-jdk pkg-config zlib1g-dev \
+                         default-jdk pkg-config zlib1g-dev \
                          libjaxb-api-java libnss3-tools cmake zip unzip \
                          junit4
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -8,7 +8,7 @@ This project has the following dependencies:
  - [NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS)
     - A c and c++ compiler such as [gcc](ttps://gcc.gnu.org/)
     - [zlib](https://zlib.net/)
- - [OpenJDK 1.8.0](http://openjdk.java.net/)
+ - [OpenJDK 1.8.0 or newer](http://openjdk.java.net/)
  - [CMake](https://cmake.org/)
  - [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/)
  - [Apache Commons Codec](https://commons.apache.org/proper/commons-codec/)
@@ -28,7 +28,7 @@ To install these dependencies on Debian, execute the following:
 
     sudo apt-get install build-essential libcommons-codec-java \
                          libcommons-lang-java libnss3-dev libslf4j-java \
-                         openjdk-8-jdk pkg-config zlib1g-dev \
+                         default-jdk pkg-config zlib1g-dev \
                          libjaxb-api-java cmake zip unzip
 
 ## Test Suite Dependencies:


### PR DESCRIPTION
With the advent of JDK 11+ being the default JDK in Debian testing,
we should stop suggesting that JDK 8 is the only supported JDK for JSS.
Since we are compatible with JDK 8+ and Debian provides a default-jdk
installation target, use that instead.

This change was suggested by @emaldona.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`