### PR TITLE
Fix sandbox builds of JSS

### DIFF
--- a/cmake/FindNSPR.cmake
+++ b/cmake/FindNSPR.cmake
@@ -88,26 +88,31 @@ else (NSPR_LIBRARIES AND NSPR_INCLUDE_DIRS)
     ${NSPR_INCLUDE_DIR}
   )
 
-  if (PLDS4_LIBRARY)
+  if(PLDS4_LIBRARY)
+    get_filename_component(PLDS4_LIBRARY "${PLDS4_LIBRARY}" DIRECTORY)
     set(NSPR_LIBRARIES
         ${NSPR_LIBRARIES}
         ${PLDS4_LIBRARY}
     )
-  endif (PLDS4_LIBRARY)
+  endif()
 
-  if (PLC4_LIBRARY)
+  if(PLC4_LIBRARY)
+    get_filename_component(PLC4_LIBRARY "${PLC4_LIBRARY}" DIRECTORY)
     set(NSPR_LIBRARIES
         ${NSPR_LIBRARIES}
         ${PLC4_LIBRARY}
     )
-  endif (PLC4_LIBRARY)
+  endif()
 
-  if (NSPR4_LIBRARY)
+  if(NSPR4_LIBRARY)
+    get_filename_component(NSPR4_LIBRARY "${NSPR4_LIBRARY}" DIRECTORY)
     set(NSPR_LIBRARIES
         ${NSPR_LIBRARIES}
         ${NSPR4_LIBRARY}
     )
-  endif (NSPR4_LIBRARY)
+  endif()
+
+  list(REMOVE_DUPLICATES NSPR_LIBRARIES)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(NSPR DEFAULT_MSG NSPR_LIBRARIES NSPR_INCLUDE_DIRS)

--- a/cmake/FindNSS.cmake
+++ b/cmake/FindNSS.cmake
@@ -99,33 +99,39 @@ else (NSS_LIBRARIES AND NSS_INCLUDE_DIRS)
     ${NSS_INCLUDE_DIR}
   )
 
-  if (SSL3_LIBRARY)
+  if(SSL3_LIBRARY)
+    get_filename_component(SSL3_LIBRARY "${SSL3_LIBRARY}" DIRECTORY)
     set(NSS_LIBRARIES
         ${NSS_LIBRARIES}
         ${SSL3_LIBRARY}
     )
-  endif (SSL3_LIBRARY)
+  endif()
 
-  if (SMIME3_LIBRARY)
+  if(SMIME3_LIBRARY)
+    get_filename_component(SMIME3_LIBRARY "${SMIME3_LIBRARY}" DIRECTORY)
     set(NSS_LIBRARIES
         ${NSS_LIBRARIES}
         ${SMIME3_LIBRARY}
     )
-  endif (SMIME3_LIBRARY)
+  endif()
 
-  if (NSS3_LIBRARY)
+  if(NSS3_LIBRARY)
+    get_filename_component(NSS3_LIBRARY "${NSS3_LIBRARY}" DIRECTORY)
     set(NSS_LIBRARIES
         ${NSS_LIBRARIES}
         ${NSS3_LIBRARY}
     )
-  endif (NSS3_LIBRARY)
+  endif()
 
-  if (NSSUTIL3_LIBRARY)
+  if(NSSUTIL3_LIBRARY)
+    get_filename_component(NSSUTIL3_LIBRARY "${NSSUTIL3_LIBRARY}" DIRECTORY)
     set(NSS_LIBRARIES
         ${NSS_LIBRARIES}
         ${NSSUTIL3_LIBRARY}
     )
-  endif (NSSUTIL3_LIBRARY)
+  endif()
+
+  list(REMOVE_DUPLICATES NSS_LIBRARIES)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(NSS DEFAULT_MSG NSS_LIBRARIES NSS_INCLUDE_DIRS)

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -436,19 +436,30 @@ macro(jss_test_exec)
         COMMAND ${TEST_EXEC_COMMAND}
     )
 
+    list(APPEND LD_LIBRARY ${NSS_LIBRARIES})
+    list(APPEND LD_LIBRARY ${NSPR_LIBRARIES})
+
     # If we are calling a java program, use the versioned library to ensure
     # that any new JNI calls are made visible.
     if(TEST_EXEC_LIBRARY AND (TEST_EXEC_LIBRARY STREQUAL "java"))
+        list(APPEND LD_LIBRARY "${CMAKE_BINARY_DIR}")
+        list(REMOVE_DUPLICATES LD_LIBRARY)
+        jss_list_join(LD_LIBRARY ":" LD_LIBRARY_PATH)
+
         set_tests_properties(
             "${TEST_EXEC_NAME}"
             PROPERTIES ENVIRONMENT
-            "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}"
+            "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
         )
     else()
+        list(APPEND LD_LIBRARY "${LIB_OUTPUT_DIR}")
+        list(REMOVE_DUPLICATES LD_LIBRARY)
+        jss_list_join(LD_LIBRARY ":" LD_LIBRARY_PATH)
+
         set_tests_properties(
             "${TEST_EXEC_NAME}"
             PROPERTIES ENVIRONMENT
-            "LD_LIBRARY_PATH=${LIB_OUTPUT_DIR}"
+            "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
         )
     endif()
     if(TEST_EXEC_DEPENDS)

--- a/tools/run_test.sh.in
+++ b/tools/run_test.sh.in
@@ -5,11 +5,11 @@
 # with command line arguments and ensures that the correct build artifacts
 # get used.
 
-export LD_LIBRARY_PATH="${CMAKE_BINARY_DIR}"
+export LD_LIBRARY_PATH="${NSS_LIBRARIES}:${CMAKE_BINARY_DIR}:${NSPR_LIBRARIES}"
 
 if [ "$1" == "--gdb" ]; then
     shift
-    gdb --args "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="${CMAKE_BINARY_DIR}" "$@"
+    gdb --args "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" "$@"
 else
-    "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="${CMAKE_BINARY_DIR}" "$@"
+    "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" "$@"
 fi


### PR DESCRIPTION
Previously, we wouldn't include `NSS_LIBRARIES` in `LD_LIBRARY_PATH`, in part because it wasn't always a directory -- sometimes it was a path to a the library.

This fixes sandbox builds when NSS isn't installed on the system, or when the sandboxed NSS otherwise rejects the system NSS's library versions.