### PR TITLE
Add option to run test suite under Valgrind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ if (DEFINED ENV{SANDBOX})
 endif()
 option(SANDBOX "When enabled, expect to find nss and nspr from the parent (sandbox) directory instead of using the system-installed versions of the libraries." ${SANDBOX_ENV})
 
+if (DEFINED ENV{TEST_VALGRIND})
+    set(TEST_VALGRIND_ENV TRUE)
+endif()
+option(TEST_VALGRIND "When enabled, run the entire test suite under Valgrind. This will be noisy as JSS can't clean up NSS initialization and the JVM itself leaks." ${TEST_VALGRIND_ENV})
+
 # Build a debug build by default when no type is specified on the command line
 if(NOT (DEFINED CMAKE_BUILD_TYPE))
     set(CMAKE_BUILD_TYPE "Debug")

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -445,6 +445,10 @@ macro(jss_test_exec)
     set(TEST_ARGS  "COMMAND" "DEPENDS")
     cmake_parse_arguments(TEST_EXEC "" "${TEST_FLAGS}" "${TEST_ARGS}" ${ARGN})
 
+    if(TEST_VALGRIND)
+        list(INSERT TEST_EXEC_COMMAND 0 "valgrind" "--track-origins=yes" "--leak-check=full")
+    endif()
+
     add_test(
         NAME "${TEST_EXEC_NAME}"
         COMMAND ${TEST_EXEC_COMMAND}

--- a/docs/build_system.md
+++ b/docs/build_system.md
@@ -80,6 +80,10 @@ command line with `-D<VAR>=<VALUE>` syntax, or in the environment.
     `sandbox/dist` folder is automatically created by NSS upon build.
     Please first build NSS (according to current instructions) and then
     build JSS.
+ - `TEST_VALGRIND` -- run the entire test suite under Valgrind. This option
+    is quite slow. By default it passes two arguments: `--track-origins=yes`
+    and `--leak-check=full`. Modify `cmake/JSSTests.cmake` (macro:
+    `jss_test_exec`) to change these options.
 
 ### Adding a Test Case
 


### PR DESCRIPTION
Introduces the `TEST_VALGRIND` option to run the entire test suite under
Valgrind. This is exceedingly slow and reports lots of false positives
due to the way the JVM exits (and restrictions on the Cryptographic
Provider interface making shutting down NSS hard).

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`