### PR TITLE
Modernize Exception Constructors

### DIFF
--- a/org/mozilla/jss/CRLImportException.java
+++ b/org/mozilla/jss/CRLImportException.java
@@ -9,7 +9,16 @@ package org.mozilla.jss;
 public class CRLImportException extends java.lang.Exception {
     private static final long serialVersionUID = 1L;
     public CRLImportException() {}
+
     public CRLImportException(String mesg) {
         super(mesg);
+    }
+
+    public CRLImportException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public CRLImportException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/org/mozilla/jss/CertDatabaseException.java
+++ b/org/mozilla/jss/CertDatabaseException.java
@@ -10,7 +10,16 @@ package org.mozilla.jss;
 public class CertDatabaseException extends java.lang.Exception {
     private static final long serialVersionUID = 1L;
     public CertDatabaseException() {}
+
     public CertDatabaseException(String mesg) {
         super(mesg);
+    }
+
+    public CertDatabaseException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public CertDatabaseException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/org/mozilla/jss/KeyDatabaseException.java
+++ b/org/mozilla/jss/KeyDatabaseException.java
@@ -10,7 +10,17 @@ package org.mozilla.jss;
 public class KeyDatabaseException extends java.lang.Exception {
     private static final long serialVersionUID = 1L;
     public KeyDatabaseException() {}
+
     public KeyDatabaseException(String mesg) {
         super(mesg);
     }
+
+    public KeyDatabaseException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public KeyDatabaseException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
+
 }

--- a/org/mozilla/jss/NoSuchTokenException.java
+++ b/org/mozilla/jss/NoSuchTokenException.java
@@ -9,7 +9,16 @@ package org.mozilla.jss;
 public class NoSuchTokenException extends java.lang.Exception {
     private static final long serialVersionUID = 1L;
     public NoSuchTokenException() {}
+
     public NoSuchTokenException(String mesg) {
         super(mesg);
+    }
+
+    public NoSuchTokenException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public NoSuchTokenException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/org/mozilla/jss/asn1/FieldNotPresentException.java
+++ b/org/mozilla/jss/asn1/FieldNotPresentException.java
@@ -15,7 +15,15 @@ public class FieldNotPresentException extends java.lang.Exception
         super();
     }
 
-    public FieldNotPresentException(String msg) {
-        super(msg);
+    public FieldNotPresentException(String mesg) {
+        super(mesg);
+    }
+
+    public FieldNotPresentException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public FieldNotPresentException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/org/mozilla/jss/crypto/AlreadyInitializedException.java
+++ b/org/mozilla/jss/crypto/AlreadyInitializedException.java
@@ -14,4 +14,12 @@ public class AlreadyInitializedException extends java.lang.Exception {
     public AlreadyInitializedException(String mesg) {
         super(mesg);
     }
+
+    public AlreadyInitializedException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public AlreadyInitializedException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/org/mozilla/jss/crypto/BadPaddingException.java
+++ b/org/mozilla/jss/crypto/BadPaddingException.java
@@ -12,7 +12,8 @@ public class BadPaddingException extends javax.crypto.BadPaddingException {
     public BadPaddingException() {
         super();
     }
-    public BadPaddingException(String msg) {
-        super(msg);
+
+    public BadPaddingException(String mesg) {
+        super(mesg);
     }
 }

--- a/org/mozilla/jss/crypto/InvalidDERException.java
+++ b/org/mozilla/jss/crypto/InvalidDERException.java
@@ -11,4 +11,9 @@ public class InvalidDERException extends Exception {
     private static final long serialVersionUID = 1L;
     public InvalidDERException() { super(); }
     public InvalidDERException(String mesg) { super(mesg); }
+    public InvalidDERException(String mesg, Throwable cause) { super(mesg, cause); }
+
+    public InvalidDERException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/org/mozilla/jss/crypto/InvalidKeyFormatException.java
+++ b/org/mozilla/jss/crypto/InvalidKeyFormatException.java
@@ -15,7 +15,16 @@ public class InvalidKeyFormatException
     public InvalidKeyFormatException() {
         super();
     }
+
     public InvalidKeyFormatException(String mesg) {
         super(mesg);
+    }
+
+    public InvalidKeyFormatException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public InvalidKeyFormatException(Throwable cause) {
+        super(cause);
     }
 }

--- a/org/mozilla/jss/crypto/KeyAlreadyImportedException.java
+++ b/org/mozilla/jss/crypto/KeyAlreadyImportedException.java
@@ -14,4 +14,12 @@ public class KeyAlreadyImportedException extends java.lang.Exception {
     public KeyAlreadyImportedException(String mesg) {
         super(mesg);
     }
+
+    public KeyAlreadyImportedException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public KeyAlreadyImportedException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/org/mozilla/jss/crypto/NoSuchItemOnTokenException.java
+++ b/org/mozilla/jss/crypto/NoSuchItemOnTokenException.java
@@ -12,11 +12,17 @@ public class NoSuchItemOnTokenException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
-    public
-    NoSuchItemOnTokenException() {}
+    public NoSuchItemOnTokenException() {}
 
-    public
-    NoSuchItemOnTokenException( String message ) {
-        super( message );
+    public NoSuchItemOnTokenException(String mesg) {
+        super(mesg);
+    }
+
+    public NoSuchItemOnTokenException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public NoSuchItemOnTokenException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/org/mozilla/jss/crypto/ObjectNotFoundException.java
+++ b/org/mozilla/jss/crypto/ObjectNotFoundException.java
@@ -11,4 +11,9 @@ public class ObjectNotFoundException extends Exception {
     private static final long serialVersionUID = 1L;
     public ObjectNotFoundException() { super(); }
     public ObjectNotFoundException(String mesg) { super(mesg); }
+    public ObjectNotFoundException(String mesg, Throwable cause) { super(mesg, cause); }
+
+    public ObjectNotFoundException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/org/mozilla/jss/crypto/PQGParamGenException.java
+++ b/org/mozilla/jss/crypto/PQGParamGenException.java
@@ -7,5 +7,10 @@ package org.mozilla.jss.crypto;
 public class PQGParamGenException extends Exception {
     private static final long serialVersionUID = 1L;
     public PQGParamGenException() {}
-    public PQGParamGenException(String msg) { super(msg); }
+    public PQGParamGenException(String mesg) { super(mesg); }
+    public PQGParamGenException(String mesg, Throwable cause) { super(mesg, cause); }
+
+    public PQGParamGenException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/org/mozilla/jss/crypto/TokenException.java
+++ b/org/mozilla/jss/crypto/TokenException.java
@@ -17,4 +17,12 @@ public class TokenException extends Exception {
     public TokenException(String mesg) {
         super(mesg);
     }
+
+    public TokenException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public TokenException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/org/mozilla/jss/crypto/TokenRuntimeException.java
+++ b/org/mozilla/jss/crypto/TokenRuntimeException.java
@@ -17,4 +17,12 @@ public class TokenRuntimeException extends RuntimeException {
     public TokenRuntimeException(String mesg) {
         super(mesg);
     }
+
+    public TokenRuntimeException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public TokenRuntimeException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/org/mozilla/jss/netscape/security/pkcs/EncodingException.java
+++ b/org/mozilla/jss/netscape/security/pkcs/EncodingException.java
@@ -27,7 +27,15 @@ public class EncodingException extends Exception {
         super();
     }
 
-    public EncodingException(String s) {
-        super(s);
+    public EncodingException(String mesg) {
+        super(mesg);
+    }
+
+    public EncodingException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public EncodingException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/org/mozilla/jss/netscape/security/pkcs/ParsingException.java
+++ b/org/mozilla/jss/netscape/security/pkcs/ParsingException.java
@@ -29,7 +29,15 @@ public class ParsingException extends IOException {
         super();
     }
 
-    public ParsingException(String s) {
-        super(s);
+    public ParsingException(String mesg) {
+        super(mesg);
+    }
+
+    public ParsingException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public ParsingException(Throwable cause) {
+        super(cause);
     }
 }

--- a/org/mozilla/jss/netscape/security/x509/GeneralNamesException.java
+++ b/org/mozilla/jss/netscape/security/x509/GeneralNamesException.java
@@ -47,4 +47,23 @@ public class GeneralNamesException extends GeneralSecurityException {
     public GeneralNamesException(String message) {
         super(message);
     }
+
+    /**
+     * Constructs the exception with the specified error message and cause.
+     *
+     * @param mesg the requisite error message.
+     * @param cause the requisite cause of this error.
+     */
+    public GeneralNamesException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    /**
+     * Constructs the exception with the specified cause.
+     *
+     * @param cause the requisite cause of this error.
+     */
+    public GeneralNamesException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/org/mozilla/jss/netscape/security/x509/InvalidIPAddressException.java
+++ b/org/mozilla/jss/netscape/security/x509/InvalidIPAddressException.java
@@ -30,4 +30,13 @@ public class InvalidIPAddressException extends RuntimeException {
     public InvalidIPAddressException(String ip) {
         super("Invalid IP Address '" + ip + "'");
     }
+
+    public InvalidIPAddressException(String ip, Throwable cause) {
+        super("Invalid IP Address '" + ip + "'", cause);
+    }
+
+    public InvalidIPAddressException(String ip, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super("Invalid IP Address '" + ip + "'", cause, enableSuppression, writableStackTrace);
+    }
+
 }

--- a/org/mozilla/jss/netscape/security/x509/InvalidNetmaskException.java
+++ b/org/mozilla/jss/netscape/security/x509/InvalidNetmaskException.java
@@ -20,8 +20,15 @@ package org.mozilla.jss.netscape.security.x509;
 
 public class InvalidNetmaskException extends RuntimeException {
 
-    public InvalidNetmaskException(String desc) {
-        super("Invalid netmask (" + desc + ")");
+    public InvalidNetmaskException(String netmask) {
+        super("Invalid netmask (" + netmask + ")");
     }
 
+    public InvalidNetmaskException(String netmask, Throwable cause) {
+        super("Invalid netmask (" + netmask + ")", cause);
+    }
+
+    public InvalidNetmaskException(String netmask, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super("Invalid netmask (" + netmask + ")", cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/org/mozilla/jss/netscape/security/x509/X509ExtensionException.java
+++ b/org/mozilla/jss/netscape/security/x509/X509ExtensionException.java
@@ -46,9 +46,31 @@ public class X509ExtensionException extends GeneralSecurityException {
      * message. A detail message is a String that describes this
      * particular exception.
      *
-     * @param message the detail message.
+     * @param mesg the detail message.
      */
-    public X509ExtensionException(String message) {
-        super(message);
+    public X509ExtensionException(String mesg) {
+        super(mesg);
+    }
+
+    /**
+     * Constructs the exception with the specified detail
+     * message and cause of this exception. A detail message is a
+     * String that describes this particular exception.
+     *
+     * @param mesg the detail message.
+     * @param cause the cause of this exception.
+     */
+    public X509ExtensionException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    /**
+     * Constructs the exception with the specified cause of
+     * this exception.
+     *
+     * @param cause the cause of this exception.
+     */
+    public X509ExtensionException(Throwable cause) {
+        super(cause);
     }
 }

--- a/org/mozilla/jss/pkcs11/PK11Exception.java
+++ b/org/mozilla/jss/pkcs11/PK11Exception.java
@@ -25,4 +25,8 @@ public class PK11Exception extends RuntimeException {
     public PK11Exception(String mesg, Throwable cause) {
         super(mesg, cause);
     }
+
+    public PK11Exception(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/org/mozilla/jss/util/AssertionException.java
+++ b/org/mozilla/jss/util/AssertionException.java
@@ -17,7 +17,15 @@ public class AssertionException extends RuntimeException {
 
     public AssertionException() {}
 
-    public AssertionException(String msg) {
-        super(msg);
+    public AssertionException(String mesg) {
+        super(mesg);
+    }
+
+    public AssertionException(String mesg, Throwable cause) {
+        super(mesg, cause);
+    }
+
+    public AssertionException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/org/mozilla/jss/util/IncorrectPasswordException.java
+++ b/org/mozilla/jss/util/IncorrectPasswordException.java
@@ -8,4 +8,9 @@ public class IncorrectPasswordException extends Exception {
     private static final long serialVersionUID = 1L;
     public IncorrectPasswordException() { super(); }
     public IncorrectPasswordException(String mesg) { super(mesg); }
+    public IncorrectPasswordException(String mesg, Throwable cause) { super(mesg, cause); }
+
+    public IncorrectPasswordException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/org/mozilla/jss/util/InvalidNicknameException.java
+++ b/org/mozilla/jss/util/InvalidNicknameException.java
@@ -8,4 +8,9 @@ public class InvalidNicknameException extends Exception {
     private static final long serialVersionUID = 1L;
     public InvalidNicknameException() { super(); }
     public InvalidNicknameException(String mesg) { super(mesg); }
+    public InvalidNicknameException(String mesg, Throwable cause) { super(mesg, cause); }
+
+    public InvalidNicknameException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/org/mozilla/jss/util/NotImplementedException.java
+++ b/org/mozilla/jss/util/NotImplementedException.java
@@ -11,4 +11,9 @@ public class NotImplementedException extends Exception {
     private static final long serialVersionUID = 1L;
     public NotImplementedException() { super(); }
     public NotImplementedException(String mesg) { super(mesg); }
+    public NotImplementedException(String mesg, Throwable cause) { super(mesg, cause); }
+
+    public NotImplementedException(String mesg, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(mesg, cause, enableSuppression, writableStackTrace);
+    }
 }


### PR DESCRIPTION
For all exceptions in JSS, this modernizes them to bring parity with the
exception they drive from. In particular, this adds the form

    Exception(String message, Throwable cause)

and

    Exception(Throwable cause)

and

    Exception(String mesg, Throwable cause,
              boolean enableSuppression,
              boolean writableStackTrace)

where missing.

Resolves: GitHub issue #264

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`