### PR TITLE
Make key size enforcement optional

### DIFF
--- a/org/mozilla/jss/crypto/Policy.java
+++ b/org/mozilla/jss/crypto/Policy.java
@@ -15,6 +15,16 @@ import org.mozilla.jss.ssl.SSLVersionRange;
  */
 public class Policy {
     /**
+     * Whether or not this JSS instance is enforcing local crypto-policy,
+     * with respect to key sizes.
+     *
+     * Defaults to false; this lets applications use whatever key sizes are
+     * supported by NSS, at the risk of performing non-compliant operations.
+     * Set to true to enable enforcement, where it exists.
+     */
+    public static boolean ENFORCING_KEY_SIZES = false;
+
+    /**
      * Minimum RSA key length in bits permitted by local policy.
      */
     public static int RSA_MINIMUM_KEY_SIZE = getRSAMinimumKeySize();


### PR DESCRIPTION
Because cdfed4e1e079130eb5fd94c8ff5936007b1668bb was technically a
breaking change for some applications, make its enforcement
configurable. This currently defaults to false; so applications wishing
to enable strict enforcement must opt-in by changing the value of
`org.mozilla.jss.crypto.Policy.ENFORCING_KEY_SIZES` to `true`.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`