### PR TITLE
Fix client auth handling in JSSParameters

### DIFF
--- a/org/mozilla/jss/ssl/javax/JSSParameters.java
+++ b/org/mozilla/jss/ssl/javax/JSSParameters.java
@@ -44,11 +44,16 @@ public class JSSParameters extends SSLParameters {
         setProtocols(downcast.getProtocols());
         setAlgorithmConstraints(downcast.getAlgorithmConstraints());
         setEndpointIdentificationAlgorithm(downcast.getEndpointIdentificationAlgorithm());
-        setNeedClientAuth(downcast.getNeedClientAuth());
         setServerNames(downcast.getServerNames());
         setSNIMatchers(downcast.getSNIMatchers());
         setUseCipherSuitesOrder(downcast.getUseCipherSuitesOrder());
-        setWantClientAuth(downcast.getWantClientAuth());
+
+        if (downcast.getWantClientAuth()) {
+            setWantClientAuth(downcast.getWantClientAuth());
+        }
+        if (downcast.getNeedClientAuth()) {
+            setNeedClientAuth(downcast.getNeedClientAuth());
+        }
     }
 
     public JSSParameters(String[] cipherSuites) {


### PR DESCRIPTION
`SSLParameters` and `SSLEngine` impose an interesting duality between the
"want client auth" and "need client auth" options: they're mutually
exclusive (and setting one clears the other). This wasn't correctly
handled in `JSSParameters` because NSS has a different notion: requesting
peer auth and requiring peer auth.

Fix `JSSParameters` to align better with Java's expectations.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`