### PR TITLE
Track SSLCipher supported status

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -430,6 +430,7 @@ Java_org_mozilla_jss_crypto_Policy_getRSAMinimumKeySize;
 Java_org_mozilla_jss_crypto_Policy_getDHMinimumKeySize;
 Java_org_mozilla_jss_crypto_Policy_getDSAMinimumKeySize;
 Java_org_mozilla_jss_nss_SSL_ConfigJSSDefaultCertAuthCallback;
+Java_org_mozilla_jss_ssl_SSLCipher_checkSupportedStatus;
     local:
         *;
 };

--- a/org/mozilla/jss/ssl/SSLCipher.c
+++ b/org/mozilla/jss/ssl/SSLCipher.c
@@ -1,0 +1,39 @@
+#include <nspr.h>
+#include <nss.h>
+#include <ssl.h>
+#include <pk11pub.h>
+#include <jni.h>
+
+#include "_jni/org_mozilla_jss_ssl_SSLCipher.h"
+
+JNIEXPORT jboolean JNICALL
+Java_org_mozilla_jss_ssl_SSLCipher_checkSupportedStatus(JNIEnv *env, jclass clazz, jint cipher_suite)
+{
+    SSLCipherSuiteInfo info = { 0 };
+    jboolean found = JNI_FALSE;
+
+    for (PRUint16 index = 0; index < SSL_NumImplementedCiphers; index++) {
+        if (SSL_ImplementedCiphers[index] == cipher_suite) {
+            found = JNI_TRUE;
+            break;
+        }
+    }
+
+    if (found == JNI_FALSE) {
+        return found;
+    }
+
+    if (SSL_GetCipherSuiteInfo(cipher_suite, &info, sizeof(info)) != SECSuccess || info.length < sizeof(info)) {
+        return JNI_FALSE;
+    }
+
+    if (info.nonStandard != 0) {
+        return JNI_FALSE;
+    }
+
+    if (info.isFIPS == 0 && PK11_IsFIPS()) {
+        return JNI_FALSE;
+    }
+
+    return JNI_TRUE;
+}

--- a/org/mozilla/jss/ssl/SSLCipher.java
+++ b/org/mozilla/jss/ssl/SSLCipher.java
@@ -341,21 +341,35 @@ public enum SSLCipher {
     TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA384         (0xD002, true),
 
     /* Special TLS 1.3 cipher suites that really just specify AEAD */
-    TLS_AES_128_GCM_SHA256                        (0x1301),
-    TLS_AES_256_GCM_SHA384                        (0x1302),
-    TLS_CHACHA20_POLY1305_SHA256                  (0x1303);
+    TLS_AES_128_GCM_SHA256                        (0x1301, false, true),
+    TLS_AES_256_GCM_SHA384                        (0x1302, false, true),
+    TLS_CHACHA20_POLY1305_SHA256                  (0x1303, false, true);
 
     private int id;
     private boolean ecc;
+    private boolean tls13;
+    private boolean supported;
 
     private SSLCipher(int id) {
-        this.id = id;
+        this(id, false);
     }
 
     private SSLCipher(int id, boolean ecc) {
+        this(id, ecc, false);
+    }
+
+    private SSLCipher(int id, boolean ecc, boolean tls13) {
+        this(id, ecc, tls13, checkSupportedStatus(id));
+    }
+
+    private SSLCipher(int id, boolean ecc, boolean tls13, boolean supported) {
         this.id = id;
         this.ecc = ecc;
+        this.tls13 = tls13;
+        this.supported = supported;
     }
+
+    private static native boolean checkSupportedStatus(int id);
 
     public int getID() {
         return id;
@@ -363,6 +377,22 @@ public enum SSLCipher {
 
     public boolean isECC() {
         return ecc;
+    }
+
+    public boolean isTLSv13() {
+        return tls13;
+    }
+
+    public boolean isSupported() {
+        return supported;
+    }
+
+    public boolean requiresRSACert() {
+        return this.name().contains("_RSA_");
+    }
+
+    public boolean requiresECDSACert() {
+        return this.name().contains("_ECDSA_");
     }
 
     public static SSLCipher valueOf(int id) {


### PR DESCRIPTION
This allows consumers of `SSLCipher` to know whether or not a given
cipher suite is supported in various conditions:

 - With TLSv1.3, or
 - In FIPS mode, or
 - With RSA or ECDSA certificates.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---- 

@edewata This doesn't quite bring full crypto-policies compliance, just FIPS compliance. I'm not sure how to do the former.