### PR TITLE
Fix handling of global_ref_proxy

### DIFF
--- a/org/mozilla/jss/CryptoManager.c
+++ b/org/mozilla/jss/CryptoManager.c
@@ -200,7 +200,7 @@ static jobject globalPasswordCallback = NULL;
  * The Java virtual machine can be used to retrieve the JNI environment
  * pointer from callback functions.
  */
-JavaVM * JSS_javaVM;
+JavaVM * JSS_javaVM = NULL;
 
 JNIEXPORT void JNICALL
 Java_org_mozilla_jss_CryptoManager_initializeAllNative

--- a/org/mozilla/jss/util/GlobalRefProxy.c
+++ b/org/mozilla/jss/util/GlobalRefProxy.c
@@ -42,8 +42,6 @@ finish:
         (*env)->DeleteGlobalRef(env, *ref);
     }
 
-    *ref = NULL;
-
     PR_ASSERT(refObj || (*env)->ExceptionOccurred(env));
     return refObj;
 }


### PR DESCRIPTION
In JSS, a `GlobalRefProxy` stores a JNI global `jobject` reference, to allow
Java to clean it up later. This allows us to pass the ref to a NSS SSL
callback, assuming we promise to clean it up later (and not clean it up
before NSS is done with it!).

This fixes various issues with the handling of global references:

 - We needn't clear the value on successful storage, as we intend to
   continue using said reference.
 - We need to validate that the ref isn't `NULL`, when created.
 - We need to validate JSS_javaVM is non-`NULL` (so we can extract a
   JNI ENV reference).

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

-----

Aside: It turns out that handling of inbound/outbound alerts only impact alerts received after the handshake has completed. This is a small subset of fatal alert scenarios (most fatal alerts would happen during the course of the handshake), so it is less important. But, still worthwhile fixing. 