### PR TITLE
Mark JSS Provider and PKCS#11 classes as public

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11DSAPrivateKey.java
+++ b/org/mozilla/jss/pkcs11/PK11DSAPrivateKey.java
@@ -6,7 +6,7 @@ import java.math.BigInteger;
 import java.security.interfaces.DSAParams;
 import java.security.interfaces.DSAPrivateKey;
 
-class PK11DSAPrivateKey
+public class PK11DSAPrivateKey
     extends PK11PrivKey implements DSAPrivateKey
 {
 

--- a/org/mozilla/jss/pkcs11/PK11ECPrivateKey.java
+++ b/org/mozilla/jss/pkcs11/PK11ECPrivateKey.java
@@ -7,7 +7,7 @@ import java.math.BigInteger;
 import org.mozilla.jss.crypto.PrivateKey;
 import org.mozilla.jss.util.EC;
 
-class PK11ECPrivateKey
+public class PK11ECPrivateKey
     extends PK11PrivKey
     implements ECPrivateKey
 {

--- a/org/mozilla/jss/pkcs11/PK11RSAPrivateKey.java
+++ b/org/mozilla/jss/pkcs11/PK11RSAPrivateKey.java
@@ -6,7 +6,7 @@ import org.mozilla.jss.crypto.PrivateKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class PK11RSAPrivateKey
+public class PK11RSAPrivateKey
     extends PK11PrivKey implements java.security.interfaces.RSAPrivateKey
 {
     public static Logger logger = LoggerFactory.getLogger(PK11RSAPrivateKey.class);

--- a/org/mozilla/jss/provider/java/security/JSSKeyPairGeneratorSpi.java
+++ b/org/mozilla/jss/provider/java/security/JSSKeyPairGeneratorSpi.java
@@ -17,7 +17,7 @@ import org.mozilla.jss.crypto.TokenRuntimeException;
 import org.mozilla.jss.crypto.TokenSupplierManager;
 
 
-class JSSKeyPairGeneratorSpi
+public class JSSKeyPairGeneratorSpi
     extends java.security.KeyPairGeneratorSpi
 {
 

--- a/org/mozilla/jss/provider/java/security/JSSSignatureSpi.java
+++ b/org/mozilla/jss/provider/java/security/JSSSignatureSpi.java
@@ -21,7 +21,7 @@ import org.mozilla.jss.crypto.SignatureAlgorithm;
 import org.mozilla.jss.crypto.TokenException;
 import org.mozilla.jss.crypto.TokenSupplierManager;
 
-class JSSSignatureSpi extends java.security.SignatureSpi {
+public class JSSSignatureSpi extends java.security.SignatureSpi {
 
     org.mozilla.jss.crypto.Signature sig;
     SignatureAlgorithm alg;

--- a/org/mozilla/jss/provider/javax/crypto/JSSCipherSpi.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSCipherSpi.java
@@ -41,7 +41,7 @@ import org.mozilla.jss.pkcs11.PK11PubKey;
 import org.mozilla.jss.pkix.primitive.SubjectPublicKeyInfo;
 import org.mozilla.jss.util.Assert;
 
-class JSSCipherSpi extends javax.crypto.CipherSpi {
+public class JSSCipherSpi extends javax.crypto.CipherSpi {
     private String algFamily=null;
     private String algMode=null;
     private String algPadding=null;

--- a/org/mozilla/jss/provider/javax/crypto/JSSKeyGeneratorSpi.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSKeyGeneratorSpi.java
@@ -21,7 +21,7 @@ import org.mozilla.jss.crypto.TokenException;
 import org.mozilla.jss.crypto.TokenRuntimeException;
 import org.mozilla.jss.crypto.TokenSupplierManager;
 
-class JSSKeyGeneratorSpi extends javax.crypto.KeyGeneratorSpi {
+public class JSSKeyGeneratorSpi extends javax.crypto.KeyGeneratorSpi {
     private KeyGenerator keyGenerator= null;
 
     protected JSSKeyGeneratorSpi(KeyGenAlgorithm alg) {

--- a/org/mozilla/jss/provider/javax/crypto/JSSMacSpi.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSMacSpi.java
@@ -21,7 +21,7 @@ import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.TokenRuntimeException;
 import org.mozilla.jss.crypto.TokenSupplierManager;
 
-class JSSMacSpi extends javax.crypto.MacSpi {
+public class JSSMacSpi extends javax.crypto.MacSpi {
 
     private JSSMessageDigest digest=null;
     private DigestAlgorithm alg;

--- a/org/mozilla/jss/provider/javax/crypto/JSSSecretKeyFactorySpi.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSSecretKeyFactorySpi.java
@@ -36,7 +36,7 @@ import org.mozilla.jss.crypto.TokenRuntimeException;
 import org.mozilla.jss.crypto.TokenSupplierManager;
 import org.mozilla.jss.util.Password;
 
-class JSSSecretKeyFactorySpi extends SecretKeyFactorySpi {
+public class JSSSecretKeyFactorySpi extends SecretKeyFactorySpi {
 
     private KeyGenAlgorithm alg = null;
     private CryptoToken token = null;


### PR DESCRIPTION
This enables javadoc generation for these classes. While the JSSProvider
clases lack useful javadocs, their existence helps developers check the
supported interfaces. Additionally, the PKCS#11 `PrivateKey` interfaces
should be made public to mirror their `PublicKey` counterparts, in the
rare instances where they're used instead of the generic Java
interfaces.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`