### PR TITLE
Handle MIME-encoded Base64 in base64decode

### DIFF
--- a/org/mozilla/jss/netscape/security/pkcs/PKCS7.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS7.java
@@ -31,7 +31,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.Base64;
 import java.util.Vector;
 
 import org.mozilla.jss.netscape.security.util.Utils;
@@ -166,7 +165,7 @@ public class PKCS7 {
             }
         }
 
-        byte[] bytes = Base64.getDecoder().decode(sb.toString());
+        byte[] bytes = Utils.base64decode(sb.toString());
         parse(new DerInputStream(bytes));
     }
 

--- a/org/mozilla/jss/netscape/security/util/Utils.java
+++ b/org/mozilla/jss/netscape/security/util/Utils.java
@@ -395,7 +395,7 @@ public class Utils {
      * @return byte array
      */
     public static byte[] base64decode(String string) {
-        return Base64.getDecoder().decode(string);
+        return Base64.getMimeDecoder().decode(string);
     }
 
     /**


### PR DESCRIPTION
`jss.netscape.security.util.Utils.base64decode` previously could accept
MIME-encoded Base64 because Apache Commons Codec didn't care about the
difference. In 8de4440c5652f6f1af5b4b923a15730ba84f29e1, support was
erroneously removed. This commit re-introduces support.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`