### PR TITLE
Move javac command to file lists

### DIFF
--- a/cmake/JSSCommon.cmake
+++ b/cmake/JSSCommon.cmake
@@ -37,6 +37,17 @@ macro(jss_build_globs)
         endif()
     endforeach()
 
+    # Write the Java sources to a file to reduce the size of the javac
+    # command line.
+    list(SORT JAVA_SOURCES)
+    list(SORT JAVA_TEST_SOURCES)
+    jss_list_join(JAVA_SOURCES "\n" JAVA_SOURCES_CONTENTS)
+    jss_list_join(JAVA_TEST_SOURCES "\n" JAVA_TEST_SOURCES_CONTENTS)
+
+    file(WRITE "${JAVA_SOURCES_FILE}" "${JAVA_SOURCES_CONTENTS}")
+    file(WRITE "${JAVA_TEST_SOURCES_FILE}" "${JAVA_TEST_SOURCES_CONTENTS}")
+
+
     file(GLOB_RECURSE _C_HEADERS org/*.h)
     foreach(_C_HEADER ${_C_HEADERS})
         if(${_C_HEADER} MATCHES "mozilla/jss/tests/")
@@ -76,14 +87,14 @@ macro(jss_build_java)
     #   https://gitlab.kitware.com/cmake/community/wikis/FAQ#how-can-i-add-a-dependency-to-a-source-file-which-is-generated-in-a-subdirectory
     add_custom_command(
         OUTPUT "${JNI_OUTPUTS}"
-        COMMAND ${Java_JAVAC_EXECUTABLE} ${JSS_JAVAC_FLAGS} -d ${CLASSES_OUTPUT_DIR} -h ${JNI_OUTPUT_DIR} ${JAVA_SOURCES}
+        COMMAND ${Java_JAVAC_EXECUTABLE} ${JSS_JAVAC_FLAGS} -d ${CLASSES_OUTPUT_DIR} -h ${JNI_OUTPUT_DIR} @${JAVA_SOURCES_FILE}
         COMMAND touch "${JNI_OUTPUTS}"
         DEPENDS ${JAVA_SOURCES}
     )
 
     add_custom_command(
         OUTPUT "${TESTS_JNI_OUTPUTS}"
-        COMMAND ${Java_JAVAC_EXECUTABLE} ${JSS_TEST_JAVAC_FLAGS} -d ${TESTS_CLASSES_OUTPUT_DIR} -h ${TESTS_JNI_OUTPUT_DIR} ${JAVA_TEST_SOURCES}
+        COMMAND ${Java_JAVAC_EXECUTABLE} ${JSS_TEST_JAVAC_FLAGS} -d ${TESTS_CLASSES_OUTPUT_DIR} -h ${TESTS_JNI_OUTPUT_DIR} @${JAVA_TEST_SOURCES_FILE}
         COMMAND touch "${TESTS_JNI_OUTPUTS}"
         DEPENDS ${JAVA_TEST_SOURCES}
     )

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -65,6 +65,8 @@ macro(jss_config_outputs)
 
     # This folder is for pseudo-locations for CMake targets
     set(TARGETS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/.targets")
+    set(JAVA_SOURCES_FILE "${TARGETS_OUTPUT_DIR}/java.sources")
+    set(JAVA_TEST_SOURCES_FILE "${TARGETS_OUTPUT_DIR}/java-test.sources")
 
     # These folders are for the NSS DBs created during testing
     set(RESULTS_DATA_OUTPUT_DIR "${CMAKE_BINARY_DIR}/results/data")


### PR DESCRIPTION
`javac` supports parsing options from a file using the `@/path/to/arguments`
syntax. This lets us pass all of our sources to `javac` in a single file
(containing all of the Java files we wish to build in this pass) instead
of passing them individually on the command line. This reduces the size
of the output significantly when there's an error in the build.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`