### PR TITLE
Add GitHub actions for required jobs

### DIFF
--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -1,0 +1,53 @@
+name: Optional Tests
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  pkcs11check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "pkcs11check" || echo "::warning ::Job exited with status $?"
+  debian_jdk11:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "debian_jdk11" || echo "::warning ::Job exited with status $?"
+  ubuntu_jdk8:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "ubuntu_jdk8" || echo "::warning ::Job exited with status $?"
+  fedora_29_jdk11:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "fedora_29_jdk11" || echo "::warning ::Job exited with status $?"
+  fedora_rawhide:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "fedora_rawhide" || echo "::warning ::Job exited with status $?"
+  fedora_sandbox:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "fedora_sandbox" || echo "::warning ::Job exited with status $?"

--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -1,0 +1,25 @@
+name: Required Tests
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  fedora30:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "fedora_30"
+  fedora31:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "fedora_31"


### PR DESCRIPTION
This fully replaces our `.travis.yml` configuration. After this, we can remove Travis from JSS if we desire.

Thoughts? I didn't look closely at matrix like features (like we have in our Travis script) but we could if desired.

I also didn't look to see if there was a better way to annotate failed (optional) tests. You can see this in the PKCS#11 Constants test: it displays a little warning when you expand the "Build and Run the Docker Image" step, but other than that, there's no obvious way to see that the optional job "failed" (while still reporting it succeeds to GitHub...). These are more informative than required jobs. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`