### PR TITLE
Add Generic Secret key type

### DIFF
--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -201,6 +201,8 @@ public final class JSSProvider extends java.security.Provider {
         /////////////////////////////////////////////////////////////
         // SecretKeyFactory
         /////////////////////////////////////////////////////////////
+        put("SecretKeyFactory.GenericSecret", "org.mozilla.jss.provider.javax.crypto.JSSSecretKeyFactorySpi$GenericSecret");
+        put("Alg.Alias.SecretKeyFactory.GENERIC_SECRET", "GenericSecret");
         put("SecretKeyFactory.DES",
             "org.mozilla.jss.provider.javax.crypto.JSSSecretKeyFactorySpi$DES");
         put("SecretKeyFactory.DESede",

--- a/org/mozilla/jss/crypto/Algorithm.c
+++ b/org/mozilla/jss/crypto/Algorithm.c
@@ -105,7 +105,11 @@ JSS_AlgInfo JSS_AlgTable[NUM_ALGS] = {
 /* 69 */    {CKM_SHA512_HMAC, PK11_MECH},
 
 /* CKM_AES_CMAC is new to NSS; some implementations might not yet have it. */
-/* 70 */    {CKM_AES_CMAC, PK11_MECH}
+/* 70 */    {CKM_AES_CMAC, PK11_MECH},
+
+/* CKM_GENERIC_SECRET_KEY_GEN stub for additional keys. */
+/* 71 */    {CKM_GENERIC_SECRET_KEY_GEN, PK11_MECH},
+
 /* REMEMBER TO UPDATE NUM_ALGS!!! (in Algorithm.h) */
 };
 

--- a/org/mozilla/jss/crypto/Algorithm.h
+++ b/org/mozilla/jss/crypto/Algorithm.h
@@ -24,7 +24,7 @@ typedef struct JSS_AlgInfoStr {
     JSS_AlgType type;
 } JSS_AlgInfo;
 
-#define NUM_ALGS 71
+#define NUM_ALGS 72
 
 extern JSS_AlgInfo JSS_AlgTable[];
 extern CK_ULONG JSS_symkeyUsage[];

--- a/org/mozilla/jss/crypto/Algorithm.java
+++ b/org/mozilla/jss/crypto/Algorithm.java
@@ -244,4 +244,7 @@ public class Algorithm {
 
     // PKCS#11 AES-CMAC
     protected static final int CKM_AES_CMAC=70;
+
+    // Generic Secret
+    protected static final int CKM_GENERIC_SECRET_KEY_GEN=71;
 }

--- a/org/mozilla/jss/crypto/KeyGenAlgorithm.java
+++ b/org/mozilla/jss/crypto/KeyGenAlgorithm.java
@@ -32,6 +32,14 @@ public class KeyGenAlgorithm extends Algorithm {
         }
     }
 
+    protected static class AnyKeyStrengthValidator
+            implements KeyStrengthValidator
+    {
+        public boolean isValidKeyStrength(int strength) {
+            return true;
+        }
+    }
+
     protected KeyGenAlgorithm(int oidTag, String name,
             KeyStrengthValidator keyStrengthValidator,
             OBJECT_IDENTIFIER oid, Class<?> paramClass)
@@ -78,6 +86,16 @@ public class KeyGenAlgorithm extends Algorithm {
     public boolean isValidStrength(int strength) {
         return keyStrengthValidator.isValidKeyStrength(strength);
     }
+
+    //////////////////////////////////////////////////////////////
+    public static final KeyGenAlgorithm
+    GENERIC_SECRET = new KeyGenAlgorithm(
+        CKM_GENERIC_SECRET_KEY_GEN,
+        "GenericSecret",
+        new AnyKeyStrengthValidator(),
+        null,
+        null
+    );
 
     //////////////////////////////////////////////////////////////
     public static final KeyGenAlgorithm

--- a/org/mozilla/jss/crypto/SymmetricKey.java
+++ b/org/mozilla/jss/crypto/SymmetricKey.java
@@ -4,12 +4,15 @@
 package org.mozilla.jss.crypto;
 
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Hashtable;
 
 import org.mozilla.jss.pkcs11.PKCS11Constants;
+import org.mozilla.jss.pkcs11.KeyType;
 
 public interface SymmetricKey extends javax.crypto.SecretKey {
 
+    public static final Type GENERIC_SECRET = Type.GENERIC_SECRET;
     public static final Type DES = Type.DES;
     public static final Type DES3 = Type.DES3;
     public static final Type RC4 = Type.RC4;
@@ -52,35 +55,43 @@ public interface SymmetricKey extends javax.crypto.SecretKey {
     public final static class Type {
         // all names converted to lowercase for case insensitivity
         private static Hashtable<String, Type> nameMap = new Hashtable<>();
+        private static ArrayList<Type> allTypes = new ArrayList<>();
 
         private String[] names;
         private KeyGenAlgorithm keyGenAlg;
+        private KeyType keyType;
+
         private Type() { }
-        private Type(String[] names, KeyGenAlgorithm keyGenAlg) {
+        private Type(String[] names, KeyGenAlgorithm keyGenAlg, KeyType keyType) {
             this.names = names;
             this.keyGenAlg = keyGenAlg;
+            this.keyType = keyType;
 
             for (String name : names) {
                 nameMap.put(name.toLowerCase(), this);
             }
+
+            allTypes.add(this);
         }
-        public static final Type DES = new Type(new String[]{ "DES" }, KeyGenAlgorithm.DES);
+
+        public static final Type GENERIC_SECRET = new Type(new String[]{ "GenericSecret", "GENERIC_SECRET" }, KeyGenAlgorithm.GENERIC_SECRET, KeyType.GENERIC_SECRET);
+        public static final Type DES = new Type(new String[]{ "DES" }, KeyGenAlgorithm.DES, KeyType.DES);
         public static final Type DES3 =
-            new Type(new String[] { "DESede", "TDES", "3DES", "DES3" }, KeyGenAlgorithm.DES3);
+            new Type(new String[] { "DESede", "TDES", "3DES", "DES3" }, KeyGenAlgorithm.DES3, KeyType.DES3);
         public static final Type DESede = DES3;
-        public static final Type RC4 = new Type(new String[]{ "RC4" }, KeyGenAlgorithm.RC4);
-        public static final Type RC2 = new Type(new String[]{ "RC2" }, KeyGenAlgorithm.RC2);
+        public static final Type RC4 = new Type(new String[]{ "RC4" }, KeyGenAlgorithm.RC4, KeyType.RC4);
+        public static final Type RC2 = new Type(new String[]{ "RC2" }, KeyGenAlgorithm.RC2, KeyType.RC4);
         public static final Type SHA1_HMAC = new Type(new String[]{ "SHA1_HMAC", "SHA1-HMAC", "SHA1HMAC", "HMAC_SHA1", "HMAC-SHA1", "HMACSHA1" },
-            KeyGenAlgorithm.SHA1_HMAC);
+            KeyGenAlgorithm.SHA1_HMAC, KeyType.SHA1_HMAC);
         public static final Type SHA256_HMAC = new Type(new String[]{ "SHA256_HMAC", "SHA256-HMAC", "SHA256HMAC", "HMAC_SHA256", "HMAC-SHA256", "HMACSHA256" },
-            KeyGenAlgorithm.SHA256_HMAC);
+            KeyGenAlgorithm.SHA256_HMAC, null);
         public static final Type SHA384_HMAC = new Type(new String[]{ "SHA384_HMAC", "SHA384-HMAC", "SHA384HMAC", "HMAC_SHA384", "HMAC-SHA384", "HMACSHA384" },
-            KeyGenAlgorithm.SHA384_HMAC);
+            KeyGenAlgorithm.SHA384_HMAC, null);
         public static final Type SHA512_HMAC = new Type(new String[]{ "SHA512_HMAC", "SHA512-HMAC", "SHA512HMAC", "HMAC_SHA512", "HMAC-SHA512", "HMACSHA512" },
-            KeyGenAlgorithm.SHA512_HMAC);
+            KeyGenAlgorithm.SHA512_HMAC, null);
         public static final Type PBA_SHA1_HMAC = new Type(new String[]{ "PBA_SHA1_HMAC" },
-            KeyGenAlgorithm.PBA_SHA1_HMAC);
-        public static final Type AES = new Type(new String[]{ "AES" }, KeyGenAlgorithm.AES);
+            KeyGenAlgorithm.PBA_SHA1_HMAC, null);
+        public static final Type AES = new Type(new String[]{ "AES" }, KeyGenAlgorithm.AES, KeyType.AES);
 
 
         public String toString() {
@@ -92,21 +103,35 @@ public interface SymmetricKey extends javax.crypto.SecretKey {
         }
 
         public KeyGenAlgorithm getKeyGenAlg() throws NoSuchAlgorithmException {
-            if( keyGenAlg == null ) {
+            if (keyGenAlg == null) {
                 throw new NoSuchAlgorithmException(names[0]);
             }
             return keyGenAlg;
+        }
+
+        public KeyType getKeyType() {
+            return keyType;
         }
 
         public static Type fromName(String name)
                 throws NoSuchAlgorithmException
         {
             Object type = nameMap.get(name.toLowerCase());
-            if( type == null ) {
+            if (type == null) {
                 throw new NoSuchAlgorithmException();
             } else {
                 return (Type) type;
             }
+        }
+
+        public static Type fromKeyType(KeyType type)
+        {
+            for (Type current : allTypes) {
+                if (current.getKeyType() == type) {
+                    return current;
+                }
+            }
+            return null;
         }
     }
 

--- a/org/mozilla/jss/pkcs11/PK11SymKey.java
+++ b/org/mozilla/jss/pkcs11/PK11SymKey.java
@@ -29,22 +29,13 @@ public final class PK11SymKey implements SymmetricKey {
 
     public SymmetricKey.Type getType() {
         KeyType kt = getKeyType();
-        if(kt == KeyType.DES) {
-            return DES;
-        } else if(kt == KeyType.DES3) {
-            return DES3;
-        } else if(kt == KeyType.RC4) {
-            return RC4;
-        } else if(kt == KeyType.RC2) {
-            return RC2;
-        } else if(kt == KeyType.AES) {
-            return AES;
-        } else if(kt == KeyType.SHA1_HMAC) {
-            return SHA1_HMAC;
-        } else {
+
+        SymmetricKey.Type result = SymmetricKey.Type.fromKeyType(kt);
+        if (result == null) {
             throw new RuntimeException("Unrecognized key type: " + kt);
-            // return DES;
         }
+
+        return result;
     }
 
     public native CryptoToken getOwningToken();

--- a/org/mozilla/jss/provider/javax/crypto/JSSSecretKeyFactorySpi.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSSecretKeyFactorySpi.java
@@ -428,4 +428,9 @@ class JSSSecretKeyFactorySpi extends SecretKeyFactorySpi {
         }
     }
 
+    public static class GenericSecret extends JSSSecretKeyFactorySpi {
+        public GenericSecret() {
+            super(KeyGenAlgorithm.GENERIC_SECRET);
+        }
+    }
 }


### PR DESCRIPTION
Unlike other key types, a `CKK_GENERIC_SECRET` isn't limited to a single
algorithm. This requires support in JSS Provider for such keys.

This also refactors handling of `SecretKey.Type` to map them to
`jss.pkcs11.KeyTypes`.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`