### PR TITLE
Use CipherPolicyGet instead of GetCipherSuiteInfo

### DIFF
--- a/org/mozilla/jss/ssl/SSLCipher.c
+++ b/org/mozilla/jss/ssl/SSLCipher.c
@@ -1,39 +1,31 @@
 #include <nspr.h>
 #include <nss.h>
 #include <ssl.h>
-#include <pk11pub.h>
 #include <jni.h>
+#include <pk11pub.h>
 
 #include "_jni/org_mozilla_jss_ssl_SSLCipher.h"
 
 JNIEXPORT jboolean JNICALL
 Java_org_mozilla_jss_ssl_SSLCipher_checkSupportedStatus(JNIEnv *env, jclass clazz, jint cipher_suite)
 {
+    PRInt32 allowed;
+
+    if (SSL_CipherPolicyGet(cipher_suite, &allowed) != SECSuccess) {
+        return JNI_FALSE;
+    }
+
+    if (!PK11_IsFIPS() || allowed != SSL_ALLOWED) {
+        return (allowed == SSL_ALLOWED) ? JNI_TRUE : JNI_FALSE;
+    }
+
+    /* Our NSS DB or application could've configured FIPS mode explicitly,
+     * even though the system might not be in FIPS mode. In that case,
+     * explicitly check that this allowed cipher is available in FIPS mode. */
     SSLCipherSuiteInfo info = { 0 };
-    jboolean found = JNI_FALSE;
-
-    for (PRUint16 index = 0; index < SSL_NumImplementedCiphers; index++) {
-        if (SSL_ImplementedCiphers[index] == cipher_suite) {
-            found = JNI_TRUE;
-            break;
-        }
-    }
-
-    if (found == JNI_FALSE) {
-        return found;
-    }
-
     if (SSL_GetCipherSuiteInfo(cipher_suite, &info, sizeof(info)) != SECSuccess || info.length < sizeof(info)) {
         return JNI_FALSE;
     }
 
-    if (info.nonStandard != 0) {
-        return JNI_FALSE;
-    }
-
-    if (info.isFIPS == 0 && PK11_IsFIPS()) {
-        return JNI_FALSE;
-    }
-
-    return JNI_TRUE;
+    return (info.isFIPS != 0) ? JNI_TRUE : JNI_FALSE;
 }


### PR DESCRIPTION
I've tested this under various policies with #150 and it appears to behave as expected.

 - LEGACY
 - DEFAULT
 - NEXT
 - FUTURE

Though there are still a few handshake errors in LEGACY that leave stuff to be desired. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`