### PR TITLE
Track the root cause of SSLSocket exceptions

### DIFF
--- a/org/mozilla/jss/ssl/SSLServerSocket.java
+++ b/org/mozilla/jss/ssl/SSLServerSocket.java
@@ -278,7 +278,7 @@ public class SSLServerSocket extends java.net.ServerSocket {
       try {
         setServerCert( CryptoManager.getInstance().findCertByNickname(nick) );
       } catch(NotInitializedException nie) {
-        throw new SocketException("CryptoManager not initialized");
+        throw new SocketException("CryptoManager not initialized: " + nie);
       } catch(ObjectNotFoundException onfe) {
         throw new SocketException("Object not found: " + onfe);
       } catch(TokenException te) {

--- a/org/mozilla/jss/ssl/SSLSocket.java
+++ b/org/mozilla/jss/ssl/SSLSocket.java
@@ -1488,10 +1488,10 @@ public class SSLSocket extends java.net.Socket {
                 iRet = socketRead(b, off, len, base.getTimeout());
             } catch (SocketTimeoutException ste) {
                 throw new SocketTimeoutException(
-                    "SocketTimeoutException cannot read on socket");
+                    "SocketTimeoutException cannot read on socket: " + ste);
             } catch (IOException ioe) {
                 throw new IOException(
-                    "SocketException cannot read on socket");
+                    "SocketException cannot read on socket: " + ioe.getMessage(), ioe);
             } finally {
                 synchronized (this) {
                     inRead = false;
@@ -1515,10 +1515,10 @@ public class SSLSocket extends java.net.Socket {
                 socketWrite(b, off, len, base.getTimeout());
             } catch (SocketTimeoutException ste) {
                 throw new SocketTimeoutException(
-                    "SocketTimeoutException cannot write on socket");
+                    "SocketTimeoutException cannot write on socket: " + ste);
             } catch (IOException ioe) {
                 throw new IOException(
-                    "SocketException cannot write on socket");
+                    "SocketException cannot write on socket: " + ioe.getMessage(), ioe);
             } finally {
                 synchronized (this) {
                     inWrite = false;


### PR DESCRIPTION
`SSLSocket` and `SSLServerSocket` "mask" the cause of certain exceptions,
which results in less clear error messages.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`