### PR TITLE
SSL Alert Handling

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -401,6 +401,7 @@ Java_org_mozilla_jss_CryptoManager_importDERCertNative;
 Java_org_mozilla_jss_nss_SSL_AttachClientCertCallback;
 Java_org_mozilla_jss_CryptoManager_getJSSDebug;
 Java_org_mozilla_jss_util_GlobalRefProxy_releaseNativeResources;
+Java_org_mozilla_jss_nss_SSL_EnableAlertLoggingNative;
     local:
         *;
 };

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -440,6 +440,33 @@ Java_org_mozilla_jss_nss_SSL_AttachClientCertCallback(JNIEnv *env, jclass clazz,
 }
 
 JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_EnableAlertLoggingNative(JNIEnv *env, jclass clazz,
+    jobject fd)
+{
+    PRFileDesc *real_fd = NULL;
+    jobject fd_ref = NULL;
+    SECStatus ret = SECFailure;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return ret;
+    }
+
+    if (JSS_NSS_addGlobalRef(env, fd, &fd_ref) != PR_SUCCESS) {
+        return ret;
+    }
+
+    ret = SSL_AlertReceivedCallback(real_fd, JSSL_SSLFDAlertReceivedCallback, fd_ref);
+    if (ret != SECSuccess) {
+        return ret;
+    }
+
+    ret = SSL_AlertSentCallback(real_fd, JSSL_SSLFDAlertSentCallback, fd_ref);
+    return ret;
+}
+
+JNIEXPORT jint JNICALL
 Java_org_mozilla_jss_nss_SSL_getSSLRequestCertificate(JNIEnv *env, jclass clazz)
 {
     return SSL_REQUEST_CERTIFICATE;

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -5,9 +5,12 @@ package org.mozilla.jss.nss;
  * and handles the usage of NativeProxy objects.
  */
 
+import java.util.ArrayList;
+
 import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.pkcs11.PK11PrivKey;
 
+import org.mozilla.jss.ssl.SSLAlertEvent;
 import org.mozilla.jss.ssl.SSLVersionRange;
 
 public class SSL {
@@ -187,6 +190,24 @@ public class SSL {
      *           org.mozilla.jss.nss.SSLFDProxy.SetClientCert(...)
      */
     public static native int AttachClientCertCallback(SSLFDProxy fd) throws Exception;
+
+    /**
+     * Enable recording of alerts in the SSLFDProxy object.
+     *
+     * See also: SSL_AlertReceivedCallback in /usr/include/nss3/ssl.h,
+     *           SSL_AlertSentCallback in /usr/include/nss3/ssl.h
+     */
+    public static int EnableAlertLogging(SSLFDProxy fd) {
+        fd.inboundAlerts = new ArrayList<SSLAlertEvent>();
+        fd.inboundOffset = 0;
+        fd.outboundAlerts = new ArrayList<SSLAlertEvent>();
+        fd.outboundOffset = 0;
+
+        return EnableAlertLoggingNative(fd);
+    }
+
+    /* Internal helper for EnableAlertLogging method. */
+    private static native int EnableAlertLoggingNative(SSLFDProxy fd);
 
     /* Internal methods for querying constants. */
     private static native int getSSLRequestCertificate();

--- a/org/mozilla/jss/nss/SSLFDProxy.c
+++ b/org/mozilla/jss/nss/SSLFDProxy.c
@@ -8,6 +8,7 @@
 #include "jssutil.h"
 #include "pk11util.h"
 #include "SSLFDProxy.h"
+#include "GlobalRefProxy.h"
 
 PRStatus
 JSS_NSS_getSSLClientCert(JNIEnv *env, jobject sslfd_proxy, CERTCertificate **cert)
@@ -41,6 +42,218 @@ JSS_NSS_getSSLClientCert(JNIEnv *env, jobject sslfd_proxy, CERTCertificate **cer
     /* Get the underlying CERTCertificate pointer from the clientCert
      * (of type PK11Cert) object. */
     return JSS_PK11_getCertPtr(env, certProxy, cert);
+}
+
+static PRStatus
+JSS_NSS_getEventArrayList(JNIEnv *env, jobject sslfd_proxy, const char *which, jobject *list)
+{
+    jclass sslfdProxyClass;
+    jfieldID eventArrayListField;
+
+    PR_ASSERT(env != NULL && sslfd_proxy != NULL && list != NULL);
+
+    sslfdProxyClass = (*env)->GetObjectClass(env, sslfd_proxy);
+    if (sslfdProxyClass == NULL) {
+        return PR_FAILURE;
+    }
+
+    eventArrayListField = (*env)->GetFieldID(env, sslfdProxyClass, which,
+                                             SSLFD_PROXY_EVENT_LIST_SIG);
+    if (eventArrayListField == NULL) {
+        /* Unlike JSS_NSS_getSSLClientCert above, this is a failure to process
+         * the event. We expect the  */
+        return PR_FAILURE;
+    }
+
+    *list = (*env)->GetObjectField(env, sslfd_proxy, eventArrayListField);
+    if (*list == NULL) {
+        return PR_FAILURE;
+    }
+
+    return PR_SUCCESS;
+}
+
+PRStatus
+JSS_NSS_getSSLAlertReceivedList(JNIEnv *env, jobject sslfd_proxy, jobject *list)
+{
+    return JSS_NSS_getEventArrayList(env, sslfd_proxy, "inboundAlerts", list);
+}
+
+PRStatus
+JSS_NSS_getSSLAlertSentList(JNIEnv *env, jobject sslfd_proxy, jobject *list)
+{
+    return JSS_NSS_getEventArrayList(env, sslfd_proxy, "outboundAlerts", list);
+}
+
+PRStatus
+JSS_NSS_addGlobalRef(JNIEnv *env, jobject sslfd_proxy, jobject *global_ref)
+{
+    jclass sslfdProxyClass;
+    jfieldID globalRefField;
+    jobject globalRefElem;
+
+    if (JSS_getPtrFromProxyOwner(env, sslfd_proxy, "globalRef",
+                                 "L" GLOBAL_REF_PROXY_CLASS_NAME ";",
+                                 (void **)global_ref) == PR_FAILURE) {
+        /* We assume we failed because we don't yet have a global reference
+         * to this SSLFDProxy object. Create one. */
+        (*env)->ExceptionClear(env);
+
+        sslfdProxyClass = (*env)->GetObjectClass(env, sslfd_proxy);
+        if (sslfdProxyClass == NULL) {
+            return PR_FAILURE;
+        }
+
+        globalRefField = (*env)->GetFieldID(env, sslfdProxyClass, "globalRef",
+                                            "L" GLOBAL_REF_PROXY_CLASS_NAME ";");
+        if (globalRefField == NULL) {
+            return PR_FAILURE;
+        }
+
+        *global_ref = (*env)->NewGlobalRef(env, sslfd_proxy);
+
+        globalRefElem = JSS_PR_wrapGlobalRef(env, global_ref);
+
+        (*env)->SetObjectField(env, sslfd_proxy, globalRefField, globalRefElem);
+    }
+
+    return PR_SUCCESS;
+}
+
+void
+JSS_NSS_removeGlobalRef(JNIEnv *env, jobject sslfd_proxy)
+{
+    jclass sslfdProxyClass;
+    jfieldID globalRefField;
+
+    jobject globalRefElem;
+    jclass globalRefClass;
+    jmethodID globalRefClose;
+
+    sslfdProxyClass = (*env)->GetObjectClass(env, sslfd_proxy);
+    if (sslfdProxyClass == NULL) {
+        return;
+    }
+
+    globalRefField = (*env)->GetFieldID(env, sslfdProxyClass, "globalRef",
+                                        NATIVE_PROXY_CLASS_NAME);
+    if (globalRefField == NULL) {
+        return;
+    }
+
+    globalRefElem = (*env)->GetObjectField(env, sslfd_proxy, globalRefField);
+    if (globalRefElem == NULL) {
+        return;
+    }
+
+    globalRefClass = (*env)->GetObjectClass(env, globalRefElem);
+    if (globalRefClass == NULL) {
+        return;
+    }
+
+    globalRefClose = (*env)->GetMethodID(env, globalRefClass, "close", "()V");
+    if (globalRefClose == NULL) {
+        return;
+    }
+
+    (*env)->CallVoidMethod(env, globalRefElem, globalRefClose);
+}
+
+PRStatus
+JSS_NSS_addSSLAlert(JNIEnv *env, jobject sslfd_proxy, jobject list,
+    const SSLAlert *alert)
+{
+    jclass eventClass;
+    jmethodID eventConstructor;
+    jobject event;
+
+    jclass eventListClass;
+    jmethodID arrayListAdd;
+
+    PR_ASSERT(env != NULL && sslfd_proxy != NULL && list != NULL && alert != NULL);
+
+    /* Build the new alert event object (org.mozilla.jss.ssl.SSLAlertEvent). */
+    eventClass = (*env)->FindClass(env, SSL_ALERT_EVENT_CLASS);
+    if (eventClass == NULL) {
+        return PR_FAILURE;
+    }
+
+    eventConstructor = (*env)->GetMethodID(env, eventClass, "<init>",
+                                           "(L" SSLFD_PROXY_CLASS_NAME ";II)V");
+    if (eventConstructor == NULL) {
+        return PR_FAILURE;
+    }
+
+    event = (*env)->NewObject(env, eventClass, eventConstructor,
+                              sslfd_proxy, (int)alert->level,
+                              (int)alert->description);
+    if (event == NULL) {
+        return PR_FAILURE;
+    }
+
+    /* Add it to the event list. */
+    eventListClass = (*env)->GetObjectClass(env, list);
+    if (eventListClass == NULL) {
+        return PR_FAILURE;
+    }
+
+    arrayListAdd = (*env)->GetMethodID(env, eventListClass, "add",
+                                       "(L" SSL_ALERT_EVENT_CLASS ";)B");
+    if (arrayListAdd == NULL) {
+        return PR_FAILURE;
+    }
+
+    // We ignore the return code: ArrayList.add() always returns true.
+    (void)(*env)->CallBooleanMethod(env, list, arrayListAdd, event);
+    return PR_SUCCESS;
+}
+
+void
+JSSL_SSLFDAlertReceivedCallback(const PRFileDesc *fd, void *arg, const SSLAlert *alert)
+{
+    JNIEnv *env;
+    jobject sslfd_proxy = (jobject)arg;
+    jobject list;
+
+    if (fd == NULL || arg == NULL || alert == NULL) {
+        return;
+    }
+
+    if ((*JSS_javaVM)->AttachCurrentThread(JSS_javaVM, (void**)&env, NULL) != JNI_OK || env != NULL) {
+        return;
+    }
+
+    if (JSS_NSS_getSSLAlertReceivedList(env, sslfd_proxy, &list) != PR_SUCCESS) {
+        return;
+    }
+
+    if (JSS_NSS_addSSLAlert(env, sslfd_proxy, list, alert) != PR_SUCCESS) {
+        return;
+    }
+}
+
+void
+JSSL_SSLFDAlertSentCallback(const PRFileDesc *fd, void *arg, const SSLAlert *alert)
+{
+    JNIEnv *env;
+    jobject sslfd_proxy = (jobject)arg;
+    jobject list;
+
+    if (fd == NULL || arg == NULL || alert == NULL) {
+        return;
+    }
+
+    if ((*JSS_javaVM)->AttachCurrentThread(JSS_javaVM, (void**)&env, NULL) != JNI_OK || env != NULL) {
+        return;
+    }
+
+    if (JSS_NSS_getSSLAlertSentList(env, sslfd_proxy, &list) != PR_SUCCESS) {
+        return;
+    }
+
+    if (JSS_NSS_addSSLAlert(env, sslfd_proxy, list, alert) != PR_SUCCESS) {
+        return;
+    }
 }
 
 SECStatus
@@ -84,3 +297,9 @@ JSSL_SSLFDCertSelectionCallback(void *arg,
     return SECSuccess;
 }
 
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_nss_SSLFDProxy_releaseNativeResources
+    (JNIEnv *env, jobject this)
+{
+    JSS_NSS_removeGlobalRef(env, this);
+}

--- a/org/mozilla/jss/nss/SSLFDProxy.h
+++ b/org/mozilla/jss/nss/SSLFDProxy.h
@@ -6,6 +6,22 @@
 
 PRStatus JSS_NSS_getSSLClientCert(JNIEnv *env, jobject sslfd_proxy, CERTCertificate **cert);
 
+PRStatus JSS_NSS_getSSLAlertSentList(JNIEnv *env, jobject sslfd_proxy, jobject *list);
+
+PRStatus JSS_NSS_getSSLAlertReceivedList(JNIEnv *env, jobject sslfd_proxy, jobject *list);
+
+PRStatus JSS_NSS_addSSLAlert(JNIEnv *env, jobject sslfd_proxy, jobject list, const SSLAlert *alert);
+
+PRStatus JSS_NSS_addGlobalRef(JNIEnv *env, jobject sslfd_proxy, jobject *global_ref);
+
+void JSS_NSS_removeGlobalRef(JNIEnv *env, jobject sslfd_proxy);
+
+void
+JSSL_SSLFDAlertReceivedCallback(const PRFileDesc *fd, void *arg, const SSLAlert *alert);
+
+void
+JSSL_SSLFDAlertSentCallback(const PRFileDesc *fd, void *arg, const SSLAlert *alert);
+
 SECStatus
 JSSL_SSLFDCertSelectionCallback(void *arg,
                                 PRFileDesc *fd,

--- a/org/mozilla/jss/nss/SSLFDProxy.java
+++ b/org/mozilla/jss/nss/SSLFDProxy.java
@@ -1,12 +1,22 @@
 package org.mozilla.jss.nss;
 
 import java.lang.IllegalArgumentException;
+import java.util.ArrayList;
 
 import org.mozilla.jss.crypto.X509Certificate;
 import org.mozilla.jss.pkcs11.PK11Cert;
+import org.mozilla.jss.ssl.SSLAlertEvent;
+import org.mozilla.jss.util.GlobalRefProxy;
 
 public class SSLFDProxy extends PRFDProxy {
     public PK11Cert clientCert;
+    public GlobalRefProxy globalRef;
+
+    public ArrayList<SSLAlertEvent> inboundAlerts;
+    public int inboundOffset;
+
+    public ArrayList<SSLAlertEvent> outboundAlerts;
+    public int outboundOffset;
 
     public SSLFDProxy(byte[] pointer) {
         super(pointer);

--- a/org/mozilla/jss/util/jssutil.c
+++ b/org/mozilla/jss/util/jssutil.c
@@ -305,8 +305,11 @@ JSS_getPtrFromProxyOwner(JNIEnv *env, jobject proxyOwner, char* proxyFieldName,
     if(proxyField == NULL) {
         return PR_FAILURE;
     }
+
     proxyObject = (*env)->GetObjectField(env, proxyOwner, proxyField);
-    PR_ASSERT(proxyObject != NULL);
+    if (proxyObject == NULL) {
+        return PR_FAILURE;
+    }
 
     /*
      * Get the pointer from the Native Reference object


### PR DESCRIPTION
This PR enables asynchronous access to SSL Alerts events from NSS. When the `JSSL_SSLFDAlertReceivedCallback` callback is triggered, it looks up the `inboundAlerts` member of the `SSLFDProxy` and appends the new alert.