### PR TITLE
Enable SSLAlertEvent to raise SSLExceptions

### DIFF
--- a/org/mozilla/jss/ssl/SSLAlertDescription.java
+++ b/org/mozilla/jss/ssl/SSLAlertDescription.java
@@ -4,55 +4,70 @@
 
 package org.mozilla.jss.ssl;
 
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLProtocolException;
+
 public enum SSLAlertDescription {
 
     // see lib/ssl/ssl3prot.h in NSS
     CLOSE_NOTIFY                    (0),
     END_OF_EARLY_DATA               (1), // TLS 1.3
-    UNEXPECTED_MESSAGE              (10),
-    BAD_RECORD_MAC                  (20),
-    DECRYPTION_FAILED               (21), // RFC 5246
-    RECORD_OVERFLOW                 (22), // TLS only
-    DECOMPRESSION_FAILURE           (30),
-    HANDSHAKE_FAILURE               (40),
-    NO_CERTIFICATE                  (41), // SSL3 only, NOT TLS
-    BAD_CERTIFICATE                 (42),
-    UNSUPPORTED_CERTIFICATE         (43),
-    CERTIFICATE_REVOKED             (44),
-    CERTIFICATE_EXPIRED             (45),
-    CERTIFICATE_UNKNOWN             (46),
-    ILLEGAL_PARAMETER               (47),
+    UNEXPECTED_MESSAGE              (10, SSLProtocolException.class),
+    BAD_RECORD_MAC                  (20, SSLProtocolException.class),
+    DECRYPTION_FAILED               (21, SSLProtocolException.class), // RFC 5246
+    RECORD_OVERFLOW                 (22, SSLProtocolException.class), // TLS only
+    DECOMPRESSION_FAILURE           (30, SSLProtocolException.class),
+    HANDSHAKE_FAILURE               (40, SSLHandshakeException.class),
+    NO_CERTIFICATE                  (41, SSLPeerUnverifiedException.class), // SSL3 only, NOT TLS
+    BAD_CERTIFICATE                 (42, SSLPeerUnverifiedException.class),
+    UNSUPPORTED_CERTIFICATE         (43, SSLPeerUnverifiedException.class),
+    CERTIFICATE_REVOKED             (44, SSLPeerUnverifiedException.class),
+    CERTIFICATE_EXPIRED             (45, SSLPeerUnverifiedException.class),
+    CERTIFICATE_UNKNOWN             (46, SSLPeerUnverifiedException.class),
+    ILLEGAL_PARAMETER               (47, SSLProtocolException.class),
 
     // All alerts below are TLS only.
-    UNKNOWN_CA                      (48),
-    ACCESS_DENIED                   (49),
-    DECODE_ERROR                    (50),
-    DECRYPT_ERROR                   (51),
-    EXPORT_RESTRICTION              (60),
-    PROTOCOL_VERSION                (70),
-    INSUFFICIENT_SECURITY           (71),
-    INTERNAL_ERROR                  (80),
-    INAPPROPRIATE_FALLBACK          (86), // could also be sent for SSLv3
-    USER_CANCELED                   (90),
-    NO_RENEGOTIATION                (100),
+    UNKNOWN_CA                      (48, SSLPeerUnverifiedException.class),
+    ACCESS_DENIED                   (49, SSLHandshakeException.class),
+    DECODE_ERROR                    (50, SSLProtocolException.class),
+    DECRYPT_ERROR                   (51, SSLProtocolException.class),
+    EXPORT_RESTRICTION              (60, SSLHandshakeException.class),
+    PROTOCOL_VERSION                (70, SSLHandshakeException.class),
+    INSUFFICIENT_SECURITY           (71, SSLHandshakeException.class),
+    INTERNAL_ERROR                  (80, SSLProtocolException.class),
+    INAPPROPRIATE_FALLBACK          (86, SSLProtocolException.class), // could also be sent for SSLv3
+    USER_CANCELED                   (90, SSLProtocolException.class),
+    NO_RENEGOTIATION                (100, SSLHandshakeException.class),
 
     // Alerts for client hello extensions
-    MISSING_EXTENSION               (109),
-    UNSUPPORTED_EXTENSION           (110),
-    CERTIFICATE_UNOBTAINABLE        (111),
-    UNRECOGNIZED_NAME               (112),
-    BAD_CERTIFICATE_STATUS_RESPONSE (113),
-    BAD_CERTIFICATE_HASH_VALUE      (114),
-    NO_APPLICATION_PROTOCOL         (120);
+    MISSING_EXTENSION               (109, SSLHandshakeException.class),
+    UNSUPPORTED_EXTENSION           (110, SSLHandshakeException.class),
+    CERTIFICATE_UNOBTAINABLE        (111, SSLPeerUnverifiedException.class),
+    UNRECOGNIZED_NAME               (112, SSLHandshakeException.class),
+    BAD_CERTIFICATE_STATUS_RESPONSE (113, SSLPeerUnverifiedException.class),
+    BAD_CERTIFICATE_HASH_VALUE      (114, SSLPeerUnverifiedException.class),
+    NO_APPLICATION_PROTOCOL         (120, SSLHandshakeException.class);
 
     private int id;
+    private Class<? extends SSLException> exception;
 
     private SSLAlertDescription(int id) {
         this.id = id;
     }
 
+    private SSLAlertDescription(int id, Class exception) {
+        this(id);
+        this.exception = exception;
+    }
+
     public int getID() {
         return id;
+    }
+
+    public Class<? extends SSLException> getExceptionClass() {
+        return exception;
     }
 
     public static SSLAlertDescription valueOf(int id) {


### PR DESCRIPTION
When using `SSLAlertEvents` inside an `SSLEngine`, we need to raise a
`SSLException` of the correct type. There's one issue here though:

While we could add support for telling if this is an inbound or
an outbound alert, we don't know _what_ caused said alert (because
NSS created it) -- an issue on the client or an issue on the server.
This means that we can't report a `SSLKeyException` and only report
`SSLProtocolExceptions`.

Considering NSS is the one sending the alert, and we're just exposing
it happened to the calling `SSLEngine`, this is a fine trade-off.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

--- 

Note that most of the time that a `SSLKeyException` would occur, it could've been detected sooner, when the key is provided to the `SSLEngine` itself and raised as an IllegalArgumentException. I think one of the few times is when the peer rejects our key. I'm not sure that'll matter much. Thoughts? 