### PR TITLE
Fix EncryptedPrivateKeyInfo.createPBE

### DIFF
--- a/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
+++ b/org/mozilla/jss/crypto/KeyWrapAlgorithm.java
@@ -138,7 +138,10 @@ public class KeyWrapAlgorithm extends Algorithm {
 
     public static KeyWrapAlgorithm fromOID(String wrapOID) throws NoSuchAlgorithmException {
         OBJECT_IDENTIFIER oid = new OBJECT_IDENTIFIER(wrapOID);
+        return fromOID(oid);
+    }
 
+    public static KeyWrapAlgorithm fromOID(OBJECT_IDENTIFIER oid) throws NoSuchAlgorithmException {
         if (oid.equals(AES_KEY_WRAP_PAD_OID))
             return AES_KEY_WRAP_PAD;
 
@@ -154,6 +157,6 @@ public class KeyWrapAlgorithm extends Algorithm {
         if (oid.equals(DES_CBC_PAD_OID))
             return DES_CBC_PAD;
 
-        throw new NoSuchAlgorithmException("Unknown Algorithm for OID: " + wrapOID);
+        throw new NoSuchAlgorithmException("Unknown Algorithm for OID: " + oid);
     }
 }

--- a/org/mozilla/jss/pkcs7/EncryptedContentInfo.java
+++ b/org/mozilla/jss/pkcs7/EncryptedContentInfo.java
@@ -182,7 +182,7 @@ public class EncryptedContentInfo implements ASN1Value {
         // generate IV
         EncryptionAlgorithm encAlg = pbeAlg.getEncryptionAlg();
         AlgorithmParameterSpec params=null;
-        Class<?> [] paramClasses = pbeAlg.getParameterClasses();
+        Class<?> [] paramClasses = encAlg.getParameterClasses();
         for (int i = 0; i < paramClasses.length; i ++) {
             if ( paramClasses[i].equals(
                       javax.crypto.spec.IvParameterSpec.class ) ) {

--- a/org/mozilla/jss/pkix/cms/EncryptedContentInfo.java
+++ b/org/mozilla/jss/pkix/cms/EncryptedContentInfo.java
@@ -180,7 +180,7 @@ public class EncryptedContentInfo implements ASN1Value {
         // generate IV
         EncryptionAlgorithm encAlg = pbeAlg.getEncryptionAlg();
         AlgorithmParameterSpec params=null;
-        Class<?> [] paramClasses = pbeAlg.getParameterClasses();
+        Class<?> [] paramClasses = encAlg.getParameterClasses();
         for (int i = 0; i < paramClasses.length; i ++) {
             if ( paramClasses[i].equals( IVParameterSpec.class ) ) {
                 params = new IVParameterSpec( kg.generatePBE_IV() );

--- a/org/mozilla/jss/pkix/primitive/EncryptedPrivateKeyInfo.java
+++ b/org/mozilla/jss/pkix/primitive/EncryptedPrivateKeyInfo.java
@@ -147,7 +147,7 @@ public class EncryptedPrivateKeyInfo implements ASN1Value {
         // generate IV
         EncryptionAlgorithm encAlg = pbeAlg.getEncryptionAlg();
         AlgorithmParameterSpec params=null;
-        Class<?> [] paramClasses = pbeAlg.getParameterClasses();
+        Class<?> [] paramClasses = encAlg.getParameterClasses();
         for (int i = 0; i < paramClasses.length; i ++) {
             if ( paramClasses[i].equals( javax.crypto.spec.IvParameterSpec.class ) ) {
                 params = new IVParameterSpec( kg.generatePBE_IV() );
@@ -328,7 +328,7 @@ public class EncryptedPrivateKeyInfo implements ASN1Value {
         // generate IV
         EncryptionAlgorithm encAlg = pbeAlg.getEncryptionAlg();
         AlgorithmParameterSpec params=null;
-        Class<?> [] paramClasses = pbeAlg.getParameterClasses();
+        Class<?> [] paramClasses = encAlg.getParameterClasses();
         for (int i = 0; i < paramClasses.length; i ++) {
             if ( paramClasses[i].equals(
                       javax.crypto.spec.IvParameterSpec.class ) ) {

--- a/org/mozilla/jss/pkix/primitive/EncryptedPrivateKeyInfo.java
+++ b/org/mozilla/jss/pkix/primitive/EncryptedPrivateKeyInfo.java
@@ -337,8 +337,8 @@ public class EncryptedPrivateKeyInfo implements ASN1Value {
             }
         }
 
-        KeyWrapper wrapper = token.getKeyWrapper(
-                KeyWrapAlgorithm.DES3_CBC_PAD);
+        // wrap the key
+        KeyWrapper wrapper = token.getKeyWrapper(KeyWrapAlgorithm.fromOID(encAlg.toOID()));
         wrapper.initWrap(key, params);
         byte encrypted[] = wrapper.wrap(pri);
 


### PR DESCRIPTION
This fixes the KRA .p12 recovery failures we've been seeing in Dogtag. 

This fix is in two parts: 

 - Fix swapped parameter names with PBE
 - Use specified algorithm for KeyWrap

See each commit message for additional details. 