### PR TITLE
Add CK_ATTRIBUTE classes

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -404,3 +404,16 @@ Java_org_mozilla_jss_util_GlobalRefProxy_releaseNativeResources;
     local:
         *;
 };
+JSS_4.6.3 {
+    global:
+Java_org_mozilla_jss_pkcs11_attrs_CKAClass_acquireNativeResources;
+Java_org_mozilla_jss_pkcs11_attrs_CKAClass_releaseNativeResources;
+Java_org_mozilla_jss_pkcs11_attrs_CKAKeyType_acquireNativeResources;
+Java_org_mozilla_jss_pkcs11_attrs_CKAKeyType_releaseNativeResources;
+Java_org_mozilla_jss_pkcs11_attrs_CKAUsage_acquireNativeResources;
+Java_org_mozilla_jss_pkcs11_attrs_CKAUsage_releaseNativeResources;
+Java_org_mozilla_jss_pkcs11_attrs_CKAValueLen_acquireNativeResources;
+Java_org_mozilla_jss_pkcs11_attrs_CKAValueLen_releaseNativeResources;
+    local:
+        *;
+};

--- a/org/mozilla/jss/pkcs11/attrs/CKAClass.java
+++ b/org/mozilla/jss/pkcs11/attrs/CKAClass.java
@@ -1,0 +1,119 @@
+package org.mozilla.jss.pkcs11.attrs;
+
+import org.mozilla.jss.pkcs11.PKCS11Constants;
+
+/**
+ * CKAClass is an instance of a PKCS#11 CK_ATTRIBUTE with type = CKA_CLASS.
+ */
+public class CKAClass extends CKAttribute {
+    private long value;
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_CLASS and a
+     * custom value.
+     *
+     * Note: it is generally recommended to use the subclasses of this class
+     * instead of providing a custom value.
+     */
+    public CKAClass(long value) {
+        super(PKCS11Constants.CKA_CLASS);
+        setValue(value);
+    }
+
+    /**
+     * Set the value of this CKA_CLASS attribute.
+     */
+    public void setValue(long value) {
+        this.value = value;
+    }
+
+    /**
+     * Get the value of this CKA_CLASS attribute.
+     */
+    public long getValue() {
+        return value;
+    }
+
+    protected native void acquireNativeResources();
+    protected native void releaseNativeResources();
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_CLASS and value
+     * CKO_DATA.
+     */
+    public static class Data extends CKAClass {
+        public Data() {
+            super(PKCS11Constants.CKO_DATA);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_CLASS and value
+     * CKO_CERTIFICATE.
+     */
+    public static class Certificate extends CKAClass {
+        public Certificate() {
+            super(PKCS11Constants.CKO_CERTIFICATE);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_CLASS and value
+     * CKO_PUBLIC_KEY.
+     */
+    public static class PublicKey extends CKAClass {
+        public PublicKey() {
+            super(PKCS11Constants.CKO_PUBLIC_KEY);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_CLASS and value
+     * CKO_PRIVATE_KEY.
+     */
+    public static class PrivateKey extends CKAClass {
+        public PrivateKey() {
+            super(PKCS11Constants.CKO_PRIVATE_KEY);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_CLASS and value
+     * CKO_SECRET_KEY.
+     */
+    public static class SecretKey extends CKAClass {
+        public SecretKey() {
+            super(PKCS11Constants.CKO_SECRET_KEY);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_CLASS and value
+     * CKO_HW_FEATURE.
+     */
+    public static class HWFeature extends CKAClass {
+        public HWFeature() {
+            super(PKCS11Constants.CKO_HW_FEATURE);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_CLASS and value
+     * CKO_DOMAIN_PARAMETERS.
+     */
+    public static class DomainParameters extends CKAClass {
+        public DomainParameters() {
+            super(PKCS11Constants.CKO_DOMAIN_PARAMETERS);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_CLASS and value
+     * CKO_MECHANISM.
+     */
+    public static class Mechanism extends CKAClass {
+        public Mechanism() {
+            super(PKCS11Constants.CKO_MECHANISM);
+        }
+    }
+}

--- a/org/mozilla/jss/pkcs11/attrs/CKAKeyType.java
+++ b/org/mozilla/jss/pkcs11/attrs/CKAKeyType.java
@@ -1,0 +1,320 @@
+package org.mozilla.jss.pkcs11.attrs;
+
+import org.mozilla.jss.pkcs11.PKCS11Constants;
+
+/**
+ * CKA_KEY_TYPE is an instance of a PKCS#11 CK_ATTRIBUTE with
+ * type = CKA_KEY_TYPE.
+ */
+public class CKAKeyType extends CKAttribute {
+    private long value;
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and a
+     * custom value.
+     *
+     * Note: it is generally recommended to use the subclasses of this class
+     * instead of providing a custom value.
+     */
+    public CKAKeyType(long value) {
+        super(PKCS11Constants.CKA_KEY_TYPE);
+        setValue(value);
+    }
+
+    /**
+     * Set the value of this CKA_KEY_TYPE attribute.
+     */
+    public void setValue(long value) {
+        this.value = value;
+    }
+
+    /**
+     * Get the value of this CKA_KEY_TYPE attribute.
+     */
+    public long getValue() {
+        return value;
+    }
+
+    protected native void acquireNativeResources();
+    protected native void releaseNativeResources();
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_RSA.
+     */
+    public static class RSA extends CKAKeyType {
+        public RSA() {
+            super(PKCS11Constants.CKK_RSA);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_DSA.
+     */
+    public static class DSA extends CKAKeyType {
+        public DSA() {
+            super(PKCS11Constants.CKK_DSA);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_DH.
+     */
+    public static class DH extends CKAKeyType {
+        public DH() {
+            super(PKCS11Constants.CKK_DH);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_ECDSA.
+     */
+    public static class ECDSA extends CKAKeyType {
+        public ECDSA() {
+            super(PKCS11Constants.CKK_ECDSA);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_EC.
+     */
+    public static class EC extends CKAKeyType {
+        public EC() {
+            super(PKCS11Constants.CKK_EC);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_X9_42_DH.
+     */
+    public static class X9_42_DH extends CKAKeyType {
+        public X9_42_DH() {
+            super(PKCS11Constants.CKK_X9_42_DH);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_KEA.
+     */
+    public static class KEA extends CKAKeyType {
+        public KEA() {
+            super(PKCS11Constants.CKK_KEA);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_GENERIC_SECRET.
+     */
+    public static class GenericSecret extends CKAKeyType {
+        public GenericSecret() {
+            super(PKCS11Constants.CKK_GENERIC_SECRET);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_RC2.
+     */
+    public static class RC2 extends CKAKeyType {
+        public RC2() {
+            super(PKCS11Constants.CKK_RC2);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_RC4.
+     */
+    public static class RC4 extends CKAKeyType {
+        public RC4() {
+            super(PKCS11Constants.CKK_RC4);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_DES.
+     */
+    public static class DES extends CKAKeyType {
+        public DES() {
+            super(PKCS11Constants.CKK_DES);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_DES2.
+     */
+    public static class DES2 extends CKAKeyType {
+        public DES2() {
+            super(PKCS11Constants.CKK_DES2);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_DES3.
+     */
+    public static class DES3 extends CKAKeyType {
+        public DES3() {
+            super(PKCS11Constants.CKK_DES3);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_CAST.
+     */
+    public static class CAST extends CKAKeyType {
+        public CAST() {
+            super(PKCS11Constants.CKK_CAST);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_CAST3.
+     */
+    public static class CAST3 extends CKAKeyType {
+        public CAST3() {
+            super(PKCS11Constants.CKK_CAST3);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_CAST5.
+     */
+    public static class CAST5 extends CKAKeyType {
+        public CAST5() {
+            super(PKCS11Constants.CKK_CAST5);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_CAST128.
+     */
+    public static class CAST128 extends CKAKeyType {
+        public CAST128() {
+            super(PKCS11Constants.CKK_CAST128);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_RC5.
+     */
+    public static class RC5 extends CKAKeyType {
+        public RC5() {
+            super(PKCS11Constants.CKK_RC5);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_IDEA.
+     */
+    public static class IDEA extends CKAKeyType {
+        public IDEA() {
+            super(PKCS11Constants.CKK_IDEA);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_SKIPJACK.
+     */
+    public static class Skipjack extends CKAKeyType {
+        public Skipjack() {
+            super(PKCS11Constants.CKK_SKIPJACK);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_BATON.
+     */
+    public static class BATON extends CKAKeyType {
+        public BATON() {
+            super(PKCS11Constants.CKK_BATON);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_JUNIPER.
+     */
+    public static class JUNIPER extends CKAKeyType {
+        public JUNIPER() {
+            super(PKCS11Constants.CKK_JUNIPER);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_CDMF.
+     */
+    public static class CDMF extends CKAKeyType {
+        public CDMF() {
+            super(PKCS11Constants.CKK_CDMF);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_AES.
+     */
+    public static class AES extends CKAKeyType {
+        public AES() {
+            super(PKCS11Constants.CKK_AES);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_BLOWFISH.
+     */
+    public static class Blowfish extends CKAKeyType {
+        public Blowfish() {
+            super(PKCS11Constants.CKK_BLOWFISH);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_TWOFISH.
+     */
+    public static class Twofish extends CKAKeyType {
+        public Twofish() {
+            super(PKCS11Constants.CKK_TWOFISH);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_CAMELLIA.
+     */
+    public static class Camellia extends CKAKeyType {
+        public Camellia() {
+            super(PKCS11Constants.CKK_CAMELLIA);
+        }
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_KEY_TYPE and
+     * value CKK_SEED.
+     */
+    public static class Seed extends CKAKeyType {
+        public Seed() {
+            super(PKCS11Constants.CKK_SEED);
+        }
+    }
+}

--- a/org/mozilla/jss/pkcs11/attrs/CKAUsage.java
+++ b/org/mozilla/jss/pkcs11/attrs/CKAUsage.java
@@ -1,0 +1,113 @@
+package org.mozilla.jss.pkcs11.attrs;
+
+import org.mozilla.jss.pkcs11.PKCS11Constants;
+
+/**
+ * CKAUsage is a collection of PKCS#11 CK_ATTRIBUTES which have common value
+ * (CK_TRUE).
+ */
+public class CKAUsage extends CKAttribute {
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with custom type, setting the
+     * value to CK_TRUE.
+     *
+     * Note: it is generally recommended to use the subclasses of this class
+     * instead of providing a custom value.
+     */
+    public CKAUsage(long type) {
+        super(type);
+    }
+
+    protected native void acquireNativeResources();
+    protected native void releaseNativeResources();
+
+    /**
+     * CKAEncrypt is an instance of PKCS#11 CK_ATTRIBUTE with
+     * type = CKA_ENCRYPT and value CK_TRUE.
+     */
+    public static class Encrypt extends CKAUsage {
+        public Encrypt() {
+            super(PKCS11Constants.CKA_ENCRYPT);
+        }
+    }
+
+    /**
+     * CKADecrypt is an instance of PKCS#11 CK_ATTRIBUTE with
+     * type = CKA_DECRYPT and value CK_TRUE.
+     */
+    public static class Decrypt extends CKAUsage {
+        public Decrypt() {
+            super(PKCS11Constants.CKA_DECRYPT);
+        }
+    }
+
+    /**
+     * CKAWrap is an instance of PKCS#11 CK_ATTRIBUTE with
+     * type = CKA_WRAP and value CK_TRUE.
+     */
+    public static class Wrap extends CKAUsage {
+        public Wrap() {
+            super(PKCS11Constants.CKA_WRAP);
+        }
+    }
+
+    /**
+     * CKAUnwrap is an instance of PKCS#11 CK_ATTRIBUTE with
+     * type = CKA_UNWRAP and value CK_TRUE.
+     */
+    public static class Unwrap extends CKAUsage {
+        public Unwrap() {
+            super(PKCS11Constants.CKA_UNWRAP);
+        }
+    }
+
+    /**
+     * CKASign is an instance of PKCS#11 CK_ATTRIBUTE with
+     * type = CKA_SIGN and value CK_TRUE.
+     */
+    public static class Sign extends CKAUsage {
+        public Sign() {
+            super(PKCS11Constants.CKA_SIGN);
+        }
+    }
+
+    /**
+     * CKASignRecover is an instance of PKCS#11 CK_ATTRIBUTE with
+     * type = CKA_SIGN_RECOVER and value CK_TRUE.
+     */
+    public static class SignRecover extends CKAUsage {
+        public SignRecover() {
+            super(PKCS11Constants.CKA_SIGN_RECOVER);
+        }
+    }
+
+    /**
+     * CKAVerify is an instance of PKCS#11 CK_ATTRIBUTE with
+     * type = CKA_VERIFY and value CK_TRUE.
+     */
+    public static class Verify extends CKAUsage {
+        public Verify() {
+            super(PKCS11Constants.CKA_VERIFY);
+        }
+    }
+
+    /**
+     * CKAVerifyRecover is an instance of PKCS#11 CK_ATTRIBUTE with
+     * type = CKA_VERIFY_RECOVER and value CK_TRUE.
+     */
+    public static class VerifyRecover extends CKAUsage {
+        public VerifyRecover() {
+            super(PKCS11Constants.CKA_VERIFY_RECOVER);
+        }
+    }
+
+    /**
+     * CKADerive is an instance of PKCS#11 CK_ATTRIBUTE with
+     * type = CKA_DERIVE and value CK_TRUE.
+     */
+    public static class Derive extends CKAUsage {
+        public Derive() {
+            super(PKCS11Constants.CKA_DERIVE);
+        }
+    }
+}

--- a/org/mozilla/jss/pkcs11/attrs/CKAValueLen.java
+++ b/org/mozilla/jss/pkcs11/attrs/CKAValueLen.java
@@ -1,0 +1,47 @@
+package org.mozilla.jss.pkcs11.attrs;
+
+import org.mozilla.jss.pkcs11.PKCS11Constants;
+
+/**
+ * CKAClass is an instance of a PKCS#11 CK_ATTRIBUTE with type = CKA_CLASS.
+ */
+public class CKAValueLen extends CKAttribute {
+    private long length = 0;
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_VALUE_LEN and
+     * default length for the key type.
+     *
+     * Note that when key type is not specified and/or that mechanism lacks a
+     * default size, the corresponding PKCS#11 call will error out.
+     */
+    public CKAValueLen() {
+        super(PKCS11Constants.CKA_VALUE_LEN);
+    }
+
+    /**
+     * Representation of a PKCS#11 CK_ATTRIBUTE with type CKA_VALUE_LEN and a
+     * specified length.
+     */
+    public CKAValueLen(long length) {
+        this();
+        setLength(length);
+    }
+
+    /**
+     * Set the length specified by this CKA_VALUE_LEN attribute.
+     */
+    public void setLength(long length) {
+        this.length = length;
+    }
+
+    /**
+     * Get the length of this CKA_VALUE_LEN attribute.
+     */
+    public long getLength() {
+        return length;
+    }
+
+    protected native void acquireNativeResources();
+    protected native void releaseNativeResources();
+}

--- a/org/mozilla/jss/pkcs11/attrs/CKAttribute.c
+++ b/org/mozilla/jss/pkcs11/attrs/CKAttribute.c
@@ -1,0 +1,275 @@
+#include <nspr.h>
+#include <nss.h>
+#include <pkcs11t.h>
+#include <jni.h>
+
+#include "CKAttribute.h"
+#include "StaticVoidPointer.h"
+#include "NativeEnclosure.h"
+
+#include "_jni/org_mozilla_jss_pkcs11_attrs_CKAClass.h"
+#include "_jni/org_mozilla_jss_pkcs11_attrs_CKAKeyType.h"
+#include "_jni/org_mozilla_jss_pkcs11_attrs_CKAUsage.h"
+#include "_jni/org_mozilla_jss_pkcs11_attrs_CKAValueLen.h"
+
+static const CK_BBOOL JSS_CK_TRUE = CK_TRUE;
+
+PRStatus
+JSS_PK11_WrapAttribute(JNIEnv *env, jobject this, void *ptr, size_t ptr_length) {
+    jclass this_class;
+    jfieldID field_id;
+    jobject ptr_object;
+    CK_ATTRIBUTE_PTR attr = calloc(1, sizeof(CK_ATTRIBUTE));
+
+    PR_ASSERT(env != NULL && this != NULL && attr != NULL);
+
+    this_class = (*env)->GetObjectClass(env, this);
+    if (this_class == NULL) {
+        goto failure;
+    }
+
+    field_id = (*env)->GetFieldID(env, this_class, "type", "J");
+    if (field_id == NULL) {
+        goto failure;
+    }
+
+    attr->type = (CK_ULONG)((*env)->GetLongField(env, this, field_id));
+    attr->pValue = ptr;
+    attr->ulValueLen = ptr_length;
+
+    ptr_object = JSS_PR_wrapStaticVoidPointer(env, (void **)&attr);
+    if (ptr_object == NULL) {
+        goto failure;
+    }
+
+    if (JSS_PR_StoreNativeEnclosure(env, this, ptr_object, sizeof(CK_ATTRIBUTE)) != PR_SUCCESS) {
+        goto failure;
+    }
+
+    return PR_SUCCESS;
+
+failure:
+    memset(attr, 0, sizeof(CK_ATTRIBUTE));
+    free(attr);
+    return PR_FAILURE;
+}
+
+PRStatus
+JSS_PK11_UnwrapAttribute(JNIEnv *env, jobject this, CK_ATTRIBUTE_PTR *attr) {
+    jobject ptr_obj;
+    jlong size = 0;
+
+    PR_ASSERT(env != NULL && this != NULL && attr != NULL);
+
+    if (JSS_PR_LoadNativeEnclosure(env, this, &ptr_obj, &size) != PR_SUCCESS) {
+        goto failure;
+    }
+
+    if (JSS_PR_getStaticVoidRef(env, ptr_obj, (void **)attr) != PR_SUCCESS || *attr == NULL) {
+        goto failure;
+    }
+
+    if (size != sizeof(CK_ATTRIBUTE)) {
+        goto failure;
+    }
+
+    return PR_SUCCESS;
+
+failure:
+    *attr = NULL;
+    return PR_FAILURE;
+}
+
+/* ===== CKA_CLASS Attribute ===== */
+
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_pkcs11_attrs_CKAClass_acquireNativeResources(JNIEnv *env, jobject this)
+{
+    jclass this_class;
+    jfieldID field_id;
+    CK_ULONG *ptr = calloc(1, sizeof(CK_ULONG));
+
+    PR_ASSERT(env != NULL && this != NULL && ptr != NULL);
+
+    this_class = (*env)->GetObjectClass(env, this);
+    if (this_class == NULL) {
+        goto failure;
+    }
+
+    field_id = (*env)->GetFieldID(env, this_class, "value", "J");
+    if (field_id == NULL) {
+        goto failure;
+    }
+
+    *ptr = (CK_ULONG)((*env)->GetLongField(env, this, field_id));
+
+    if (JSS_PK11_WrapAttribute(env, this, (void *)ptr, sizeof(*ptr)) == PR_FAILURE) {
+        goto failure;
+    }
+
+    return;
+
+failure:
+    memset(ptr, 0, sizeof(*ptr));
+    free(ptr);
+}
+
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_pkcs11_attrs_CKAClass_releaseNativeResources(JNIEnv *env, jobject this)
+{
+    CK_ATTRIBUTE_PTR attr = NULL;
+
+    if (JSS_PK11_UnwrapAttribute(env, this, &attr) != PR_SUCCESS || attr == NULL) {
+        return;
+    }
+
+    PR_ASSERT(attr->type == CKA_CLASS);
+    PR_ASSERT(attr->pValue != NULL);
+    PR_ASSERT(attr->ulValueLen == sizeof(CK_ULONG));
+
+    if (attr->pValue != NULL) {
+        memset(attr->pValue, 0, attr->ulValueLen);
+        free(attr->pValue);
+    }
+
+    memset(attr, 0, sizeof(CK_ATTRIBUTE));
+    free(attr);
+
+    return;
+}
+
+/* ===== CKA_KEY_TYPE Attribute ===== */
+
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_pkcs11_attrs_CKAKeyType_acquireNativeResources(JNIEnv *env, jobject this)
+{
+    jclass this_class;
+    jfieldID field_id;
+    CK_ULONG *ptr = calloc(1, sizeof(CK_ULONG));
+
+    PR_ASSERT(env != NULL && this != NULL && ptr != NULL);
+
+    this_class = (*env)->GetObjectClass(env, this);
+    if (this_class == NULL) {
+        goto failure;
+    }
+
+    field_id = (*env)->GetFieldID(env, this_class, "value", "J");
+    if (field_id == NULL) {
+        goto failure;
+    }
+
+    *ptr = (CK_ULONG)((*env)->GetLongField(env, this, field_id));
+
+    JSS_PK11_WrapAttribute(env, this, (void *)ptr, sizeof(*ptr));
+
+    return;
+failure:
+    memset(ptr, 0, sizeof(*ptr));
+    free(ptr);
+}
+
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_pkcs11_attrs_CKAKeyType_releaseNativeResources(JNIEnv *env, jobject this)
+{
+    CK_ATTRIBUTE_PTR attr = NULL;
+
+    if (JSS_PK11_UnwrapAttribute(env, this, &attr) != PR_SUCCESS || attr == NULL) {
+        return;
+    }
+
+    PR_ASSERT(attr->type == CKA_KEY_TYPE);
+    PR_ASSERT(attr->pValue != NULL);
+    PR_ASSERT(attr->ulValueLen == sizeof(CK_ULONG));
+
+    if (attr->pValue != NULL) {
+        memset(attr->pValue, 0, attr->ulValueLen);
+        free(attr->pValue);
+    }
+
+    memset(attr, 0, sizeof(CK_ATTRIBUTE));
+    free(attr);
+
+    return;
+}
+
+/* ===== CKA_{ENCRYPT,DECRYPT,...} Usage Attributes ===== */
+
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_pkcs11_attrs_CKAUsage_acquireNativeResources(JNIEnv *env, jobject this)
+{
+    JSS_PK11_WrapAttribute(env, this, (void *)&JSS_CK_TRUE, sizeof(JSS_CK_TRUE));
+}
+
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_pkcs11_attrs_CKAUsage_releaseNativeResources(JNIEnv *env, jobject this)
+{
+    CK_ATTRIBUTE_PTR attr = NULL;
+
+    if (JSS_PK11_UnwrapAttribute(env, this, &attr) != PR_SUCCESS || attr == NULL) {
+        return;
+    }
+
+    /* Since the internal pValue member is always a reference to JSS_CK_TRUE,
+     * don't free it! Only free the outer CK_ATTRIBUTE pointer. */
+
+    memset(attr, 0, sizeof(CK_ATTRIBUTE));
+    free(attr);
+}
+
+/* ===== CKA_VALUE_LEN Attribute ===== */
+
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_pkcs11_attrs_CKAValueLen_acquireNativeResources(JNIEnv *env, jobject this)
+{
+    jclass this_class;
+    jfieldID field_id;
+    CK_ULONG *ptr = calloc(1, sizeof(CK_ULONG));
+
+    PR_ASSERT(env != NULL && this != NULL && ptr != NULL);
+
+    this_class = (*env)->GetObjectClass(env, this);
+    if (this_class == NULL) {
+        goto failure;
+    }
+
+    field_id = (*env)->GetFieldID(env, this_class, "length", "J");
+    if (field_id == NULL) {
+        goto failure;
+    }
+
+    *ptr = (CK_ULONG)((*env)->GetLongField(env, this, field_id));
+
+    if (JSS_PK11_WrapAttribute(env, this, (void *)ptr, sizeof(*ptr)) == PR_FAILURE) {
+        goto failure;
+    }
+
+    return;
+failure:
+    memset(ptr, 0, sizeof(*ptr));
+    free(ptr);
+}
+
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_pkcs11_attrs_CKAValueLen_releaseNativeResources(JNIEnv *env, jobject this)
+{
+    CK_ATTRIBUTE_PTR attr = NULL;
+
+    if (JSS_PK11_UnwrapAttribute(env, this, &attr) != PR_SUCCESS || attr == NULL) {
+        return;
+    }
+
+    PR_ASSERT(attr->type == CKA_VALUE_LEN);
+    PR_ASSERT(attr->pValue != NULL);
+    PR_ASSERT(attr->ulValueLen == sizeof(CK_ULONG));
+
+    if (attr->pValue != NULL) {
+        memset(attr->pValue, 0, attr->ulValueLen);
+        free(attr->pValue);
+    }
+
+    memset(attr, 0, sizeof(CK_ATTRIBUTE));
+    free(attr);
+
+    return;
+}

--- a/org/mozilla/jss/pkcs11/attrs/CKAttribute.h
+++ b/org/mozilla/jss/pkcs11/attrs/CKAttribute.h
@@ -1,0 +1,8 @@
+#include <nspr.h>
+#include <jni.h>
+
+PRStatus
+JSS_PK11_WrapAttribute(JNIEnv *env, jobject this, void *ptr, size_t ptr_length);
+
+PRStatus
+JSS_PK11_UnwrapAttribute(JNIEnv *env, jobject this, CK_ATTRIBUTE_PTR *attr);

--- a/org/mozilla/jss/pkcs11/attrs/CKAttribute.java
+++ b/org/mozilla/jss/pkcs11/attrs/CKAttribute.java
@@ -1,0 +1,31 @@
+package org.mozilla.jss.pkcs11.attrs;
+
+import org.mozilla.jss.util.NativeEnclosure;
+
+/**
+ * A CKAttribute is an instance of PKCS#11 CK_ATTRIBUTE.
+ *
+ * Each CK_ATTRIBUTE contains three parts:
+ *  1. A type (type),
+ *  2. A pointer to a value (pValue),
+ *  3. The size of said value (ulValueLen).
+ *
+ * In the Java layer, CKAttribute has a member "type" to contain the type
+ * of the CK_ATTRIBUTE. It takes on values from PKCS11Constants (pkcs11t.h
+ * and pkcs11n.h) with prefix "CKA_". The two NativeEnclosure fields,
+ * mPointer and mPointerSize wrap a pointer to the underlying CK_ATTRIBUTE
+ * and its size respectively. They get allocated when open() is called, and
+ * freed when close() is called.
+ *
+ * The value (numbers 2 and 3 above) get determined by the extending type,
+ * and its corresponding native methods. Some use statically allocated values,
+ * like CKAUsage's classes. Others are dynamically allocated pointers, such as
+ * when referring to CK_ULONG values (as with CKAValueLen for instance).
+ */
+public abstract class CKAttribute extends NativeEnclosure {
+    public long type;
+
+    public CKAttribute(long type) {
+        this.type = type;
+    }
+}


### PR DESCRIPTION
The new class `org.mozilla.jss.pkcs11.attrs.CKAttribute` represents a
single PKCS#11 `CK_ATTRIBUTE` in Java. These attributes can be serialized
to the native layer (via `NativeEnclosure`). Each attribute is handled in
a derived class. Currently four types of attributes are supported:

 - `CKA_CLASS` in `jss.pkcs11.attrs.CKAClass`
 - `CKA_KEY_TYPE` in `jss.pkcs11.attrs.CKAKeyType`
 - `CKA_{ENCRYPT,DECRYPT,...}` usage attributes in
   `jss.pkcs11.attrs.CKAUsage`
 - `CKA_VALUE_LEN` in `jss.pkcs11.attrs.CKAValueLen`

These attributes are useful for constructing key templates for
additional derived keys in PKCS#11's NIST SP800-108 KBKDF interface.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`