### PR TITLE
Allow `PK11KeyPairGenerator` use of `RSAKeyGenParameterSpec`

### DIFF
--- a/org/mozilla/jss/crypto/RSAParameterSpec.java
+++ b/org/mozilla/jss/crypto/RSAParameterSpec.java
@@ -4,12 +4,13 @@
 package org.mozilla.jss.crypto;
 
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.RSAKeyGenParameterSpec;
 import java.math.BigInteger;
 
 /**
  * This class specifies the parameters used for generating an RSA key pair.
  */
-public class RSAParameterSpec implements AlgorithmParameterSpec {
+public class RSAParameterSpec extends RSAKeyGenParameterSpec {
 
     /**
      * Creates a new RSAParameterSpec with the specified parameter values.
@@ -18,20 +19,11 @@ public class RSAParameterSpec implements AlgorithmParameterSpec {
      *      are 3, 17, and 65537.  65537 is recommended.
      */
     public RSAParameterSpec(int keySize, BigInteger publicExponent) {
-        this.keySize = keySize;
-        this.publicExponent = publicExponent;
+        super(keySize, publicExponent);
     }
 
     /**
      * Returns the size of the modulus in bits.
      */
-    public int getKeySize() { return keySize; }
-
-    /**
-     * Returns the public exponent <i>e</i>.
-     */
-    public BigInteger getPublicExponent() { return publicExponent; }
-
-    private int keySize;
-    private BigInteger publicExponent;
+    public int getKeySize() { return getKeysize(); }
 }

--- a/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.java
+++ b/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.java
@@ -14,6 +14,7 @@ import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.DSAParameterSpec;
 import java.security.spec.ECGenParameterSpec;
+import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Hashtable;
 
 import org.mozilla.jss.asn1.ASN1Util;
@@ -417,13 +418,12 @@ public final class PK11KeyPairGenerator
         }
 
         if(algorithm == KeyPairAlgorithm.RSA) {
-            if(! (params instanceof RSAParameterSpec) ) {
+            if (!(params instanceof RSAKeyGenParameterSpec)) {
                 throw new InvalidAlgorithmParameterException();
             }
 
             // Security library stores public exponent in an unsigned long
-            if( ((RSAParameterSpec)params).getPublicExponent().bitLength()
-                                                                        > 31) {
+            if (((RSAKeyGenParameterSpec)params).getPublicExponent().bitLength() > 31) {
                 throw new InvalidAlgorithmParameterException(
                         "RSA Public Exponent must fit in 31 or fewer bits.");
             }
@@ -468,10 +468,10 @@ public final class PK11KeyPairGenerator
     {
         if(algorithm == KeyPairAlgorithm.RSA) {
             if(params != null) {
-                RSAParameterSpec rsaparams = (RSAParameterSpec)params;
+                RSAKeyGenParameterSpec rsaparams = (RSAKeyGenParameterSpec)params;
                 return generateRSAKeyPairWithOpFlags(
                                     token,
-                                    rsaparams.getKeySize(),
+                                    rsaparams.getKeysize(),
                                     rsaparams.getPublicExponent().longValue(),
                                     temporaryPairMode,
                                     sensitivePairMode,


### PR DESCRIPTION
Java provides the `java.security.spec.RSAKeyGenParameterSpec` that is the
same as our `RSAParameterSpec`, sans casing on one function call. Update
`RSAParameterSpec` to extend `RSAKeyGenParameterSpec` for backwards
compatibility and let `PK11KeyPairGenerator` use `RSAKeyGenParameterSpec`
instead.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

--- 

This gets tested through the existing test cases, so I think it should be fine. Also note that PKI doesn't actually use this class. Go figure. 