### PR TITLE
Support CK_ prefixed PKCS#11 constants

### DIFF
--- a/org/mozilla/jss/pkcs11/PKCS11Constants.java
+++ b/org/mozilla/jss/pkcs11/PKCS11Constants.java
@@ -46,6 +46,48 @@ public interface PKCS11Constants {
      *
      * Source file: /usr/include/nss3/pkcs11t.h
      */
+    public static final long CK_TRUE = 0x00000001L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11t.h
+     */
+    public static final long CK_FALSE = 0x00000000L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11t.h
+     */
+    public static final long CK_NULL_PTR = 0x00000000L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11t.h
+     */
+    public static final long CK_INVALID_SESSION = 0x00000000L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11t.h
+     */
+    public static final long CK_EFFECTIVELY_INFINITE = 0x00000000L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11t.h
+     */
+    public static final long CK_INVALID_HANDLE = 0x00000000L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11t.h
+     */
     public static final long CKN_SURRENDER = 0x00000000L;
 
     /**


### PR DESCRIPTION
PKCS#11 includes several constants with the `CK_` prefix, including
`CK_TRUE`, `CK_FALSE`, `CK_INVALID_HANDLE`, and others. With PKCS#11 v3.0 in
draft state, this namespace also includes various SP800-108 (KBKDF)
specific constants. We need a blacklist to handle certain function
pointer macros, but otherwise import all `CK_` constants that we can.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`