### PR TITLE
Minimum RSA Key Sizes

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -425,6 +425,9 @@ Java_org_mozilla_jss_crypto_KBKDFIterationVariableParam_acquireNativeResources;
 Java_org_mozilla_jss_crypto_KBKDFIterationVariableParam_releaseNativeResources;
 Java_org_mozilla_jss_crypto_KBKDFOptionalCounterParam_acquireNativeResources;
 Java_org_mozilla_jss_crypto_KBKDFOptionalCounterParam_releaseNativeResources;
+Java_org_mozilla_jss_crypto_Policy_getRSAMinimumKeySize;
+Java_org_mozilla_jss_crypto_Policy_getDHMinimumKeySize;
+Java_org_mozilla_jss_crypto_Policy_getDSAMinimumKeySize;
     local:
         *;
 };

--- a/org/mozilla/jss/crypto/Policy.c
+++ b/org/mozilla/jss/crypto/Policy.c
@@ -1,0 +1,54 @@
+#include "_jni/org_mozilla_jss_crypto_Policy.h"
+
+#include <nspr.h>
+#include <nss.h>
+#include <jni.h>
+
+jint
+nearest_power_of_two(jint value)
+{
+    for (jint exponent = 8; exponent < 20; exponent++) {
+        if ((1 << exponent) >= value) {
+            return 1 << exponent;
+        }
+    }
+
+    return value;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_crypto_Policy_getRSAMinimumKeySize(JNIEnv *env, jclass clazz)
+{
+    PRInt32 value = 0;
+    SECStatus ret = NSS_OptionGet(NSS_RSA_MIN_KEY_SIZE, &value);
+    if (ret != SECSuccess) {
+        PR_ASSERT(PR_FALSE);
+    }
+
+    return nearest_power_of_two(value);
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_crypto_Policy_getDHMinimumKeySize(JNIEnv *env, jclass clazz)
+{
+    PRInt32 value = 0;
+    SECStatus ret = NSS_OptionGet(NSS_DH_MIN_KEY_SIZE, &value);
+    if (ret != SECSuccess) {
+        PR_ASSERT(PR_FALSE);
+    }
+
+    return nearest_power_of_two(value);
+}
+
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_crypto_Policy_getDSAMinimumKeySize(JNIEnv *env, jclass clazz)
+{
+    PRInt32 value = 0;
+    SECStatus ret = NSS_OptionGet(NSS_DSA_MIN_KEY_SIZE, &value);
+    if (ret != SECSuccess) {
+        PR_ASSERT(PR_FALSE);
+    }
+
+    return nearest_power_of_two(value);
+}

--- a/org/mozilla/jss/crypto/Policy.java
+++ b/org/mozilla/jss/crypto/Policy.java
@@ -1,0 +1,35 @@
+package org.mozilla.jss.crypto;
+
+import java.math.BigInteger;
+
+/**
+ * This class helps JSS callers align with local system cryptographic policy.
+ *
+ * In the event of a policy violation, applications can override policy by
+ * writing to the desired variable.
+ */
+public class Policy {
+    /**
+     * Minimum RSA key length in bits permitted by local policy.
+     */
+    public static int RSA_MINIMUM_KEY_SIZE = getRSAMinimumKeySize();
+
+    /**
+     * Minimum RSA public exponent allowed by JSS.
+     */
+    public static BigInteger RSA_MINIMUM_PUBLIC_EXPONENT = BigInteger.valueOf(65537);
+
+    /**
+     * Minimum DH key length in bits permitted by local policy.
+     */
+    public static int DH_MINIMUM_KEY_SIZE = getDHMinimumKeySize();
+
+    /**
+     * Minimum DSA key length in bits permitted by local policy.
+     */
+    public static int DSA_MINIMUM_KEY_SIZE = getDSAMinimumKeySize();
+
+    private static native int getRSAMinimumKeySize();
+    private static native int getDHMinimumKeySize();
+    private static native int getDSAMinimumKeySize();
+}

--- a/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.java
+++ b/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.java
@@ -20,6 +20,7 @@ import java.util.Hashtable;
 import org.mozilla.jss.asn1.ASN1Util;
 import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
 import org.mozilla.jss.crypto.KeyPairAlgorithm;
+import org.mozilla.jss.crypto.Policy;
 import org.mozilla.jss.crypto.PQGParams;
 import org.mozilla.jss.crypto.RSAParameterSpec;
 import org.mozilla.jss.crypto.TokenException;
@@ -469,6 +470,23 @@ public final class PK11KeyPairGenerator
         if(algorithm == KeyPairAlgorithm.RSA) {
             if(params != null) {
                 RSAKeyGenParameterSpec rsaparams = (RSAKeyGenParameterSpec)params;
+
+                if (rsaparams.getKeysize() < Policy.RSA_MINIMUM_KEY_SIZE) {
+                    String msg = "Disallowing unsafe RSA key size of ";
+                    msg += rsaparams.getKeysize() + ". Policy.RSA_MINIMUM_KEY_SIZE ";
+                    msg += "dictates a minimum of " + Policy.RSA_MINIMUM_KEY_SIZE;
+
+                    throw new TokenException(msg);
+                }
+                if (rsaparams.getPublicExponent().longValue() < Policy.RSA_MINIMUM_PUBLIC_EXPONENT.longValue()) {
+                    String msg = "Disallowing unsafe RSA exponent of ";
+                    msg += rsaparams.getPublicExponent().longValue() + ". ";
+                    msg += "Policy.RSA_MINIMUM_PUBLIC_EXPONENT dictates a minimum of ";
+                    msg += Policy.RSA_MINIMUM_PUBLIC_EXPONENT.longValue();
+
+                    throw new TokenException(msg);
+                }
+
                 return generateRSAKeyPairWithOpFlags(
                                     token,
                                     rsaparams.getKeysize(),

--- a/org/mozilla/jss/tests/JCAKeyWrap.java
+++ b/org/mozilla/jss/tests/JCAKeyWrap.java
@@ -9,6 +9,7 @@ import java.io.UnsupportedEncodingException;
 import org.mozilla.jss.crypto.SecretKeyFacade;
 import org.mozilla.jss.crypto.AlreadyInitializedException;
 import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.crypto.Policy;
 import org.mozilla.jss.crypto.TokenException;
 import javax.crypto.SecretKey;
 import javax.crypto.BadPaddingException;
@@ -86,11 +87,11 @@ public class JCAKeyWrap {
             // Generate an RSA keypair
             KeyPairGenerator kpgen;
             kpgen = KeyPairGenerator.getInstance("RSA", MOZ_PROVIDER_NAME);
-            kpgen.initialize(1024);
+            kpgen.initialize(Policy.RSA_MINIMUM_KEY_SIZE);
             KeyPair rsaKeyPairNSS = kpgen.generateKeyPair();
 
             kpgen = KeyPairGenerator.getInstance("RSA", otherRSAProvider);
-            kpgen.initialize(1024);
+            kpgen.initialize(Policy.RSA_MINIMUM_KEY_SIZE);
             KeyPair rsaKeyPairOtherProvider = kpgen.generateKeyPair();
 
             javax.crypto.SecretKey tripleDESKey;

--- a/org/mozilla/jss/tests/JCASigTest.java
+++ b/org/mozilla/jss/tests/JCASigTest.java
@@ -13,6 +13,8 @@ import java.security.Signature;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.InitializationValues;
 
+import org.mozilla.jss.crypto.Policy;
+
 
 public class JCASigTest {
 
@@ -89,7 +91,7 @@ public class JCASigTest {
 
             // Generate an RSA keypair
             kpgen = KeyPairGenerator.getInstance("RSA");
-            kpgen.initialize(1024);
+            kpgen.initialize(Policy.RSA_MINIMUM_KEY_SIZE);
             keyPair = kpgen.generateKeyPair();
             Provider  provider = kpgen.getProvider();
 

--- a/org/mozilla/jss/tests/SigTest.java
+++ b/org/mozilla/jss/tests/SigTest.java
@@ -20,6 +20,7 @@ import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.KeyPairAlgorithm;
 import org.mozilla.jss.crypto.KeyPairGenerator;
 import org.mozilla.jss.crypto.KeyPairGeneratorSpi;
+import org.mozilla.jss.crypto.Policy;
 import org.mozilla.jss.crypto.Signature;
 import org.mozilla.jss.crypto.SignatureAlgorithm;
 import org.mozilla.jss.pkcs11.PK11Token;
@@ -73,7 +74,7 @@ public class SigTest {
             }
             // Generate an RSA keypair
             kpgen = token.getKeyPairGenerator(KeyPairAlgorithm.RSA);
-            kpgen.initialize(1024);
+            kpgen.initialize(Policy.RSA_MINIMUM_KEY_SIZE);
             KeyPairGeneratorSpi.Usage usages[] = {
                 KeyPairGeneratorSpi.Usage.SIGN,
                 KeyPairGeneratorSpi.Usage.VERIFY};


### PR DESCRIPTION
Note that this doesn't update EC (to support limiting curves) or DSA or DH -- only RSA at this point in time.  One of the issues with DSA is that NSS only supports up to 1024-bit DSA key generation, but policy requires at least 2048 bits! To fix this, we need to switch to the NSS PQG v2 API instead of the v1 API. 

---- 

Add `jss.crypto.Policy` to reflect local policy

This queries NSS for a few policy suggestions so that applications using
JSS can begin obeying local system policy.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

Update RSA key generation to obey local policy

This uses the newly added `jss.crypto.Policy` class to validate local
parameter selection against what the system policy enforces. In
particular, this allows for validating the exponent (currently a
hard-coded sane default) and the RSA key size.

Resolves: GitHub JSS Issue #298

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`
