### PR TITLE
Add SSLVersionRange to crypto.Policy

### DIFF
--- a/org/mozilla/jss/crypto/Policy.java
+++ b/org/mozilla/jss/crypto/Policy.java
@@ -2,6 +2,11 @@ package org.mozilla.jss.crypto;
 
 import java.math.BigInteger;
 
+import org.mozilla.jss.ssl.SSLProtocolVariant;
+import org.mozilla.jss.ssl.SSLSocket;
+import org.mozilla.jss.ssl.SSLVersion;
+import org.mozilla.jss.ssl.SSLVersionRange;
+
 /**
  * This class helps JSS callers align with local system cryptographic policy.
  *
@@ -28,6 +33,22 @@ public class Policy {
      * Minimum DSA key length in bits permitted by local policy.
      */
     public static int DSA_MINIMUM_KEY_SIZE = getDSAMinimumKeySize();
+
+    public static SSLVersionRange TLS_VERSION_RANGE = getTLSVersionRange();
+
+    public static SSLVersion TLS_MINIMUM_VERSION = TLS_VERSION_RANGE.getMinVersion();
+
+    public static SSLVersion TLS_MAXIMUM_VERSION = TLS_VERSION_RANGE.getMaxVersion();
+
+    private static SSLVersionRange getTLSVersionRange() {
+        SSLVersionRange range = new SSLVersionRange(SSLVersion.minSupported(),
+                                                    SSLVersion.maxSupported());
+        try {
+            return SSLSocket.boundSSLVersionRange(SSLProtocolVariant.STREAM, range);
+        } catch (Exception e) {
+            return range;
+        }
+    }
 
     private static native int getRSAMinimumKeySize();
     private static native int getDHMinimumKeySize();

--- a/org/mozilla/jss/ssl/SSLVersion.java
+++ b/org/mozilla/jss/ssl/SSLVersion.java
@@ -76,4 +76,19 @@ public enum SSLVersion {
         // find by name
         return SSLVersion.valueOf(alias);
     }
+
+    public static SSLVersion maxSupported() {
+        SSLVersion result = null;
+        for (SSLVersion v : SSLVersion.values()) {
+            if (result == null || v.compareTo(result) > 0) {
+                result = v;
+            }
+        }
+
+        return result;
+    }
+
+    public static SSLVersion minSupported() {
+        return SSLVersion.TLS_1_0;
+    }
 }

--- a/org/mozilla/jss/ssl/SSLVersionRange.java
+++ b/org/mozilla/jss/ssl/SSLVersionRange.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.jss.ssl;
 
+import java.util.ArrayList;
+
 public class SSLVersionRange {
 
     private SSLVersion minVersion;
@@ -78,4 +80,20 @@ public class SSLVersionRange {
      * @return enumeration value
      */
     public int getMaxEnum() { return maxVersion.value(); }
+
+    /**
+     * Gets all of the SSLVersions in this range, including endpoints.
+     *
+     * @return All SSLVersions in this range
+     */
+    public SSLVersion[] getAllInRange() {
+        ArrayList<SSLVersion> result = new ArrayList<SSLVersion>();
+        for (SSLVersion v : SSLVersion.values()) {
+            if (v.compareTo(this.minVersion) >= 0 && v.compareTo(this.maxVersion) <= 0) {
+                result.add(v);
+            }
+        }
+
+        return result.toArray(new SSLVersion[result.size()]);
+    }
 }


### PR DESCRIPTION
This lets users inquire about the supported TLS versions of their local
system policy, when applicable. Internally, this will be used by
`SSLEngine` to facilitate compliance with local policy.

When local policy isn't available, default to a range of
`[TLSv1.0, max(SSLVersion)]`.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`