### PR TITLE
Cleanup SymKeyDeriving and re-add to test suite

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -235,6 +235,11 @@ macro(jss_tests)
         DEPENDS "Setup_DBs"
     )
     jss_test_java(
+        NAME "Symmetric_Key_Deriving"
+        COMMAND "org.mozilla.jss.tests.SymKeyDeriving" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
+        DEPENDS "Setup_DBs"
+    )
+    jss_test_java(
         NAME "JSSProvider"
         COMMAND "org.mozilla.jss.tests.JSSProvider" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
         DEPENDS "List_CA_certs"


### PR DESCRIPTION
`SymKeyDeriving` tests `PK11SymmetricKeyDeriver`, which uses
`PK11_Derive(...)`. We remove the old single DES test and re-add it to the
test suite, cleaning it up in the process.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`