### PR TITLE
Switch SHA2/HMAC to PKCS#11 interface

### DIFF
--- a/org/mozilla/jss/crypto/HMACAlgorithm.java
+++ b/org/mozilla/jss/crypto/HMACAlgorithm.java
@@ -58,15 +58,15 @@ public class HMACAlgorithm extends DigestAlgorithm {
              OBJECT_IDENTIFIER.ALGORITHM.subBranch(26), 20);
 
     public static final HMACAlgorithm SHA256 = new HMACAlgorithm
-        (SEC_OID_HMAC_SHA256, "SHA-256-HMAC",
+        (CKM_SHA256_HMAC, "SHA-256-HMAC",
              OBJECT_IDENTIFIER.RSA_DIGEST.subBranch(9), 32);
 
     public static final HMACAlgorithm SHA384 = new HMACAlgorithm
-        (SEC_OID_HMAC_SHA384, "SHA-384-HMAC",
+        (CKM_SHA384_HMAC, "SHA-384-HMAC",
              OBJECT_IDENTIFIER.RSA_DIGEST.subBranch(10), 48);
 
     public static final HMACAlgorithm SHA512 = new HMACAlgorithm
-        (SEC_OID_HMAC_SHA512, "SHA-512-HMAC",
+        (CKM_SHA512_HMAC, "SHA-512-HMAC",
              OBJECT_IDENTIFIER.RSA_DIGEST.subBranch(11), 64);
 
 }


### PR DESCRIPTION
This enables the new KBKDF mechanisms to specify the underlying MAC
algorithm by using high-level instances (of `CMACAlgorithm` and
`HMACAlgorithm`). However, all of these need to be PKCS#11 interface and
can't be `SEC_OID`s.

---

Note that `CKM_*_HMAC` were already added to `Algorithm.{c,Java}`, so this just switches over to using it.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`