### PR TITLE
Query and Set Default SSL configuration

### DIFF
--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -278,6 +278,66 @@ Java_org_mozilla_jss_nss_SSL_VersionRangeGet(JNIEnv *env, jclass clazz,
     return JSS_SSL_wrapVersionRange(env, vrange);
 }
 
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_SSL_VersionRangeSetDefaultNative(JNIEnv *env, jclass clazz,
+    jint variant_ssl, jint min_ssl, jint max_ssl)
+{
+    SSLVersionRange vrange;
+    SSLProtocolVariant variant;
+
+    PR_ASSERT(env != NULL);
+    PR_SetError(0, 0);
+
+    if (min_ssl < 0 || min_ssl >= JSSL_enums_size ||
+            max_ssl < 0 || max_ssl >= JSSL_enums_size ||
+            variant_ssl < 0 || variant_ssl >= JSSL_enums_size)
+    {
+        char buf[200];
+        snprintf(buf, 200,
+                 "SSL.VersionRangeSetDefaultNative(): for min=%d max=%d "
+                 "variant=%d failed - out of range for array JSSL_enums "
+                 "size: %d", min_ssl, max_ssl, variant_ssl, JSSL_enums_size);
+        JSSL_throwSSLSocketException(env, buf);
+        return SECFailure;
+    }
+
+    vrange.min = JSSL_enums[min_ssl];
+    vrange.max = JSSL_enums[max_ssl];
+    variant = JSSL_enums[variant_ssl];
+
+    return SSL_VersionRangeSetDefault(variant, &vrange);
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_mozilla_jss_nss_SSL_VersionRangeGetDefaultNative(JNIEnv *env,
+    jclass clazz, jint variant_ssl)
+{
+    SSLVersionRange vrange;
+    SSLProtocolVariant variant;
+
+    PR_SetError(0, 0);
+
+    if (variant_ssl < 0 || variant_ssl >= JSSL_enums_size) {
+        char buf[200];
+        snprintf(buf, 200,
+                 "SSL.VersionRangeGetDefaultNative(): for variant=%d failed: "
+                 "out of range for array JSSL_enums size: %d", variant_ssl,
+                 JSSL_enums_size);
+        JSSL_throwSSLSocketException(env, buf);
+        return NULL;
+    }
+
+    variant = JSSL_enums[variant_ssl];
+
+    if (SSL_VersionRangeGetDefault(variant, &vrange) != SECSuccess) {
+        JSS_throwMsg(env, INVALID_PARAMETER_EXCEPTION,
+            "Unable to inquire default SSL version for this protocol");
+        return NULL;
+    }
+
+    return JSS_SSL_wrapVersionRange(env, vrange);
+}
+
 JNIEXPORT jobject JNICALL
 Java_org_mozilla_jss_nss_SSL_SecurityStatus(JNIEnv *env, jclass clazz,
     jobject fd)

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -193,6 +193,34 @@ Java_org_mozilla_jss_nss_SSL_CipherPrefGet(JNIEnv *env, jclass clazz,
 }
 
 JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_SSL_CipherPrefSetDefault(JNIEnv *env, jclass clazz,
+    jint cipher, jboolean enabled)
+{
+    PR_ASSERT(env != NULL);
+    PR_SetError(0, 0);
+
+    return SSL_CipherPrefSetDefault(cipher, enabled);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_mozilla_jss_nss_SSL_CipherPrefGetDefault(JNIEnv *env, jclass clazz,
+    jint cipher)
+{
+    int enabled = false;
+
+    PR_ASSERT(env != NULL);
+    PR_SetError(0, 0);
+
+    if (SSL_CipherPrefGetDefault(cipher, &enabled) != SECSuccess) {
+        JSS_throwMsg(env, ILLEGAL_ARGUMENT_EXCEPTION,
+            "Unknown cipher suite to get or getting its value failed");
+        return enabled;
+    }
+
+    return enabled;
+}
+
+JNIEXPORT int JNICALL
 Java_org_mozilla_jss_nss_SSL_VersionRangeSetNative(JNIEnv *env, jclass clazz,
     jobject fd, jint min_ssl, jint max_ssl)
 {

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -98,6 +98,23 @@ public class SSL {
     public static native boolean CipherPrefGet(SSLFDProxy fd, int cipher) throws Exception;
 
     /**
+     * Set the default preferences for a specific cipher suite across all
+     * future PRFileDesc's.
+     *
+     * See also: SSL_CipherPrefSetDefault in /usr/include/nss3/ssl.h
+     */
+    public static native int CipherPrefSetDefault(int cipher, boolean enabled);
+
+    /**
+     * Get the default preferences for a specific cipher suite across all
+     * future PRFileDesc's. Note that this can raise an Exception when the
+     * cipher is unknown.
+     *
+     * See also: SSL_CipherPrefGetDefault in /usr/include/nss3/ssl.h
+     */
+    public static native boolean CipherPrefGetDefault(int cipher);
+
+    /**
      * Set the range of TLS versions enabled by this server by SSLVersionRange.
      *
      * See also: SSL_VersionRangeSet in /usr/include/nss3/ssl.h

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -11,6 +11,7 @@ import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.pkcs11.PK11PrivKey;
 
 import org.mozilla.jss.ssl.SSLAlertEvent;
+import org.mozilla.jss.ssl.SSLProtocolVariant;
 import org.mozilla.jss.ssl.SSLVersionRange;
 
 public class SSL {
@@ -137,6 +138,56 @@ public class SSL {
      * See also: SSL_VersionRangeSet in /usr/include/nss3/ssl.h
      */
     public static native SSLVersionRange VersionRangeGet(SSLFDProxy fd) throws Exception;
+
+    /**
+     * Set the range of TLS versions enabled by default, for all future
+     * PRFileDesc's of the default protocol variant type, STREAM.
+     *
+     * See also: SSL_VersionRangeSetDefault in /usr/include/nss3/ssl.h
+     */
+    public static int VersionRangeSetDefault(SSLVersionRange range) {
+        return VersionRangeSetDefault(SSLProtocolVariant.STREAM, range);
+    }
+
+    /**
+     * Set the range of TLS versions enabled by default, for all future
+     * PRFileDesc's of the specified protocol variant.
+     *
+     * See also: SSL_VersionRangeSetDefault in /usr/include/nss3/ssl.h
+     */
+    public static int VersionRangeSetDefault(SSLProtocolVariant variant, SSLVersionRange range) {
+        return VersionRangeSetDefaultNative(variant.getEnum(), range.getMinEnum(), range.getMaxEnum());
+    }
+
+    /**
+     * Set the range of default TLS versions enabled in all future
+     * PRFileDesc's. The integer parameters are values of the SSLVersion enum.
+     *
+     * See also: SSL_VersionRangeSet in /usr/include/nss3/ssl.h
+     */
+    private static native int VersionRangeSetDefaultNative(int variant_ssl, int min_ssl, int max_ssl);
+
+    /**
+     * Get the range of TLS versions enabled in all future PRFileDesc's of the
+     * default STREAM protocol variant..
+     *
+     * See also: SSL_VersionRangeGetDefault in /usr/include/nss3/ssl.h
+     */
+    public static SSLVersionRange VersionRangeGetDefault() {
+        return VersionRangeGetDefault(SSLProtocolVariant.STREAM);
+    }
+
+    /**
+     * Get the range of TLS versions enabled in all future PRFileDesc's of the
+     * specified protocol variant.
+     *
+     * See also: SSL_VersionRangeGetDefault in /usr/include/nss3/ssl.h
+     */
+    public static SSLVersionRange VersionRangeGetDefault(SSLProtocolVariant variant) {
+        return VersionRangeGetDefaultNative(variant.getEnum());
+    }
+
+    private static native SSLVersionRange VersionRangeGetDefaultNative(int variant);
 
     /**
      * Check the security status of a SSL handshake.

--- a/org/mozilla/jss/ssl/SSLProtocolVariant.java
+++ b/org/mozilla/jss/ssl/SSLProtocolVariant.java
@@ -16,5 +16,5 @@ public class SSLProtocolVariant {
 
     private SSLProtocolVariant(int val) { _enum = val; }
 
-    int getEnum() { return _enum; }
+    public int getEnum() { return _enum; }
 }


### PR DESCRIPTION
When splitting `JSSEngine` into an abstract class and a reference implementation (in #150), I've left the `SSLFDProxy` instance, `ssl_fd`, in the reference implementation, but moved all the cipher suite configuration to JSSEngine.

This resulted in the need to query default configuration, instead of asking `ssl_fd` how it was configured, though technically this need already existed (as `ssl_fd` could've been `null`, which we largely ignored).

This introduces wrappers for `SSL_CipherPrefSetDefault`, `SSL_CipherPrefGetDefault`, `SSL_VersionRangeGetDefault`, and `SSL_VersionRangeSetDefault`. 