### PR TITLE
Change to dynamic-first libjss4.so linking

### DIFF
--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -1477,24 +1477,20 @@ public final class CryptoManager implements TokenSupplier
      */
     synchronized static void loadNativeLibraries()
     {
-        if( ! mNativeLibrariesLoaded ) {
-            try { // 64 bit rhel/fedora
-                System.load( "/usr/lib64/jss/libjss4.so" );
-                Debug.trace(Debug.VERBOSE, "64-bit jss library loaded");
+        if (!mNativeLibrariesLoaded) {
+            try { // java.library.path
+                System.loadLibrary("jss4");
+                Debug.trace(Debug.VERBOSE, "jss library loaded from java.library.path");
                 mNativeLibrariesLoaded = true;
-            } catch( UnsatisfiedLinkError e ) {
-                try { // 32 bit rhel/fedora
-                    System.load( "/usr/lib/jss/libjss4.so" );
-                    Debug.trace(Debug.VERBOSE, "32-bit jss library loaded");
+            } catch (UnsatisfiedLinkError ule) {
+                try { // 64-bit library
+                    System.load("/usr/lib64/jss/libjss4.so");
+                    Debug.trace(Debug.VERBOSE, "64-bit jss library loaded from /usr/lib64/jss/libjss4.so");
                     mNativeLibrariesLoaded = true;
-                } catch( UnsatisfiedLinkError f ) {
-                    try {// possibly other platforms
-                        System.loadLibrary( "jss4" );
-                        Debug.trace(Debug.VERBOSE, "jss library loaded");
-                        mNativeLibrariesLoaded = true;
-                    } catch( UnsatisfiedLinkError g ) {
-                        Debug.trace(Debug.VERBOSE, "jss library load failed");
-                    }
+                } catch(UnsatisfiedLinkError ule64bit) {
+                    System.load("/usr/lib/jss/libjss4.so");
+                    Debug.trace(Debug.VERBOSE, "32-bit jss library loaded from /usr/lib/jss/libjss4.so");
+                    mNativeLibrariesLoaded = true;
                 }
             }
         }


### PR DESCRIPTION
JSS master branch has changed to prefer a dynamic approach to finding
libjss4.so: use the value of -Djava.library.path and then fallback to
hard-coded paths if the native portion of JSS isn't found. Update the
JSS v4.4.x code to follow this behavior.

Resolves: rh-bz#1796642

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`