### PR TITLE
Migrate from ubuntu:latest to ubuntu:rolling

### DIFF
--- a/tools/Dockerfiles/ubuntu_jdk8
+++ b/tools/Dockerfiles/ubuntu_jdk8
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:rolling
 
 # Install generic dependencies to build jss
 RUN true \


### PR DESCRIPTION
This should address the issue in CI caused by the older NSS version:

    Exception in thread "main" java.lang.RuntimeException: Unknown key type: expected the public key of an EC key to be an PK11ECPublicKey; got: null
            at org.mozilla.jss.pkcs11.PK11ECPrivateKey.getParams(PK11ECPrivateKey.java:30)
            at org.mozilla.jss.tests.X509CertTest.testKeys(X509CertTest.java:158)
            at org.mozilla.jss.tests.X509CertTest.testEC(X509CertTest.java:88)
            at org.mozilla.jss.tests.X509CertTest.main(X509CertTest.java:75)

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`