### PR TITLE
Finish releasing slots after use

### DIFF
--- a/org/mozilla/jss/crypto/KBKDF.c
+++ b/org/mozilla/jss/crypto/KBKDF.c
@@ -638,10 +638,11 @@ Java_org_mozilla_jss_crypto_KBKDFDerivedKey_getKeyFromHandle(JNIEnv *env, jobjec
     }
 
     slot = PK11_GetSlotFromKey(parent);
-    PK11_FreeSlot(slot);
 
     key = PK11_SymKeyFromHandle(slot, parent, PK11_OriginDerive, mech,
                                 handle, is_perm, NULL);
+
+    PK11_FreeSlot(slot);
 
     return JSS_PK11_wrapSymKey(env, &key);
 }

--- a/org/mozilla/jss/pkcs11/PK11PrivKey.c
+++ b/org/mozilla/jss/pkcs11/PK11PrivKey.c
@@ -92,7 +92,6 @@ Java_org_mozilla_jss_pkcs11_PK11PrivKey_verifyKeyIsOnToken
 	SECKEYPrivateKey *key = NULL;
 	PK11SlotInfo *slot = NULL;
 	PK11SlotInfo *keySlot = NULL;
-	PK11SlotInfo *dbSlot = NULL;
 	PK11SlotInfo *cryptoSlot = NULL;
 
 	if( JSS_PK11_getPrivKeyPtr(env, this, &key) != PR_SUCCESS) {
@@ -106,8 +105,7 @@ Java_org_mozilla_jss_pkcs11_PK11PrivKey_verifyKeyIsOnToken
 	}
 
 	keySlot = PK11_GetSlotFromPrivateKey(key);
-	dbSlot = PK11_GetInternalKeySlot();
-	if(keySlot == dbSlot) {
+	if (PK11_IsInternalKeySlot(keySlot)) {
 		cryptoSlot = PK11_GetInternalSlot();
 		/* hack for internal module */
 		if(slot != keySlot && slot != cryptoSlot) {
@@ -125,10 +123,7 @@ finish:
 	if(keySlot != NULL) {
 		PK11_FreeSlot(keySlot);
 	}
-        if(dbSlot != NULL) {
-		PK11_FreeSlot(dbSlot);
-	}
-        if(cryptoSlot != NULL) {
+	if (cryptoSlot != NULL) {
 		PK11_FreeSlot(cryptoSlot);
 	}
 }


### PR DESCRIPTION
Slots in NSS are reference counted; it is important to release our copy
of the reference when we're done using it. This fixes various instances
of slots either not being released or being released in the wrong order.

This should help to address [`rh-bz#676083`](https://bugzilla.redhat.com/show_bug.cgi?id=676083). It should be tested with additional subsystems to ensure it doesn't break Dogtag. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`