### PR TITLE
Add Fedora 31 Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ stages:
   - extra
 
 env:
-  - BASE_IMAGE="fedora_29"
   - BASE_IMAGE="fedora_30"
+  - BASE_IMAGE="fedora_31"
 
 script:
   - bash tools/run_container.sh "$BASE_IMAGE"

--- a/tools/Dockerfiles/fedora_27
+++ b/tools/Dockerfiles/fedora_27
@@ -4,7 +4,7 @@ FROM fedora:27
 RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core gcc make rpm-build \
-        && dnf copr -y enable ${JSS_4_5_REPO:-@pki/10.6} \
+        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/master} \
         && dnf build-dep -y jss \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \

--- a/tools/Dockerfiles/fedora_28
+++ b/tools/Dockerfiles/fedora_28
@@ -4,7 +4,7 @@ FROM fedora:28
 RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core gcc make rpm-build \
-        && dnf copr -y enable ${JSS_4_5_REPO:-@pki/10.6} \
+        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/master} \
         && dnf build-dep -y jss \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \

--- a/tools/Dockerfiles/fedora_29
+++ b/tools/Dockerfiles/fedora_29
@@ -4,7 +4,7 @@ FROM fedora:29
 RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core gcc make rpm-build \
-        && dnf copr -y enable ${JSS_4_5_REPO:-@pki/10.6} \
+        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/master} \
         && dnf build-dep -y jss \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \

--- a/tools/Dockerfiles/fedora_30
+++ b/tools/Dockerfiles/fedora_30
@@ -4,7 +4,7 @@ FROM fedora:30
 RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core gcc make rpm-build \
-        && dnf copr -y enable ${JSS_4_5_REPO:-@pki/10.6} \
+        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/master} \
         && dnf build-dep -y jss \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \

--- a/tools/Dockerfiles/fedora_31
+++ b/tools/Dockerfiles/fedora_31
@@ -4,7 +4,7 @@ FROM fedora:31
 RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core gcc make rpm-build \
-        && dnf copr -y enable ${JSS_4_5_REPO:-@pki/10.6} \
+        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/master} \
         && dnf build-dep -y jss \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \

--- a/tools/Dockerfiles/fedora_31
+++ b/tools/Dockerfiles/fedora_31
@@ -1,0 +1,30 @@
+FROM fedora:31
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+        && dnf copr -y enable ${JSS_4_5_REPO:-@pki/10.6} \
+        && dnf build-dep -y jss \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Install dependencies from the spec file in case they've changed
+# since the last release on this platform.
+RUN true \
+        && dnf build-dep -y --spec /home/sandbox/jss/jss.spec \
+        && true
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && bash ./build.sh --with-timestamp --with-commit-id rpm \
+        && dnf install -y /root/build/jss/RPMS/*.rpm \
+        && true


### PR DESCRIPTION
Remove Fedora 29 image and introduce Fedora 31 now that Fedora 29 is end of life.

Also migrates to using the correct COPR repo, though this should be unnecessary except for pulling more recent build dependencies. 