### PR TITLE
Remove JSS_PACKAGES

### DIFF
--- a/cmake/JSSCommon.cmake
+++ b/cmake/JSSCommon.cmake
@@ -229,7 +229,7 @@ macro(jss_build_javadocs)
 
     add_custom_command(
         OUTPUT ${JAVADOCS_OUTPUTS}
-        COMMAND "${Java_JAVADOC_EXECUTABLE}" -overview "${PROJECT_SOURCE_DIR}/tools/javadoc/overview.html" -windowtitle "${JSS_WINDOW_TITLE}" -notimestamp -breakiterator -classpath ${JAVAC_CLASSPATH} -sourcepath ${PROJECT_SOURCE_DIR} -d ${DOCS_OUTPUT_DIR} ${JSS_PACKAGES}
+        COMMAND "${Java_JAVADOC_EXECUTABLE}" -overview "${PROJECT_SOURCE_DIR}/tools/javadoc/overview.html" -windowtitle "${JSS_WINDOW_TITLE}" -notimestamp -breakiterator -classpath ${JAVAC_CLASSPATH} -sourcepath ${PROJECT_SOURCE_DIR} -d ${DOCS_OUTPUT_DIR} @${JAVA_SOURCES_FILE}
         COMMAND touch "${JAVADOCS_OUTPUTS}"
         DEPENDS ${JAVA_SOURCES}
     )

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -307,10 +307,8 @@ macro(jss_config_java)
     message(STATUS "JSS JAVAC FLAGS: ${JSS_JAVAC_FLAGS}")
     message(STATUS "JSS TEST JAVAC FLAGS: ${JSS_TEST_JAVAC_FLAGS}")
 
-    # Variables for javadoc building. Note that JSS_PACKAGES needs to be
-    # updated whenever a new package is created.
+    # Variables for javadoc building.
     set(JSS_WINDOW_TITLE "JSS: Java Security Services")
-    set(JSS_PACKAGES "org.mozilla.jss;org.mozilla.jss.asn1;org.mozilla.jss.crypto;org.mozilla.jss.pkcs7;org.mozilla.jss.pkcs10;org.mozilla.jss.pkcs11;org.mozilla.jss.pkcs11.attrs;org.mozilla.jss.pkcs12;org.mozilla.jss.pkix.primitive;org.mozilla.jss.pkix.cert;org.mozilla.jss.pkix.cmc;org.mozilla.jss.pkix.cmmf;org.mozilla.jss.pkix.cms;org.mozilla.jss.pkix.crmf;org.mozilla.jss.provider.java.security;org.mozilla.jss.provider.javax.crypto;org.mozilla.jss.SecretDecoderRing;org.mozilla.jss.ssl;org.mozilla.jss.util;org.mozilla.jss.netscape.security.util;org.mozilla.jss.netscape.security.extensions;org.mozilla.jss.netscape.security.acl;org.mozilla.jss.netscape.security.pkcs;org.mozilla.jss.netscape.security.x509;org.mozilla.jss.netscape.security.provider;org.mozilla.jss.nss;org.mozilla.jss.ssl.javax")
 
     set(JSS_BASE_PORT 2876)
     math(EXPR JSS_TEST_PORT_CLIENTAUTH ${JSS_BASE_PORT}+0)


### PR DESCRIPTION
With the introduction of proper logging support (and subsequent removal
of the Release/Debug split) and splitting of source lists between those
in the JSS release and those in the JSS tests, we have removed the need
for `JSS_PACKAGES`.

This introduces javadocs for all packages which are part of the shipped
JSS4 JAR.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`