### PR TITLE
Fix base64-encoding of CSRs

### DIFF
--- a/org/mozilla/jss/netscape/security/util/Utils.java
+++ b/org/mozilla/jss/netscape/security/util/Utils.java
@@ -378,7 +378,10 @@ public class Utils {
      * @return base-64 encoded data
      */
     public static String base64encodeMultiLine(byte[] bytes) {
-        return Base64.getMimeEncoder().encodeToString(bytes);
+        // When switching from apache-commons-codec to the standard library,
+        // the standard library does not include a final line separator at
+        // the end of the encoded data. This results in malformed CSRs.
+        return Base64.getMimeEncoder().encodeToString(bytes) + "\r\n";
     }
 
 


### PR DESCRIPTION
In 8de4440c5652f6f1af5b4b923a15730ba84f29e1, the base64 encoder was
changed from `apache-commons-codec` to the Java standard library to drop
a dependency. However, the behavior changed as a result: the Java
standard library doesn't include a final line separator, whereas
`apache-commons-codec` did. This results in malformed CSRs:

> YWRPxyBKvFAOB29fwPwBJLZksrwQ0xAs7sooc+qF-----END NEW CERTIFICATE REQUEST-----

Resolves: https://pagure.io/freeipa/issue/8199

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`