### PR TITLE
Fix memory leaks around Array handling

### DIFF
--- a/org/mozilla/jss/nss/PR.c
+++ b/org/mozilla/jss/nss/PR.c
@@ -15,21 +15,23 @@ Java_org_mozilla_jss_nss_PR_Open(JNIEnv *env, jclass clazz, jstring name,
     jint flags, jint mode)
 {
     PRFileDesc *fd;
-    char *path;
+    const char *path;
 
     PR_ASSERT(env != NULL);
     PR_SetError(0, 0);
 
-    path = (char *)(*env)->GetStringUTFChars(env, name, NULL);
+    path = JSS_RefJString(env, name);
     if (path == NULL) {
          return NULL;
     }
 
     fd = PR_Open(path, flags, mode);
     if (fd == NULL) {
+        JSS_DerefJString(env, name, path);
         return NULL;
     }
 
+    JSS_DerefJString(env, name, path);
     return JSS_PR_wrapPRFDProxy(env, &fd);
 }
 

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -131,21 +131,24 @@ Java_org_mozilla_jss_nss_SSL_SetURL(JNIEnv *env, jclass clazz, jobject fd,
     jstring url)
 {
     PRFileDesc *real_fd = NULL;
-    char *real_url = NULL;
+    SECStatus ret = SECFailure;
+    const char *real_url = NULL;
 
     PR_ASSERT(env != NULL && fd != NULL);
     PR_SetError(0, 0);
 
     if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
-        return SECFailure;
+        return ret;
     }
 
-    real_url = (char *)(*env)->GetStringUTFChars(env, url, NULL);
+    real_url = JSS_RefJString(env, url);
     if (real_url == NULL) {
-        return SECFailure;
+        return ret;
     }
 
-    return SSL_SetURL(real_fd, real_url);
+    ret = SSL_SetURL(real_fd, real_url);
+    JSS_DerefJString(env, url, real_url);
+    return ret;
 }
 
 JNIEXPORT int JNICALL

--- a/org/mozilla/jss/pkcs11/PK11Cipher.c
+++ b/org/mozilla/jss/pkcs11/PK11Cipher.c
@@ -171,6 +171,9 @@ finish:
     if(outbuf) {
         PR_Free(outbuf);
     }
+    if (inbuf) {
+        (*env)->ReleaseByteArrayElements(env, inputBA, inbuf, JNI_ABORT);
+    }
     return outArray;
 }
 

--- a/org/mozilla/jss/ssl/javasock.c
+++ b/org/mozilla/jss/ssl/javasock.c
@@ -548,9 +548,11 @@ jsock_recv(PRFileDesc *fd, void *buf, PRInt32 amount,
 
         bytes = (*env)->GetByteArrayElements(env, byteArray, NULL);
 
-        memcpy(buf, bytes, retval);
+        if (bytes != NULL) {
+            memcpy(buf, bytes, retval);
 
-        JSS_DerefByteArray(env, byteArray, bytes, JNI_ABORT);
+            JSS_DerefByteArray(env, byteArray, bytes, JNI_ABORT);
+        }
     }
 
 finish:


### PR DESCRIPTION
Reported by @c42-arthur in #371.

`PK11Cipher`'s `updateContext` leaks a reference to the input byte array, a
potentially highly-used method depending on the application. This fixes
that memory leak and audits the rest of JSS for similar leaks, fixing
two in the NSPR and NSS SSL bindings.

The case in `ssl/javasock.c` is at worst a `memcpy` of a `NULL` variable, which
should fail where it to be hit.

Resolves: #371

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`