### PR TITLE
Introduce NativeEnclosure and StaticVoidPointer

### DIFF
--- a/org/mozilla/jss/util/NativeEnclosure.c
+++ b/org/mozilla/jss/util/NativeEnclosure.c
@@ -1,0 +1,69 @@
+#include <nspr.h>
+#include <jni.h>
+
+#include "java_ids.h"
+#include "NativeEnclosure.h"
+
+PRStatus
+JSS_PR_LoadNativeEnclosure(JNIEnv *env, jobject this, jobject *ptrObj, jlong *ptrSize)
+{
+    jclass this_class = NULL;
+    jfieldID field_id = NULL;
+
+    PR_ASSERT(env != NULL && this != NULL && ptrObj != NULL && ptrSize != NULL);
+
+    this_class = (*env)->GetObjectClass(env, this);
+    if (this_class == NULL) {
+        return PR_FAILURE;
+    }
+
+    field_id = (*env)->GetFieldID(env, this_class, "mPointer", "L" NATIVE_PROXY_CLASS_NAME ";");
+    if (field_id == NULL) {
+        return PR_FAILURE;
+    }
+
+    *ptrObj = (*env)->GetObjectField(env, this, field_id);
+    if (ptrObj == NULL) {
+        return PR_FAILURE;
+    }
+
+    field_id = (*env)->GetFieldID(env, this_class, "mPointerSize", "J");
+    if (field_id == NULL) {
+        return PR_FAILURE;
+    }
+
+    *ptrSize = (*env)->GetLongField(env, this, field_id);
+
+    return PR_SUCCESS;
+}
+
+PRStatus
+JSS_PR_StoreNativeEnclosure(JNIEnv *env, jobject this, jobject ptrObj, jlong ptrSize)
+{
+    jclass this_class = NULL;
+    jfieldID field_id = NULL;
+
+    PR_ASSERT(env != NULL && this != NULL && ptrObj != NULL);
+
+    this_class = (*env)->GetObjectClass(env, this);
+    if (this_class == NULL) {
+        return PR_FAILURE;
+    }
+
+    field_id = (*env)->GetFieldID(env, this_class, "mPointer", "L" NATIVE_PROXY_CLASS_NAME ";");
+    if (field_id == NULL) {
+        return PR_FAILURE;
+    }
+
+    (*env)->SetObjectField(env, this, field_id, ptrObj);
+
+    field_id = (*env)->GetFieldID(env, this_class, "mPointerSize", "J");
+    if (field_id == NULL) {
+        return PR_FAILURE;
+    }
+
+    (*env)->SetLongField(env, this, field_id, ptrSize);
+
+    return PR_SUCCESS;
+}
+

--- a/org/mozilla/jss/util/NativeEnclosure.h
+++ b/org/mozilla/jss/util/NativeEnclosure.h
@@ -1,0 +1,9 @@
+#include <nspr.h>
+#include <jni.h>
+#include <stdlib.h>
+
+PRStatus
+JSS_PR_LoadNativeEnclosure(JNIEnv *env, jobject this, jobject *ptrObj, jlong *ptrSize);
+
+PRStatus
+JSS_PR_StoreNativeEnclosure(JNIEnv *env, jobject this, jobject ptrObj, jlong ptrSize);

--- a/org/mozilla/jss/util/NativeEnclosure.java
+++ b/org/mozilla/jss/util/NativeEnclosure.java
@@ -1,0 +1,82 @@
+package org.mozilla.jss.util;
+
+/**
+ * Classes extending NativeEnclsoure wrap a single NativeProxy instance,
+ * allowing it to be accessed from the JNI layer but be allocated and scoped
+ * from the Java layer.
+ *
+ * Because this class implements AutoCloseable, it is suggested to add
+ * constructors to derived classes which call open; this'll allow a single
+ * try-with-resources block to scope the lifetime of this object:
+ *
+ * <pre>
+ * try (NEC obj = new NEC(...)) {
+ *      // ... do something with obj ...
+ * }
+ * </pre>
+ *
+ * Extending classes implement acquireNativeResources() and
+ * releaseNativeResources(). Before this instance is passed to the JNI layer,
+ * open() should be called, allocating all necessary resources. After making
+ * all necessary JNI calls, close() should be called to free resources.
+ * Ideally, open() and close() should be called close to the JNI calls,
+ * wrapped by the developer to limit accidental memory leaks.
+ */
+public abstract class NativeEnclosure implements AutoCloseable {
+    /**
+     * Enclosed NativeProxy reference.
+     */
+    public NativeProxy mPointer;
+
+    /**
+     * Size of enclosed mPointer.
+     */
+    public long        mPointerSize;
+
+    /**
+     * Allocate and initialize mPointer with its enclosed value.
+     *
+     * Note that this method prevents you from accidentally leaking memory;
+     * to call open() twice, call close() first.
+     */
+    public final void open() throws Exception {
+        if (mPointer == null) {
+            acquireNativeResources();
+        }
+    }
+
+    @Deprecated
+    protected void finalize() throws Throwable {
+        close();
+    }
+
+    /**
+     * Deinitialize and free mPointer.
+     *
+     * Must be called to prevent memory leaks.
+     */
+    public final void close() throws Exception {
+        if (mPointer != null) {
+            releaseNativeResources();
+            mPointer.close();
+        }
+
+        mPointer = null;
+        mPointerSize = 0;
+    }
+
+    /**
+     * Allocate native resources, setting mPointer and mPointerSize as
+     * appropriate.
+     */
+    protected abstract void acquireNativeResources() throws Exception;
+
+    /**
+     * Called to deallocate native resources; note that mPointer.close()
+     * is called afterwards.
+     *
+     * If mPointer.close() should be a no-op, extend from StaticVoidRef and
+     * do any required cleanup here.
+     */
+    protected abstract void releaseNativeResources() throws Exception;
+}

--- a/org/mozilla/jss/util/NativeProxy.java
+++ b/org/mozilla/jss/util/NativeProxy.java
@@ -31,7 +31,7 @@ public abstract class NativeProxy implements AutoCloseable
 
     /**
      * Create a NativeProxy from a byte array representing a C pointer.
-     * This is the only way to create a NativeProxy, it should be called
+     * This is the primary way of creating a NativeProxy; it should be called
      * from the constructor of your subclass.
      *
      * @param pointer A byte array, created with JSS_ptrToByteArray, that
@@ -39,12 +39,27 @@ public abstract class NativeProxy implements AutoCloseable
      * NativeProxy instance acts as a proxy for that native data structure.
      */
     public NativeProxy(byte[] pointer) {
-        assert(pointer!=null);
-        mPointer = pointer;
-        registry.add(this);
+        this(pointer, true);
+    }
 
-        if (saveStacktraces) {
-            mTrace = Arrays.toString(Thread.currentThread().getStackTrace());
+    /**
+     * Create a NativeProxy from a byte array representing a C pointer.
+     * This allows for creating an untracked NativeProxy instance (when
+     * track=false), which allows for creating NativeProxy instances out
+     * of stack-allocated variables and/or creating NativeProxies which
+     * aren't freed.
+     */
+    protected NativeProxy(byte[] pointer, boolean track) {
+        mPointer = pointer;
+
+        if (track) {
+            assert(pointer != null);
+
+            registry.add(this);
+
+            if (saveStacktraces) {
+                mTrace = Arrays.toString(Thread.currentThread().getStackTrace());
+            }
         }
     }
 

--- a/org/mozilla/jss/util/StaticVoidPointer.c
+++ b/org/mozilla/jss/util/StaticVoidPointer.c
@@ -1,0 +1,47 @@
+#include <nspr.h>
+#include <jni.h>
+
+#include "java_ids.h"
+#include "jssutil.h"
+
+jobject
+JSS_PR_wrapStaticVoidPointer(JNIEnv *env, void **ref)
+{
+    jbyteArray pointer = NULL;
+    jclass proxyClass;
+    jmethodID constructor;
+    jobject refObj = NULL;
+
+    PR_ASSERT(env != NULL && ref != NULL && *ref != NULL);
+
+    /* Convert pointer to byte array. */
+    pointer = JSS_ptrToByteArray(env, *ref);
+
+    /* Lookup the class and constructor. */
+    proxyClass = (*env)->FindClass(env, STATIC_VOID_POINTER_CLASS_NAME);
+    if (proxyClass == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+
+    constructor = (*env)->GetMethodID(env, proxyClass,
+                                      PLAIN_CONSTRUCTOR,
+                                      STATIC_VOID_POINTER_CONSTRUCTOR_SIG);
+    if (constructor == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+
+    /* Call the constructor. */
+    refObj = (*env)->NewObject(env, proxyClass, constructor, pointer);
+
+finish:
+    PR_ASSERT(refObj || (*env)->ExceptionOccurred(env));
+    return refObj;
+}
+
+PRStatus
+JSS_PR_getStaticVoidRef(JNIEnv *env, jobject ref_proxy, void **ref)
+{
+    return JSS_getPtrFromProxy(env, ref_proxy, ref);
+}

--- a/org/mozilla/jss/util/StaticVoidPointer.h
+++ b/org/mozilla/jss/util/StaticVoidPointer.h
@@ -1,0 +1,8 @@
+#include <nspr.h>
+#include <jni.h>
+
+jobject
+JSS_PR_wrapStaticVoidPointer(JNIEnv *env, void **ref);
+
+PRStatus
+JSS_PR_getStaticVoidRef(JNIEnv *env, jobject ref_proxy, void **ref);

--- a/org/mozilla/jss/util/StaticVoidPointer.java
+++ b/org/mozilla/jss/util/StaticVoidPointer.java
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.jss.util;
+
+import java.util.HashSet;
+
+import java.lang.AutoCloseable;
+import java.lang.Thread;
+import java.util.Arrays;
+
+import org.mozilla.jss.CryptoManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * StaticVoidPointer is a Java class that mirror a statically allocated
+ * `void *` pointer in C.
+ *
+ * This is helpful for implementing NativeEnclosure and preventing the
+ * resulting pointer from getting tracked in the usual NativeProxy allocation
+ * trackers and avoiding a double free.
+ */
+public class StaticVoidPointer extends NativeProxy
+{
+    public StaticVoidPointer(byte[] pointer) {
+        super(pointer, false);
+    }
+
+    protected void releaseNativeResources() {
+        /* Do nothing: this is a static pointer that doesn't need freeing. */
+    }
+}

--- a/org/mozilla/jss/util/java_ids.h
+++ b/org/mozilla/jss/util/java_ids.h
@@ -413,6 +413,12 @@ PR_BEGIN_EXTERN_C
 #define GLOBAL_REF_PROXY_CLASS_NAME "org/mozilla/jss/util/GlobalRefProxy"
 #define GLOBAL_REF_CONSTRUCTOR_SIG "([B)V"
 
+/*
+ * StaticVoidProxy
+ */
+#define STATIC_VOID_POINTER_CLASS_NAME "org/mozilla/jss/util/StaticVoidPointer"
+#define STATIC_VOID_POINTER_CONSTRUCTOR_SIG "([B)V"
+
 PR_END_EXTERN_C
 
 #endif


### PR DESCRIPTION
A `NativeEnclosure` is an abstract class which stores a `NativeProxy`
instance and wraps both the pointer and the size of the memory pointed
to by said pointer. When used in combination with `StaticVoidPointer`, a
pointer which isn't tracked and freed like the usual `NativeProxy` is,
this can be used as a form of serialization, especially for converting
parameters to and from the JNI layer.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`