### PR TITLE
Drop Apache Commons Codec Dependency

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,7 +5,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="/usr/share/java/slf4j/slf4j-api.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/commons-lang.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/commons-codec.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/junit.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/hamcrest/core.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/slf4j/slf4j-simple.jar"/>

--- a/README.md
+++ b/README.md
@@ -29,23 +29,20 @@ This project has the following dependencies:
  - [OpenJDK 1.8.0 or newer](https://openjdk.java.net/)
  - [CMake](https://cmake.org/)
  - [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/)
- - [Apache Commons Codec](https://commons.apache.org/proper/commons-codec/)
  - [JavaEE JAXB](https://github.com/eclipse-ee4j/jaxb-ri)
  - [SLF4J](https://www.slf4j.org/)
  - [JUnit 4](https://junit.org/junit4/)
 
 To install these dependencies on Fedora, execute the following:
 
-    sudo dnf install apache-commons-codec apache-commons-lang gcc-c++ \
-                     java-devel jpackage-utils slf4j zlib-devel \
-                     glassfish-jaxb-api nss-tools nss-devel cmake \
-                     junit
+    sudo dnf install apache-commons-lang gcc-c++ java-devel jpackage-utils \
+                     slf4j zlib-devel glassfish-jaxb-api nss-tools nss-devel \
+                     cmake junit
 
 To install these dependencies on Debian, execute the following:
 
-    sudo apt-get install build-essential libcommons-codec-java \
-                         libcommons-lang-java libnss3-dev libslf4j-java \
-                         default-jdk pkg-config zlib1g-dev \
+    sudo apt-get install build-essential libcommons-lang-java libnss3-dev \
+                         libslf4j-java default-jdk pkg-config zlib1g-dev \
                          libjaxb-api-java libnss3-tools cmake zip unzip \
                          junit4
 

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -204,10 +204,6 @@ macro(jss_config_java)
         NAMES api slf4j/api slf4j-api
     )
     find_jar(
-        CODEC_JAR
-        NAMES apache-commons-codec commons-codec
-    )
-    find_jar(
         LANG_JAR
         NAMES apache-commons-lang commons-lang
     )
@@ -233,10 +229,6 @@ macro(jss_config_java)
         message(FATAL_ERROR "Required dependency sfl4j-api.jar not found by find_jar!")
     endif()
 
-    if(CODEC_JAR STREQUAL "CODEC_JAR-NOTFOUND")
-        message(FATAL_ERROR "Required dependency apache-commons-codec.jar not found by find_jar!")
-    endif()
-
     if(LANG_JAR STREQUAL "LANG_JAR-NOTFOUND")
         message(FATAL_ERROR "Required dependency apache-commons-lang.jar not found by find_jar!")
     endif()
@@ -258,7 +250,7 @@ macro(jss_config_java)
     endif()
 
     # Set class paths
-    set(JAVAC_CLASSPATH "${SLF4J_API_JAR}:${CODEC_JAR}:${LANG_JAR}:${JAXB_JAR}")
+    set(JAVAC_CLASSPATH "${SLF4J_API_JAR}:${LANG_JAR}:${JAXB_JAR}")
     set(TEST_CLASSPATH "${JSS_JAR_PATH}:${JSS_TESTS_JAR_PATH}:${JAVAC_CLASSPATH}:${SLF4J_JDK14_JAR}:${JUNIT4_JAR}:${HAMCREST_JAR}")
 
     message(STATUS "javac classpath: ${JAVAC_CLASSPATH}")

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -11,7 +11,6 @@ This project has the following dependencies:
  - [OpenJDK 1.8.0 or newer](http://openjdk.java.net/)
  - [CMake](https://cmake.org/)
  - [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/)
- - [Apache Commons Codec](https://commons.apache.org/proper/commons-codec/)
  - [JavaEE JAXB](https://github.com/eclipse-ee4j/jaxb-ri)
  - [SLF4J](https://www.slf4j.org/)
 
@@ -20,16 +19,16 @@ reproducible builds.
 
 To install these dependencies on Fedora, execute the following:
 
-    sudo dnf install apache-commons-codec apache-commons-lang gcc-c++ \
-                     java-devel jpackage-utils slf4j zlib-devel \
-                     glassfish-jaxb-api cmake
+    sudo dnf install apache-commons-lang gcc-c++ java-devel jpackage-utils \
+                     slf4j zlib-devel glassfish-jaxb-api nss-tools nss-devel \
+                     cmake junit
 
 To install these dependencies on Debian, execute the following:
 
-    sudo apt-get install build-essential libcommons-codec-java \
-                         libcommons-lang-java libnss3-dev libslf4j-java \
-                         default-jdk pkg-config zlib1g-dev \
-                         libjaxb-api-java cmake zip unzip
+    sudo apt-get install build-essential libcommons-lang-java libnss3-dev \
+                         libslf4j-java default-jdk pkg-config zlib1g-dev \
+                         libjaxb-api-java libnss3-tools cmake zip unzip \
+                         junit4
 
 ## Test Suite Dependencies:
 
@@ -56,7 +55,6 @@ At run time, the following JARs are required to be specified on the
 
  - `jss4.jar`
  - `slf4j-api.jar`
- - `apache-commons-codec.jar`
  - `apache-commons-lang.jar`
  - `jaxb-api.jar`
 

--- a/docs/using_jss.md
+++ b/docs/using_jss.md
@@ -18,8 +18,6 @@ following dependencies are available in your `CLASSPATH`:
    `/usr/share/java/slf4j/slf4j-api.jar`.
  - `apache-commons-lang.jar` -- provided by the `apache-commons-lang` package
    and installed to `/usr/share/java/apache-commons-lang.jar`.
- - `apache-commons-codec.jar` -- provided by the `apache-commons-codec`
-   package and installed to `/usr/share/java/apache-commons-codec.jar`.
  - `jaxb-api.jar` -- provided by the `glassfish-jaxb-api` package
    and installed to `/usr/share/java/jaxb-api.jar`.
 

--- a/jss.spec
+++ b/jss.spec
@@ -49,7 +49,6 @@ BuildRequires:  glassfish-jaxb-api
 BuildRequires:  slf4j-jdk14
 %endif
 BuildRequires:  apache-commons-lang
-BuildRequires:  apache-commons-codec
 
 BuildRequires:  junit
 
@@ -64,7 +63,6 @@ Requires:       glassfish-jaxb-api
 Requires:       slf4j-jdk14
 %endif
 Requires:       apache-commons-lang
-Requires:       apache-commons-codec
 
 Conflicts:      ldapjdk < 4.20
 Conflicts:      idm-console-framework < 1.2

--- a/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.ArrayList;
 
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang.StringUtils;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.asn1.ANY;
@@ -68,6 +67,8 @@ import org.slf4j.LoggerFactory;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 import javax.naming.InvalidNameException;
+
+import org.mozilla.jss.netscape.security.util.Utils;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
 public class PKCS12Util {
@@ -214,7 +215,7 @@ public class PKCS12Util {
             SEQUENCE encSafeContents) throws Exception {
 
         byte[] keyID = keyInfo.getID();
-        logger.debug(" - Key ID: " + Hex.encodeHexString(keyID));
+        logger.debug(" - Key ID: " + Utils.HexEncode(keyID));
 
         ASN1Value content;
 
@@ -295,7 +296,7 @@ public class PKCS12Util {
             SEQUENCE safeContents) throws Exception {
 
         byte[] id = certInfo.getID();
-        logger.debug(" - Certificate ID: " + Hex.encodeHexString(id));
+        logger.debug(" - Certificate ID: " + Utils.HexEncode(id));
 
         X509CertImpl cert = certInfo.getCert();
         ASN1Value certAsn1 = new OCTET_STRING(cert.getEncoded());
@@ -380,7 +381,7 @@ public class PKCS12Util {
 
         byte[] keyID = certInfo.getKeyID();
         if (keyID != null) {
-            logger.debug("   Key ID: " + Hex.encodeHexString(keyID));
+            logger.debug("   Key ID: " + Utils.HexEncode(keyID));
 
             SEQUENCE localKeyAttr = new SEQUENCE();
             localKeyAttr.addElement(SafeBag.LOCAL_KEY_ID);
@@ -463,7 +464,7 @@ public class PKCS12Util {
         pkcs12.addCertInfo(certInfo, true);
 
         byte[] id = certInfo.getID();
-        logger.debug(" - Certificate ID: " + Hex.encodeHexString(id));
+        logger.debug(" - Certificate ID: " + Utils.HexEncode(id));
         logger.debug("   Friendly name: " + certInfo.getFriendlyName());
         logger.debug("   Trust flags: " + certInfo.getTrustFlags());
 
@@ -478,7 +479,7 @@ public class PKCS12Util {
 
                 byte[] keyID = keyInfo.getID();
                 certInfo.setKeyID(keyID);
-                logger.debug("   Key ID: " + Hex.encodeHexString(keyID));
+                logger.debug("   Key ID: " + Utils.HexEncode(keyID));
 
             } catch (ObjectNotFoundException e) {
                 logger.debug("Certificate has no private key");
@@ -498,7 +499,7 @@ public class PKCS12Util {
                 pkcs12.addCertInfo(caCertInfo, false);
 
                 byte[] caCertID = caCertInfo.getID();
-                logger.debug("   - Certificate ID: " + Hex.encodeHexString(caCertID));
+                logger.debug("   - Certificate ID: " + Utils.HexEncode(caCertID));
                 logger.debug("     Friendly name: " + caCertInfo.getFriendlyName());
                 logger.debug("     Trust flags: " + caCertInfo.getTrustFlags());
             }
@@ -690,7 +691,7 @@ public class PKCS12Util {
         // generate cert ID from SHA-1 hash of cert data
         byte[] id = SafeBag.getLocalKeyIDFromCert(x509cert);
         certInfo.setID(id);
-        logger.debug("   Certificate ID: " + Hex.encodeHexString(id));
+        logger.debug("   Certificate ID: " + Utils.HexEncode(id));
 
         X509CertImpl cert = new X509CertImpl(x509cert);
         certInfo.setCert(cert);
@@ -726,7 +727,7 @@ public class PKCS12Util {
 
                 byte[] keyID = keyIdAsn1.toByteArray();
                 certInfo.setKeyID(keyID);
-                logger.debug("   Key ID: " + Hex.encodeHexString(keyID));
+                logger.debug("   Key ID: " + Utils.HexEncode(keyID));
 
             } else if (oid.equals(PKCS12.CERT_TRUST_FLAGS_OID) && trustFlagsEnabled) {
 

--- a/org/mozilla/jss/netscape/security/pkcs/PKCS7.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS7.java
@@ -31,9 +31,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Vector;
-
-import org.apache.commons.codec.binary.Base64;
 
 import org.mozilla.jss.netscape.security.util.Utils;
 import org.mozilla.jss.netscape.security.util.BigInt;
@@ -167,7 +166,7 @@ public class PKCS7 {
             }
         }
 
-        byte[] bytes = Base64.decodeBase64(sb.toString());
+        byte[] bytes = Base64.getDecoder().decode(sb.toString());
         parse(new DerInputStream(bytes));
     }
 

--- a/org/mozilla/jss/netscape/security/util/Utils.java
+++ b/org/mozilla/jss/netscape/security/util/Utils.java
@@ -32,11 +32,10 @@ import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
+import java.util.Base64;
 import java.util.Date;
 import java.util.StringTokenizer;
 import java.util.Vector;
-
-import org.apache.commons.codec.binary.Base64;
 
 public class Utils {
     /**
@@ -374,7 +373,7 @@ public class Utils {
      * @return base-64 encoded data
      */
     public static String base64encodeMultiLine(byte[] bytes) {
-        return new Base64(64).encodeToString(bytes);
+        return Base64.getMimeEncoder().encodeToString(bytes);
     }
 
 
@@ -386,7 +385,7 @@ public class Utils {
      * @return base-64 encoded data
      */
     public static String base64encodeSingleLine(byte[] bytes) {
-        return new Base64().encodeToString(bytes);
+        return Base64.getEncoder().encodeToString(bytes);
     }
 
     /**
@@ -396,7 +395,7 @@ public class Utils {
      * @return byte array
      */
     public static byte[] base64decode(String string) {
-        return Base64.decodeBase64(string);
+        return Base64.getDecoder().decode(string);
     }
 
     /**

--- a/org/mozilla/jss/tests/ChainSortingTest.java
+++ b/org/mozilla/jss/tests/ChainSortingTest.java
@@ -1,8 +1,8 @@
 package org.mozilla.jss.tests;
 
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.jss.netscape.security.util.Cert;
@@ -23,7 +23,7 @@ public class ChainSortingTest {
 
         // Subject DN: CN=Root CA Signing Certificate, O=EXAMPLE
         // Issuer DN: CN=Root CA Signing Certificate, O=EXAMPLE
-        rootCA = new X509CertImpl(Base64.decodeBase64(
+        rootCA = new X509CertImpl(Base64.getDecoder().decode(
             "MIIDRjCCAi6gAwIBAgIJAMHiDXjnZ1J6MA0GCSqGSIb3DQEBCwUAMDgxEDAOBgNV" +
             "BAoMB0VYQU1QTEUxJDAiBgNVBAMMG1Jvb3QgQ0EgU2lnbmluZyBDZXJ0aWZpY2F0" +
             "ZTAeFw0xOTAzMDUxNzQzMjFaFw0yMDAzMDQxNzQzMjFaMDgxEDAOBgNVBAoMB0VY" +
@@ -46,7 +46,7 @@ public class ChainSortingTest {
 
         // Subject DN: CN=Subordinate CA Signing Certificate, O=EXAMPLE
         // Issuer DN: CN=Root CA Signing Certificate, O=EXAMPLE
-        subCA = new X509CertImpl(Base64.decodeBase64(
+        subCA = new X509CertImpl(Base64.getDecoder().decode(
             "MIIC8zCCAdsCCQCPJrl0/W/nMTANBgkqhkiG9w0BAQsFADA4MRAwDgYDVQQKDAdF" +
             "WEFNUExFMSQwIgYDVQQDDBtSb290IENBIFNpZ25pbmcgQ2VydGlmaWNhdGUwHhcN" +
             "MTkwMzA1MTg1MzMzWhcNMjAwMzA0MTg1MzMzWjA/MRAwDgYDVQQKDAdFWEFNUExF" +
@@ -67,7 +67,7 @@ public class ChainSortingTest {
 
         // Subject DN: UID=admin, O=EXAMPLE
         // Issuer DN: CN=Subordinate CA Signing Certificate, O=EXAMPLE
-        admin = new X509CertImpl(Base64.decodeBase64(
+        admin = new X509CertImpl(Base64.getDecoder().decode(
             "MIIC5DCCAcwCCQCh59LykL9CDTANBgkqhkiG9w0BAQsFADA/MRAwDgYDVQQKDAdF" +
             "WEFNUExFMSswKQYDVQQDDCJTdWJvcmRpbmF0ZSBDQSBTaWduaW5nIENlcnRpZmlj" +
             "YXRlMB4XDTE5MDMwNTIwMDQxNloXDTIwMDMwNDIwMDQxNlowKTEQMA4GA1UECgwH" +
@@ -88,7 +88,7 @@ public class ChainSortingTest {
 
         // Subject DN: UID=agent, O=EXAMPLE
         // Issuer DN: CN=Subordinate CA Signing Certificate, O=EXAMPLE
-        agent = new X509CertImpl(Base64.decodeBase64(
+        agent = new X509CertImpl(Base64.getDecoder().decode(
             "MIIC5DCCAcwCCQCh59LykL9CDjANBgkqhkiG9w0BAQsFADA/MRAwDgYDVQQKDAdF" +
             "WEFNUExFMSswKQYDVQQDDCJTdWJvcmRpbmF0ZSBDQSBTaWduaW5nIENlcnRpZmlj" +
             "YXRlMB4XDTE5MDMwNTIwMzU1NVoXDTIwMDMwNDIwMzU1NVowKTEQMA4GA1UECgwH" +

--- a/org/mozilla/jss/tests/X509CertTest.java
+++ b/org/mozilla/jss/tests/X509CertTest.java
@@ -14,6 +14,7 @@ import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPublicKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.ECPrivateKey;
+import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -40,8 +41,6 @@ import org.mozilla.jss.netscape.security.x509.X509CertInfo;
 import org.mozilla.jss.netscape.security.x509.X509Key;
 import org.mozilla.jss.pkcs11.PK11ECPublicKey;
 import org.mozilla.jss.util.PasswordCallback;
-
-import org.apache.commons.codec.binary.Base64;
 
 public class X509CertTest {
 
@@ -213,7 +212,7 @@ public class X509CertTest {
 
     public static void testImport() throws Exception {
         CryptoManager cryptoManager = CryptoManager.getInstance();
-        byte[] cert = Base64.decodeBase64(
+        byte[] cert = Base64.getDecoder().decode(
             "MIIDRjCCAi6gAwIBAgIJAMHiDXjnZ1J6MA0GCSqGSIb3DQEBCwUAMDgxEDAOBgNV" +
             "BAoMB0VYQU1QTEUxJDAiBgNVBAMMG1Jvb3QgQ0EgU2lnbmluZyBDZXJ0aWZpY2F0" +
             "ZTAeFw0xOTAzMDUxNzQzMjFaFw0yMDAzMDQxNzQzMjFaMDgxEDAOBgNVBAoMB0VY" +

--- a/tools/Dockerfiles/fedora_29_jdk11
+++ b/tools/Dockerfiles/fedora_29_jdk11
@@ -5,10 +5,9 @@ RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core gcc make rpm-build cmake \
                           glassfish-jaxb-api java-11-openjdk nss-tools \
-                          apache-commons-codec apache-commons-lang gcc-c++ \
-                          java-11-openjdk-devel jpackage-utils slf4j nss \
-                          zlib-devel nss-devel nspr-devel perl slf4j-jdk14 \
-                          junit \
+                          apache-commons-lang gcc-c++ java-11-openjdk-devel \
+                          jpackage-utils slf4j nss zlib-devel nss-devel \
+                          nspr-devel perl slf4j-jdk14 junit \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \
         && rm -rf /usr/share/doc /usr/share/doc-base \

--- a/tools/Dockerfiles/fedora_rawhide
+++ b/tools/Dockerfiles/fedora_rawhide
@@ -5,10 +5,9 @@ RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core gcc make rpm-build cmake \
                           glassfish-jaxb-api java-11-openjdk nss-tools \
-                          apache-commons-codec apache-commons-lang gcc-c++ \
-                          java-11-openjdk-devel jpackage-utils slf4j nss \
-                          zlib-devel nss-devel nspr-devel perl slf4j-jdk14 \
-                          junit \
+                          apache-commons-lang gcc-c++ java-11-openjdk-devel \
+                          jpackage-utils slf4j nss zlib-devel nss-devel \
+                          nspr-devel perl slf4j-jdk14 junit \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \
         && rm -rf /usr/share/doc /usr/share/doc-base \

--- a/tools/Dockerfiles/fedora_sandbox
+++ b/tools/Dockerfiles/fedora_sandbox
@@ -4,10 +4,10 @@ FROM fedora:rawhide
 RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core gcc make rpm-build cmake \
-                          glassfish-jaxb-api nss-tools apache-commons-codec \
-                          apache-commons-lang gcc-c++ jpackage-utils slf4j \
-                          zlib-devel perl slf4j-jdk14 junit ninja-build \
-                          gyp gtest mercurial python-unversioned-command \
+                          glassfish-jaxb-api nss-tools apache-commons-lang \
+                          gcc-c++ jpackage-utils slf4j zlib-devel perl \
+                          slf4j-jdk14 junit ninja-build gyp gtest mercurial \
+                          python-unversioned-command \
         && dnf build-dep nss nspr jss -y \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \


### PR DESCRIPTION
Since Base64 is included in the standard library since JDK 8, the
minimum JDK version JSS `master` supports, and we already have hex
encoding in `netscape.security.utils.Utils`, we can drop all of our
dependencies on Apache Commons Codec fairly easily. Doing so reduces the
footprint of the JSS library and otherwise is beneficial since there's
likely to be little need for it in the future.
