### PR TITLE
Merge IVParameterSpec into IvParameterSpec

### DIFF
--- a/org/mozilla/jss/crypto/Algorithm.java
+++ b/org/mozilla/jss/crypto/Algorithm.java
@@ -112,18 +112,29 @@ public class Algorithm {
      * @return Returns <code>true</code> if the given Object can be used as a parameter.
      */
     public boolean isValidParameterObject(Object o) {
-        if( o == null ) {
+        if (o == null) {
+            // It is only valid to pass a null parameter if the length of the
+            // expected class list is zero. Otherwise, the usage is invalid.
             return (parameterClasses.length == 0);
         }
-        if( parameterClasses.length == 0 ){
-            return false;
-        }
-        Class<?> c = o.getClass();
-        for( int i = 0; i < parameterClasses.length; ++i) {
-            if( c.equals( parameterClasses[i] ) ) {
+
+        // For the remaining instances, if the object's class is a subclass
+        // of the specified parameter class, allow it. This allows the
+        // construct:
+        //
+        //   IVParameterClass -child-of-> IvParameterClass
+        //
+        // by only specifying the parent, IvParameterClass.
+        for (int i = 0; i < parameterClasses.length; i++) {
+            if (parameterClasses[i].isInstance(o)) {
                 return true;
             }
         }
+
+        // If we got an object parameter, but weren't expecting any, it
+        // is invalid. Also, if our class didn't match our expectations,
+        // it is also invalid.
+
         return false;
     }
 

--- a/org/mozilla/jss/crypto/EncryptionAlgorithm.java
+++ b/org/mozilla/jss/crypto/EncryptionAlgorithm.java
@@ -293,9 +293,8 @@ public class EncryptionAlgorithm extends Algorithm {
 
     private static Class<?>[] IVParameterSpecClasses = null;
     static {
-        IVParameterSpecClasses = new Class[2];
-        IVParameterSpecClasses[0] = IVParameterSpec.class;
-        IVParameterSpecClasses[1] = IvParameterSpec.class;
+        IVParameterSpecClasses = new Class[1];
+        IVParameterSpecClasses[0] = IvParameterSpec.class;
     }
 
     /**

--- a/org/mozilla/jss/crypto/IVParameterSpec.java
+++ b/org/mozilla/jss/crypto/IVParameterSpec.java
@@ -6,21 +6,17 @@ package org.mozilla.jss.crypto;
 
 import java.security.spec.AlgorithmParameterSpec;
 
+import javax.crypto.spec.IvParameterSpec;
+
 /**
  * An algorithm parameter that consists of an initialization vector (IV).
  */
-public class IVParameterSpec implements AlgorithmParameterSpec {
-
-    private byte[] iv;
-
+public class IVParameterSpec extends IvParameterSpec {
     public IVParameterSpec(byte[] iv) {
-        this.iv = iv;
+        super(iv);
     }
 
-    /**
-     * @return Reference to an internal copy of the initialization vector.
-     */
-    public byte[] getIV() {
-        return iv;
+    public IVParameterSpec(byte[] iv, int offset, int len) {
+        super(iv, offset, len);
     }
 }

--- a/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
+++ b/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
@@ -62,9 +62,8 @@ public class KeyWrapAlgorithm extends Algorithm {
 
     private static Class<?>[] IVParameterSpecClasses = null;
     static {
-        IVParameterSpecClasses = new Class[2];
-        IVParameterSpecClasses[0] = IVParameterSpec.class;
-        IVParameterSpecClasses[1] = IvParameterSpec.class;
+        IVParameterSpecClasses = new Class[1];
+        IVParameterSpecClasses[0] = IvParameterSpec.class;
     }
 
     public static final KeyWrapAlgorithm

--- a/org/mozilla/jss/netscape/security/util/WrappingParams.java
+++ b/org/mozilla/jss/netscape/security/util/WrappingParams.java
@@ -2,9 +2,10 @@ package org.mozilla.jss.netscape.security.util;
 
 import java.security.NoSuchAlgorithmException;
 
+import javax.crypto.spec.IvParameterSpec;
+
 import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
 import org.mozilla.jss.crypto.EncryptionAlgorithm;
-import org.mozilla.jss.crypto.IVParameterSpec;
 import org.mozilla.jss.crypto.KeyGenAlgorithm;
 import org.mozilla.jss.crypto.KeyWrapAlgorithm;
 import org.mozilla.jss.crypto.SymmetricKey;
@@ -26,14 +27,14 @@ public class WrappingParams {
     KeyWrapAlgorithm payloadWrapAlgorithm;
 
     // payload encryption IV
-    IVParameterSpec payloadEncryptionIV;
+    IvParameterSpec payloadEncryptionIV;
 
     // payload wrapping IV
-    IVParameterSpec payloadWrappingIV;
+    IvParameterSpec payloadWrappingIV;
 
     public WrappingParams(Type skType, KeyGenAlgorithm skKeyGenAlgorithm, int skLength,
             KeyWrapAlgorithm skWrapAlgorithm, EncryptionAlgorithm payloadEncryptionAlgorithm,
-            KeyWrapAlgorithm payloadWrapAlgorithm, IVParameterSpec payloadEncryptIV, IVParameterSpec payloadWrapIV) {
+            KeyWrapAlgorithm payloadWrapAlgorithm, IvParameterSpec payloadEncryptIV, IvParameterSpec payloadWrapIV) {
         super();
         this.skType = skType;
         this.skKeyGenAlgorithm = skKeyGenAlgorithm;
@@ -56,7 +57,7 @@ public class WrappingParams {
 
     public WrappingParams() {}
 
-    public WrappingParams(String encryptOID, String wrapName, String priKeyAlgo, IVParameterSpec encryptIV, IVParameterSpec wrapIV)
+    public WrappingParams(String encryptOID, String wrapName, String priKeyAlgo, IvParameterSpec encryptIV, IvParameterSpec wrapIV)
             throws NumberFormatException, NoSuchAlgorithmException {
         EncryptionAlgorithm encrypt = null;
         OBJECT_IDENTIFIER eccOID = new OBJECT_IDENTIFIER("1.2.840.10045.2.1");
@@ -128,7 +129,7 @@ public class WrappingParams {
         }
     }
 
-    private WrappingParams(String wrapOID, String priKeyAlgo, IVParameterSpec wrapIV)
+    private WrappingParams(String wrapOID, String priKeyAlgo, IvParameterSpec wrapIV)
             throws NumberFormatException, NoSuchAlgorithmException {
         KeyWrapAlgorithm kwAlg = KeyWrapAlgorithm.fromOID(wrapOID);
 
@@ -179,7 +180,7 @@ public class WrappingParams {
         }
     }
 
-    public static WrappingParams getWrappingParamsFromArchiveOptions(String wrapOID, String priKeyAlgo, IVParameterSpec wrapIV)
+    public static WrappingParams getWrappingParamsFromArchiveOptions(String wrapOID, String priKeyAlgo, IvParameterSpec wrapIV)
             throws NumberFormatException, NoSuchAlgorithmException {
         return new WrappingParams(wrapOID, priKeyAlgo, wrapIV);
     }
@@ -272,19 +273,19 @@ public class WrappingParams {
         this.payloadWrapAlgorithm = KeyWrapAlgorithm.fromString(name);
     }
 
-    public IVParameterSpec getPayloadEncryptionIV() {
+    public IvParameterSpec getPayloadEncryptionIV() {
         return payloadEncryptionIV;
     }
 
-    public void setPayloadEncryptionIV(IVParameterSpec payloadEncryptionIV) {
+    public void setPayloadEncryptionIV(IvParameterSpec payloadEncryptionIV) {
         this.payloadEncryptionIV = payloadEncryptionIV;
     }
 
-    public IVParameterSpec getPayloadWrappingIV() {
+    public IvParameterSpec getPayloadWrappingIV() {
         return payloadWrappingIV;
     }
 
-    public void setPayloadWrappingIV(IVParameterSpec payloadWrappingIV) {
+    public void setPayloadWrappingIV(IvParameterSpec payloadWrappingIV) {
         this.payloadWrappingIV = payloadWrappingIV;
     }
 }

--- a/org/mozilla/jss/pkcs11/PK11Cipher.java
+++ b/org/mozilla/jss/pkcs11/PK11Cipher.java
@@ -14,7 +14,6 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.RC2ParameterSpec;
 
 import org.mozilla.jss.crypto.EncryptionAlgorithm;
-import org.mozilla.jss.crypto.IVParameterSpec;
 import org.mozilla.jss.crypto.IllegalBlockSizeException;
 import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.TokenException;
@@ -70,11 +69,9 @@ public final class PK11Cipher extends org.mozilla.jss.crypto.Cipher {
 
     private static byte[] getIVFromParams(AlgorithmParameterSpec params) {
         byte[] IV = null;
-        if( params instanceof IVParameterSpec ) {
-            IV = ((IVParameterSpec)params).getIV();
-        } else if( params instanceof IvParameterSpec ) {
+        if (params instanceof IvParameterSpec) {
             IV = ((IvParameterSpec)params).getIV();
-        } else if( params instanceof RC2ParameterSpec ) {
+        } else if (params instanceof RC2ParameterSpec) {
             IV = ((RC2ParameterSpec)params).getIV();
         }
         return IV;

--- a/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
+++ b/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
@@ -13,12 +13,12 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Arrays;
 
+import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.RC2ParameterSpec;
 
 import org.mozilla.jss.crypto.Algorithm;
 import org.mozilla.jss.crypto.EncryptionAlgorithm;
 import org.mozilla.jss.crypto.HMACAlgorithm;
-import org.mozilla.jss.crypto.IVParameterSpec;
 import org.mozilla.jss.crypto.KeyPairAlgorithm;
 import org.mozilla.jss.crypto.KeyWrapAlgorithm;
 import org.mozilla.jss.crypto.KeyWrapper;
@@ -225,11 +225,9 @@ public final class PK11KeyWrapper implements KeyWrapper {
             throw new InvalidAlgorithmParameterException(
                 algorithm + " cannot use a " + name + " parameter");
         }
-        if( params instanceof IVParameterSpec ) {
-            IV = ((IVParameterSpec)params).getIV();
-        } else if( params instanceof javax.crypto.spec.IvParameterSpec ) {
-            IV = ((javax.crypto.spec.IvParameterSpec)params).getIV();
-        } else if( params instanceof RC2ParameterSpec ) {
+        if (params instanceof IvParameterSpec) {
+            IV = ((IvParameterSpec)params).getIV();
+        } else if (params instanceof RC2ParameterSpec) {
             IV = ((RC2ParameterSpec)params).getIV();
         }
     }

--- a/org/mozilla/jss/pkcs12/AuthenticatedSafes.java
+++ b/org/mozilla/jss/pkcs12/AuthenticatedSafes.java
@@ -255,8 +255,8 @@ public class AuthenticatedSafes implements ASN1Value {
         // compute algorithm parameters
         EncryptionAlgorithm encAlg = keyGenAlgToEncryptionAlg(kgAlg);
         AlgorithmParameterSpec algParams;
-        if( encAlg.getParameterClass().equals( IVParameterSpec.class ) ) {
-            algParams = new IVParameterSpec( kg.generatePBE_IV() );
+        if (encAlg instanceof IvParameterSpec) {
+            algParams = new IvParameterSpec( kg.generatePBE_IV() );
         } else {
             algParams = null;
         }
@@ -388,8 +388,8 @@ public class AuthenticatedSafes implements ASN1Value {
         // generate IV
         EncryptionAlgorithm encAlg = keyGenAlgToEncryptionAlg(keyGenAlg);
         AlgorithmParameterSpec params=null;
-        if( encAlg.getParameterClass().equals( IVParameterSpec.class ) ) {
-            params = new IVParameterSpec( kg.generatePBE_IV() );
+        if (encAlg instanceof IvParameterSpec.class) {
+            params = new IvParameterSpec( kg.generatePBE_IV() );
         }
 
         // perform encryption

--- a/org/mozilla/jss/pkcs7/EncryptedContentInfo.java
+++ b/org/mozilla/jss/pkcs7/EncryptedContentInfo.java
@@ -14,6 +14,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.AlgorithmParameterSpec;
 
 import javax.crypto.BadPaddingException;
+import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.RC2ParameterSpec;
 
 import org.mozilla.jss.CryptoManager;
@@ -30,7 +31,6 @@ import org.mozilla.jss.asn1.Tag;
 import org.mozilla.jss.crypto.Cipher;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.EncryptionAlgorithm;
-import org.mozilla.jss.crypto.IVParameterSpec;
 import org.mozilla.jss.crypto.IllegalBlockSizeException;
 import org.mozilla.jss.crypto.KeyGenAlgorithm;
 import org.mozilla.jss.crypto.KeyGenerator;
@@ -183,12 +183,11 @@ public class EncryptedContentInfo implements ASN1Value {
         EncryptionAlgorithm encAlg = pbeAlg.getEncryptionAlg();
         AlgorithmParameterSpec params=null;
         Class<?> [] paramClasses = pbeAlg.getParameterClasses();
-        for (int i = 0; i < paramClasses.length; i ++) {
-            if ( paramClasses[i].equals(
-                      javax.crypto.spec.IvParameterSpec.class ) ) {
-                params = new IVParameterSpec(kg.generatePBE_IV());
+        for (int i = 0; i < paramClasses.length; i++) {
+            if (paramClasses[i].equals(IvParameterSpec.class)) {
+                params = new IvParameterSpec(kg.generatePBE_IV());
                 break;
-            } else if ( paramClasses[i].equals( RC2ParameterSpec.class ) ) {
+            } else if (paramClasses[i].equals(RC2ParameterSpec.class)) {
                 params = new RC2ParameterSpec(key.getStrength(),
                                               kg.generatePBE_IV());
                 break;
@@ -285,7 +284,7 @@ public class EncryptedContentInfo implements ASN1Value {
         for (int i = 0; i < paramClasses.length; i ++) {
             if ( paramClasses[i].equals(
                       javax.crypto.spec.IvParameterSpec.class ) ) {
-                algParams = new IVParameterSpec( kg.generatePBE_IV() );
+                algParams = new IvParameterSpec( kg.generatePBE_IV() );
                 break;
             } else if ( paramClasses[i].equals(RC2ParameterSpec.class ) ) {
                 algParams = new RC2ParameterSpec(key.getStrength(),

--- a/org/mozilla/jss/pkix/cms/EncryptedContentInfo.java
+++ b/org/mozilla/jss/pkix/cms/EncryptedContentInfo.java
@@ -13,6 +13,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.AlgorithmParameterSpec;
 
 import javax.crypto.BadPaddingException;
+import javax.crypto.spec.IvParameterSpec;
 
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NotInitializedException;
@@ -28,7 +29,6 @@ import org.mozilla.jss.asn1.Tag;
 import org.mozilla.jss.crypto.Cipher;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.EncryptionAlgorithm;
-import org.mozilla.jss.crypto.IVParameterSpec;
 import org.mozilla.jss.crypto.IllegalBlockSizeException;
 import org.mozilla.jss.crypto.KeyGenAlgorithm;
 import org.mozilla.jss.crypto.KeyGenerator;
@@ -181,9 +181,9 @@ public class EncryptedContentInfo implements ASN1Value {
         EncryptionAlgorithm encAlg = pbeAlg.getEncryptionAlg();
         AlgorithmParameterSpec params=null;
         Class<?> [] paramClasses = pbeAlg.getParameterClasses();
-        for (int i = 0; i < paramClasses.length; i ++) {
-            if ( paramClasses[i].equals( IVParameterSpec.class ) ) {
-                params = new IVParameterSpec( kg.generatePBE_IV() );
+        for (int i = 0; i < paramClasses.length; i++) {
+            if (paramClasses[i].equals(IvParameterSpec.class)) {
+                params = new IvParameterSpec(kg.generatePBE_IV());
                 break;
             }
         }
@@ -275,10 +275,9 @@ public class EncryptedContentInfo implements ASN1Value {
         EncryptionAlgorithm encAlg = ((PBEAlgorithm)kgAlg).getEncryptionAlg();
         AlgorithmParameterSpec algParams = null;
         Class<?> [] paramClasses = encAlg.getParameterClasses();
-        for (int i = 0; i < paramClasses.length; i ++) {
-            if ( paramClasses[i].equals(
-                       javax.crypto.spec.IvParameterSpec.class ) ) {
-                algParams = new IVParameterSpec( kg.generatePBE_IV() );
+        for (int i = 0; i < paramClasses.length; i++) {
+            if (paramClasses[i].equals(IvParameterSpec.class)) {
+                algParams = new IvParameterSpec(kg.generatePBE_IV());
                 break;
             }
         }

--- a/org/mozilla/jss/pkix/primitive/EncryptedPrivateKeyInfo.java
+++ b/org/mozilla/jss/pkix/primitive/EncryptedPrivateKeyInfo.java
@@ -15,6 +15,7 @@ import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 
 import javax.crypto.BadPaddingException;
+import javax.crypto.spec.IvParameterSpec;
 
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NotInitializedException;
@@ -29,7 +30,6 @@ import org.mozilla.jss.asn1.Tag;
 import org.mozilla.jss.crypto.Cipher;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.EncryptionAlgorithm;
-import org.mozilla.jss.crypto.IVParameterSpec;
 import org.mozilla.jss.crypto.IllegalBlockSizeException;
 import org.mozilla.jss.crypto.KeyGenAlgorithm;
 import org.mozilla.jss.crypto.KeyGenerator;
@@ -148,9 +148,9 @@ public class EncryptedPrivateKeyInfo implements ASN1Value {
         EncryptionAlgorithm encAlg = pbeAlg.getEncryptionAlg();
         AlgorithmParameterSpec params=null;
         Class<?> [] paramClasses = pbeAlg.getParameterClasses();
-        for (int i = 0; i < paramClasses.length; i ++) {
-            if ( paramClasses[i].equals( javax.crypto.spec.IvParameterSpec.class ) ) {
-                params = new IVParameterSpec( kg.generatePBE_IV() );
+        for (int i = 0; i < paramClasses.length; i++) {
+            if (paramClasses[i].equals(IvParameterSpec.class)) {
+                params = new IvParameterSpec(kg.generatePBE_IV());
                 break;
             }
         }
@@ -244,7 +244,7 @@ public class EncryptedPrivateKeyInfo implements ASN1Value {
             byte iv[] = new byte[encAlg.getBlockSize()];
             random.nextBytes(iv);
             Cipher cipher = token.getCipherContext(encAlg);
-            cipher.initEncrypt(sk, new IVParameterSpec(iv));
+            cipher.initEncrypt(sk, new IvParameterSpec(iv));
             byte[] encData = cipher.doFinal(ASN1Util.encode(privateKeyInfo));
 
             // construct KDF AlgorithmIdentifier
@@ -332,7 +332,7 @@ public class EncryptedPrivateKeyInfo implements ASN1Value {
         for (int i = 0; i < paramClasses.length; i ++) {
             if ( paramClasses[i].equals(
                       javax.crypto.spec.IvParameterSpec.class ) ) {
-                params = new IVParameterSpec( kg.generatePBE_IV() );
+                params = new IvParameterSpec( kg.generatePBE_IV() );
                 break;
             }
         }
@@ -415,10 +415,9 @@ public class EncryptedPrivateKeyInfo implements ASN1Value {
         EncryptionAlgorithm encAlg = ((PBEAlgorithm)kgAlg).getEncryptionAlg();
         AlgorithmParameterSpec algParams = null;
         Class<?> [] paramClasses = encAlg.getParameterClasses();
-        for (int i = 0; i < paramClasses.length; i ++) {
-            if ( paramClasses[i].equals(
-                      javax.crypto.spec.IvParameterSpec.class ) ) {
-                algParams = new IVParameterSpec( kg.generatePBE_IV() );
+        for (int i = 0; i < paramClasses.length; i++) {
+            if (paramClasses[i].equals(IvParameterSpec.class)) {
+                algParams = new IvParameterSpec(kg.generatePBE_IV());
                 break;
             }
         }


### PR DESCRIPTION
[`org.mozilla.jss.crypto.IVParameterSpec`](https://dogtagpki.github.io/jss/master/javadocs/org/mozilla/jss/crypto/IVParameterSpec.html) is an artifact from the dark ages when Java didn't support much crypto.

Now there's [`javax.crypto.spec.IvParameterSpec`](https://docs.oracle.com/javase/8/docs/api/javax/crypto/spec/IvParameterSpec.html). We've supported both for a while. To finally deprecate the former, make it inherit from the latter, removing its implementation completely.

There's two commits here:

1. Merge the implementations.
2. Combine all usages of the former into only caring about the latter. 

If you have better one-line commit messages, do tell me, else I could just do it in one commit.