### PR TITLE
Log invalid Base64 and return empty data

### DIFF
--- a/org/mozilla/jss/netscape/security/util/Utils.java
+++ b/org/mozilla/jss/netscape/security/util/Utils.java
@@ -37,7 +37,12 @@ import java.util.Date;
 import java.util.StringTokenizer;
 import java.util.Vector;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class Utils {
+    public static Logger logger = LoggerFactory.getLogger(Utils.class);
+
     /**
      * Checks if this is NT.
      */
@@ -395,7 +400,12 @@ public class Utils {
      * @return byte array
      */
     public static byte[] base64decode(String string) {
-        return Base64.getMimeDecoder().decode(string);
+        try {
+            return Base64.getMimeDecoder().decode(string);
+        } catch (IllegalArgumentException iae) {
+            logger.warn("Invalid base64: [" + string + "]: " + iae);
+            return new byte[0];
+        }
     }
 
     /**


### PR DESCRIPTION
Apache Commons Codec's base64 parser will happily return invalid,
nonsensical base64 data. Add logging to `Utils` to catch these inputs,
and return an empty data array. This makes `Utils.base64decode(...)` behave
like Apache Commons Codec (in that it doesn't raise an exception), but
diverges in behavior since Base64 blobs with invalid prefixes will
return empty data, a safer alternative than continuing to parse and
returning garbage.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`