### PR TITLE
Migrate CI from F29 to latest for JDK11 builds

### DIFF
--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -30,13 +30,13 @@ jobs:
       uses: actions/checkout@v2
     - name: Build and Run the Docker Image
       run: bash tools/run_container.sh "ubuntu_jdk8" || echo "::warning ::Job exited with status $?"
-  fedora_29_jdk11:
+  fedora_latest_jdk11:
     runs-on: ubuntu-latest
     steps:
     - name: Clone the repository
       uses: actions/checkout@v2
     - name: Build and Run the Docker Image
-      run: bash tools/run_container.sh "fedora_29_jdk11" || echo "::warning ::Job exited with status $?"
+      run: bash tools/run_container.sh "fedora_latest_jdk11" || echo "::warning ::Job exited with status $?"
   fedora_rawhide:
     runs-on: ubuntu-latest
     steps:

--- a/tools/Dockerfiles/fedora_latest_jdk11
+++ b/tools/Dockerfiles/fedora_latest_jdk11
@@ -1,0 +1,31 @@
+FROM fedora:latest
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build cmake \
+                          glassfish-jaxb-api java-11-openjdk nss-tools \
+                          apache-commons-lang gcc-c++ java-11-openjdk-devel \
+                          jpackage-utils slf4j nss zlib-devel nss-devel \
+                          nspr-devel perl slf4j-jdk14 junit \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk \
+        && rm -rf build \
+        && mkdir build \
+        && cd build \
+        && cmake .. \
+        && make all \
+        && ctest --output-on-failure \
+        && true


### PR DESCRIPTION
This'll ensure we're testing with a newer JDK version, as F29 is no longer maintained. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`