### PR TITLE
Handle OOM in javasoc.c with exception

### DIFF
--- a/org/mozilla/jss/ssl/javasock.c
+++ b/org/mozilla/jss/ssl/javasock.c
@@ -12,8 +12,9 @@
 #include <nss.h>
 #include <ssl.h>
 
-#include <jssutil.h>
-#include <java_ids.h>
+#include "jssutil.h"
+#include "java_ids.h"
+#include "jss_exceptions.h"
 
 static PRIntn
 invalidInt()
@@ -552,6 +553,8 @@ jsock_recv(PRFileDesc *fd, void *buf, PRInt32 amount,
             memcpy(buf, bytes, retval);
 
             JSS_DerefByteArray(env, byteArray, bytes, JNI_ABORT);
+        } else {
+            JSS_throwMsg(env, OUT_OF_MEMORY_ERROR, "Unable to get byte array elements.");
         }
     }
 


### PR DESCRIPTION
Reported by Scott Straw and Andrew Helgeson at Code42.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`