### PR TITLE
Release v4.6.3

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -2,7 +2,7 @@ macro(jss_config)
     # Set the current JSS release number. Arguments are:
     #   MAJOR MINOR PATCH BETA
     # When BETA is zero, it isn't a beta release.
-    jss_config_version(4 6 2 0)
+    jss_config_version(4 6 3 0)
 
     # Configure output directories
     jss_config_outputs()

--- a/jss.spec
+++ b/jss.spec
@@ -6,7 +6,7 @@ Summary:        Java Security Services (JSS)
 URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
-Version:        4.6.2
+Version:        4.6.3
 Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
 # global         _phase -a1
 


### PR DESCRIPTION
This version of JSS has a few enhancements over v4.6.2:

 - Support for NIST SP800-108 KBKDF
 - Various enhancements towards a SSLEngine implementation
 - Modernized exception constructors
 - Various reductions in memory leaks (with thanks to Code42)
 - Introduce jss.crypto.Policy to reflect local system crypto-policies.
   This allows callers of JSS to inquiry about, e.g., minimum RSA key
   sizes independent of platform.
 - Various enhancements to the build system

Note that this version of JSS is incompatible with NSS versions between
v3.47 and v3.50 inclusive. This is because [moz-bz#1570501](https://bugzilla.mozilla.org/show_bug.cgi?id=1570501) introduced a
bug that wasn't caught and fixed until [moz-bz#1611209](https://bugzilla.mozilla.org/show_bug.cgi?id=1611209). NSS versions
v3.46 and earlier will work but lack CMAC and KBKDF support, and NSS
versions v3.51 and later will work and have CMAC and KBKDF support.

Note that this means the value of `PKCS11Constants.CKM_AES_CMAC` and
`CKM_AES_CMAC_GENERAL` have also changed and thus differ from v4.6.2.
This also means that JSS v4.6.2 may not be compatible with NSS versions
after v3.50.

Thanks to everyone who contributed to this release!

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`