### PR TITLE
Fetch certificate by alias in JSSKeyManager

### DIFF
--- a/org/mozilla/jss/provider/javax/crypto/JSSKeyManager.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSKeyManager.java
@@ -69,6 +69,16 @@ public class JSSKeyManager implements X509KeyManager {
         return null;  // not implemented
     }
 
+    public org.mozilla.jss.crypto.X509Certificate getCertificate(String alias) {
+        try {
+            CryptoManager cm = CryptoManager.getInstance();
+            return cm.findCertByNickname(alias);
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public X509Certificate[] getCertificateChain(String alias) {
 


### PR DESCRIPTION
Expose functionality of `CryptoManager` in `JSSKeyManager`, allowing the
caller to fetch a certificate by alias (NSS DB's nickname).

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

Pulled out of #150.