### PR TITLE
Pass NSS error on CryptoManager initialization

### DIFF
--- a/org/mozilla/jss/CryptoManager.c
+++ b/org/mozilla/jss/CryptoManager.c
@@ -455,7 +455,7 @@ Java_org_mozilla_jss_CryptoManager_initializeAllNative2
     }
 
     if( rv != SECSuccess ) {
-        JSS_throwMsg(env, SECURITY_EXCEPTION,
+        JSS_throwMsgPrErr(env, SECURITY_EXCEPTION,
             "Unable to initialize security library");
         goto finish;
     }


### PR DESCRIPTION
When the `CryptoManager` fails to initialize, we throw an exception. This
should include the underlying NSS error, when available, so use
`JSS_throwMsgPrErr` instead of `JSS_throwMsg`.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`