### PR TITLE
Add support for HMAC/SHA-2 KeyGenerator

### DIFF
--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -191,6 +191,12 @@ public final class JSSProvider extends java.security.Provider {
            "org.mozilla.jss.provider.javax.crypto.JSSKeyGeneratorSpi$HmacSHA1");
         put("KeyGenerator.PBAHmacSHA1",
            "org.mozilla.jss.provider.javax.crypto.JSSKeyGeneratorSpi$PBAHmacSHA1");
+        put("KeyGenerator.HmacSHA256",
+           "org.mozilla.jss.provider.javax.crypto.JSSKeyGeneratorSpi$HmacSHA256");
+        put("KeyGenerator.HmacSHA384",
+           "org.mozilla.jss.provider.javax.crypto.JSSKeyGeneratorSpi$HmacSHA384");
+        put("KeyGenerator.HmacSHA512",
+           "org.mozilla.jss.provider.javax.crypto.JSSKeyGeneratorSpi$HmacSHA512");
 
         /////////////////////////////////////////////////////////////
         // SecretKeyFactory

--- a/org/mozilla/jss/provider/javax/crypto/JSSKeyGeneratorSpi.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSKeyGeneratorSpi.java
@@ -99,22 +99,29 @@ class JSSKeyGeneratorSpi extends javax.crypto.KeyGeneratorSpi {
             super(KeyGenAlgorithm.RC2);
         }
     }
-
-    /**
-     * @deprecated This class name is misleading. This algorithm
-     * is used for generating Password-Based Authentication keys
-     * for use with HmacSHA1. Use PBAHmacSHA1 instead.
-     */
-    @Deprecated
     public static class HmacSHA1 extends JSSKeyGeneratorSpi {
         public HmacSHA1() {
-            super(KeyGenAlgorithm.PBA_SHA1_HMAC);
+            super(KeyGenAlgorithm.SHA1_HMAC);
         }
     }
-
     public static class PBAHmacSHA1 extends JSSKeyGeneratorSpi {
         public PBAHmacSHA1() {
             super(KeyGenAlgorithm.PBA_SHA1_HMAC);
+        }
+    }
+    public static class HmacSHA256 extends JSSKeyGeneratorSpi {
+        public HmacSHA256() {
+            super(KeyGenAlgorithm.SHA256_HMAC);
+        }
+    }
+    public static class HmacSHA384 extends JSSKeyGeneratorSpi {
+        public HmacSHA384() {
+            super(KeyGenAlgorithm.SHA384_HMAC);
+        }
+    }
+    public static class HmacSHA512 extends JSSKeyGeneratorSpi {
+        public HmacSHA512() {
+            super(KeyGenAlgorithm.SHA512_HMAC);
         }
     }
 


### PR DESCRIPTION
`SecretKeyFactory` previously saw improvements for HMAC/SHA-2, but these
changes were missed for the `KeyGenerator` facility. Add the missing SHA-2
based algorithms in.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`