### PR TITLE
Workaround: NSS FIPS-mode TLS 1.3 Client Auth

### DIFF
--- a/org/mozilla/jss/tests/SSLClientAuth.java
+++ b/org/mozilla/jss/tests/SSLClientAuth.java
@@ -241,6 +241,7 @@ public class SSLClientAuth implements Runnable {
             SSLSocket.enableSSL2Default(false);
             SSLSocket.enableSSL3Default(false);
             /* TLS is enabled by default */
+            SSLSocket.setSSLVersionRangeDefault(SSLProtocolVariant.STREAM, new SSLVersionRange(SSLVersionRange.tls1_2, SSLVersionRange.tls1_2));
 
             /* Enable Session tickets by default */
             SSLSocket.enableSessionTicketsDefault(true);


### PR DESCRIPTION
TLS 1.3 client authentication is broken in NSS when run under FIPS mode.
Bound the maximum TLS version number to TLS 1.2 until this is fixed.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`