### PR TITLE
JSSProvider - java.security based loader

### DIFF
--- a/cmake/JSSCommon.cmake
+++ b/cmake/JSSCommon.cmake
@@ -191,15 +191,13 @@ macro(jss_build_jars)
     # JAR.
     add_custom_command(
         OUTPUT "${JSS_BUILD_JAR_PATH}"
-        COMMAND "${Java_JAR_EXECUTABLE}" cmf "${CMAKE_BINARY_DIR}/MANIFEST.MF" ${JSS_BUILD_JAR_PATH} org/*
-        WORKING_DIRECTORY "${CLASSES_OUTPUT_DIR}"
+        COMMAND "${Java_JAR_EXECUTABLE}" cmf "${CMAKE_BINARY_DIR}/MANIFEST.MF" "${JSS_BUILD_JAR_PATH}" -C "${CLASSES_OUTPUT_DIR}" org -C "${CLASSES_OUTPUT_DIR}" META-INF
         DEPENDS generate_java
     )
 
     add_custom_command(
         OUTPUT "${JSS_TESTS_JAR_PATH}"
-        COMMAND "${Java_JAR_EXECUTABLE}" cmf "${CMAKE_BINARY_DIR}/MANIFEST.MF" ${JSS_TESTS_JAR_PATH} org/*
-        WORKING_DIRECTORY "${TESTS_CLASSES_OUTPUT_DIR}"
+        COMMAND "${Java_JAR_EXECUTABLE}" cmf "${CMAKE_BINARY_DIR}/MANIFEST.MF" ${JSS_TESTS_JAR_PATH} -C "${TESTS_CLASSES_OUTPUT_DIR}" org
         DEPENDS generate_java
     )
 

--- a/lib/java.security.Provider.in
+++ b/lib/java.security.Provider.in
@@ -1,0 +1,1 @@
+org.mozilla.jss.JSSProvider

--- a/org/mozilla/jss/JSSLoader.java
+++ b/org/mozilla/jss/JSSLoader.java
@@ -1,0 +1,362 @@
+package org.mozilla.jss;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.lang.NullPointerException;
+import java.security.Provider;
+import java.util.Properties;
+
+import org.mozilla.jss.util.Password;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The JSS Loader facilitates loading JSS via the Provider interface directly,
+ * including from a static java.security configuration file.
+ *
+ * This replaces the previous CryptoManager.initialize(...) approach, allowing
+ * better control over where the JSSProvider gets loaded. In order to use this
+ * provider, the caller has to specify a configuration file (either via a
+ * String path or its contents via an InputStream). This configuration file is
+ * a java.util.Properties file. The following keys are understood:
+ *
+ *  - nss.config_dir -- the path to the NSS DB to initialize with
+ *  - nss.cert_prefix -- the prefix for the certificate store
+ *  - nss.key_prefix -- the prefix for the key store
+ *  - nss.secmod_name -- the name of the secmod file
+ *
+ *  - nss.read_only -- whether to open the NSS DB read-only (default: false)
+ *  - nss.java_only -- whether to initialize only the java portion of JSS,
+ *                     and assume that NSS is already initialized (default:
+ *                     false)
+ *
+ *  - nss.pkix_verify -- whether to use PKIX for verification (default: false)
+ *  - nss.no_cert_db -- whether to open the certificate and key databases;
+ *                      see InitializationValues for more info (default: false)
+ *  - nss.no_mod_db -- whether to open the security module database; see
+ *                     InitializationValues for more info (default: false)
+ *  - nss.force_open -- whether to force initializations even if the database
+ *                      cannot be opened; see InitializationValues for more
+ *                      info (default: false)
+ *  - nss.no_root_init -- whether to look for root certificate module and load
+ *                        it; see InitializationValues for more info
+ *                        (default: false)
+ *  - nss.optimize_space -- whether to use smaller tables and caches; see
+ *                          InitializationValues for more info (default: false)
+ *  - nss.pk11_thread_safe -- whether to only load PKCS#11 modules that are
+ *                            thread-safe; see InitializationValues for more
+ *                            info (default: false)
+ *  - nss.pk11_reload -- whether to ignore already initialized errors when
+ *                       loading PKCS#11 modules; see InitializationValues for
+ *                       more info (default: false)
+ *  - nss.no_pk11_finalize -- whether to avoid calling C_Finalize on PKCS#11
+ *                            modules; see InitializationValues for more info
+ *                            (default: false)
+ *  - nss.cooperate -- whether to cooperate with other parts of the program
+ *                     already having initialized NSS (default: false)
+ *
+ *  - jss.fips -- whether to switch this NSS DB into FIPS mode; allowed values
+ *                are ENABLED (to force FIPS mode), DISABLED (to force
+ *                non-FIPS mode), or UNCHANGED (default, to infer the value
+ *                from the NSS DB and/or the system)
+ *
+ *  - jss.ocsp.enabled -- whether or not to enable OCSP checking
+ *  - jss.ocsp.responder.url -- URL of the OCSP responder to check
+ *  - jss.ocsp.responder.cert_nickname -- nickname of the OCSP responder's
+ *                                        certificate in the NSS DB
+ *  - jss.ocsp.policy -- which JSS OCSP checking policy to use; allowed values
+ *                       are NONE, NORMAL, and LEAF_AND_CHAIN; refer to
+ *                       CryptoManager documentation for the difference
+ *
+ *  - jss.password -- static password to use to authenticate to tokens; if
+ *                    this fails, the user will be prompted via the console
+ */
+public class JSSLoader {
+    public static Logger logger = LoggerFactory.getLogger(JSSLoader.class);
+
+    /**
+     * Check if this provider has been configured.
+     */
+    public static boolean loaded() {
+        try {
+            return CryptoManager.getInstance() != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Initialize JSS from the specified path to a configuration file.
+     */
+    public static void init(String config_path) throws Exception {
+        if (config_path == null) {
+            String msg = "Please specify the path to the JSS configuration ";
+            msg += "file in the java.security provider list.";
+            throw new NullPointerException(msg);
+        }
+
+        try (FileInputStream fistream = new FileInputStream(config_path)) {
+            init(fistream);
+            return;
+        }
+    }
+
+    /**
+     * Initialize JSS from an InputStream.
+     */
+    public static void init(InputStream istream) throws Exception {
+        if (loaded()) {
+            return;
+        }
+
+        if (istream == null) {
+            String msg = "Please specify the JSS configuration InputStream ";
+            msg += "in order to properly install this provider.";
+            throw new NullPointerException(msg);
+        }
+
+        Properties config = new Properties();
+        config.load(istream);
+
+        InitializationValues ivs = constructIV(config);
+        parseFipsMode(config, ivs);
+        parseReadOnly(config, ivs);
+
+        parseOCSPSettings(config, ivs);
+        parseProviderSettings(config, ivs);
+        parseNSSSettings(config, ivs);
+
+        CryptoManager.initialize(ivs);
+        CryptoManager cm = CryptoManager.getInstance();
+
+        parseOCSPPolicy(config, cm);
+        parsePasswords(config, cm);
+    }
+
+    /**
+     * Constructs an InitializationValues from the specified properties files,
+     * reading only the properties required to construct a new instance.
+     *
+     * These properties are:
+     *  - nss.config_dir
+     *  - nss.cert_prefix
+     *  - nss.key_prefix
+     *  - nss.secmod_name
+     */
+    private static InitializationValues constructIV(Properties config) {
+        String configDir = config.getProperty("nss.config_dir", "/etc/pki/nssdb");
+        String certPrefix = config.getProperty("nss.cert_prefix");
+        String keyPrefix = config.getProperty("nss.key_prefix");
+        String secmodName = config.getProperty("nss.secmod_name");
+
+        if (certPrefix == null && keyPrefix == null && secmodName == null) {
+            return new InitializationValues(configDir);
+        }
+
+        return new InitializationValues(configDir, certPrefix, keyPrefix, secmodName);
+    }
+
+    /**
+     * Updates the specified InitializationValues with the FIPS-specific
+     * properties.
+     *
+     * These properties are:
+     *  - jss.fips
+     */
+    private static void parseFipsMode(Properties config, InitializationValues ivs) {
+        String mode = config.getProperty("jss.fips", "unchanged");
+
+        if (mode.equalsIgnoreCase("enabled")) {
+            ivs.fipsMode = InitializationValues.FIPSMode.ENABLED;
+        } else if (mode.equalsIgnoreCase("disabled")) {
+            ivs.fipsMode = InitializationValues.FIPSMode.DISABLED;
+        } else if (mode.equalsIgnoreCase("unchanged")) {
+            ivs.fipsMode = InitializationValues.FIPSMode.UNCHANGED;
+        } else {
+            String msg = "Unknown value for jss.fips: " + mode + ". ";
+            msg += "Expecting one of ENABLED, DISABLED, or UNCHANGED.";
+            throw new RuntimeException(msg);
+        }
+    }
+
+    /**
+     * Update the specified InitializationValues with the value of the
+     * nss.read_only property.
+     */
+    private static void parseReadOnly(Properties config, InitializationValues ivs) {
+        Boolean value = parseBoolean(config, "nss.read_only");
+        if (value != null) {
+            ivs.readOnly = value;
+        }
+    }
+
+    /**
+     * Update the specified InitializationValues with the value of the OCSP
+     * properties.
+     *
+     * These properties are:
+     *  - jss.ocsp.enabled
+     *  - jss.ocsp.responder.url
+     *  - jss.ocsp.responder.cert_nickname
+     */
+    private static void parseOCSPSettings(Properties config, InitializationValues ivs) {
+        Boolean enabled = parseBoolean(config, "jss.ocsp.enabled");
+        if (enabled != null) {
+            ivs.ocspCheckingEnabled = enabled;
+        }
+
+        String url = config.getProperty("jss.ocsp.responder.url");
+        ivs.ocspResponderURL = url;
+
+        String nickname = config.getProperty("jss.ocsp.responder.cert_nickname");
+        ivs.ocspResponderCertNickname = nickname;
+    }
+
+    /**
+     * Configure the specified InitializationValues with the correct
+     * provider-related properties.
+     */
+    private static void parseProviderSettings(Properties config, InitializationValues ivs) {
+        // We don't want to do any of this: if the user wanted to, they'd have
+        // already specified this as part of the java.security configuration
+        // file. Plus, we're installing ourselves as the Mozilla-JSS provider.
+        ivs.installJSSProvider = false;
+        ivs.removeSunProvider = false;
+        ivs.installJSSProviderFirst = false;
+    }
+
+    /**
+     * Configure the specified InitializationValues with the values of various
+     * NSS-specific configuration values.
+     *
+     * These properties are:
+     *  - nss.java_only
+     *  - nss.pkix_verify
+     *  - nss.no_cert_db
+     *  - nss.no_mod_db
+     *  - nss.force_open
+     *  - nss.no_root_init
+     *  - nss.optimize_space
+     *  - nss.pk11_thread_safe
+     *  - nss.pk11_reload
+     *  - nss.no_pk11_finalize
+     *  - nss.cooperate
+     */
+    private static void parseNSSSettings(Properties config, InitializationValues ivs) {
+        Boolean initializeJavaOnly = parseBoolean(config, "nss.java_only");
+        if (initializeJavaOnly != null) {
+            ivs.initializeJavaOnly = initializeJavaOnly;
+        }
+
+        Boolean PKIXVerify = parseBoolean(config, "nss.pkix_verify");
+        if (PKIXVerify!= null) {
+            ivs.PKIXVerify= PKIXVerify;
+        }
+
+        Boolean noCertDB = parseBoolean(config, "nss.no_cert_db");
+        if (noCertDB != null) {
+            ivs.noCertDB = noCertDB;
+        }
+
+        Boolean noModDB = parseBoolean(config, "nss.no_mod_db");
+        if (noModDB != null) {
+            ivs.noModDB = noModDB;
+        }
+
+        Boolean forceOpen = parseBoolean(config, "nss.force_open");
+        if (forceOpen != null) {
+            ivs.forceOpen = forceOpen;
+        }
+
+        Boolean noRootInit = parseBoolean(config, "nss.no_root_init");
+        if (noRootInit != null) {
+            ivs.noRootInit = noRootInit;
+        }
+
+        Boolean optimizeSpace = parseBoolean(config, "nss.optimize_space");
+        if (optimizeSpace != null) {
+            ivs.optimizeSpace = optimizeSpace;
+        }
+
+        Boolean PK11ThreadSafe = parseBoolean(config, "nss.pk11_thread_safe");
+        if (PK11ThreadSafe != null) {
+            ivs.PK11ThreadSafe = PK11ThreadSafe;
+        }
+
+        Boolean PK11Reload = parseBoolean(config, "nss.pk11_reload");
+        if (PK11Reload != null) {
+            ivs.PK11Reload = PK11Reload;
+        }
+
+        Boolean noPK11Finalize = parseBoolean(config, "nss.no_pk11_finalize");
+        if (noPK11Finalize != null) {
+            ivs.noPK11Finalize = noPK11Finalize;
+        }
+
+        Boolean cooperate = parseBoolean(config, "nss.cooperate");
+        if (cooperate != null) {
+            ivs.cooperate = cooperate;
+        }
+    }
+
+    /**
+     * Once the CryptoManager has been initialized, update it with the value
+     * of the remaining OCSP propertiy, jss.ocsp.policy.
+     */
+    private static void parseOCSPPolicy(Properties config, CryptoManager cm) {
+        String policy = config.getProperty("jss.ocsp.policy", "NONE");
+
+        if (policy.equalsIgnoreCase("none")) {
+            cm.setOCSPPolicy(CryptoManager.OCSPPolicy.NONE);
+        } else if (policy.equalsIgnoreCase("normal")) {
+            cm.setOCSPPolicy(CryptoManager.OCSPPolicy.NORMAL);
+        } else if (policy.equalsIgnoreCase("leaf_and_chain")) {
+            cm.setOCSPPolicy(CryptoManager.OCSPPolicy.LEAF_AND_CHAIN);
+        } else {
+            String msg = "Unknown value for jss.ocsp.policy: " + policy + ".";
+            msg += "Expecting one of NONE, NORMAL, or LEAF_AND_CHAIN.";
+            throw new RuntimeException(msg);
+        }
+    }
+
+    /**
+     * Once the CryptoManager has been initialized, update it with the correct
+     * PasswordCallback handler.
+     *
+     * Currently only understands a hard-coded password set via jss.password.
+     */
+    private static void parsePasswords(Properties config, CryptoManager cm) {
+        String password = config.getProperty("jss.password");
+        if (password != null && !password.isEmpty()) {
+            Password pass_cb = new Password(password.toCharArray());
+            cm.setPasswordCallback(pass_cb);
+        }
+    }
+
+    /**
+     * Helper function to parse a boolean value at the given key name.
+     *
+     * Returns true if the value is true or yes, false if the value is
+     * false or no, and null if the value is empty or not present. Throws
+     * an exception for a malformed value. Case insensitive.
+     */
+    private static Boolean parseBoolean(Properties config, String key_name) {
+        String value = config.getProperty(key_name);
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+
+        if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("yes")) {
+            return true;
+        }
+
+        if (value.equalsIgnoreCase("false") || value.equalsIgnoreCase("no")) {
+            return false;
+        }
+
+        String msg = "Unknown value for boolean " + key_name + ": " + value;
+        msg += ". Expecting true, false, or not specified.";
+        throw new RuntimeException(msg);
+    }
+}

--- a/org/mozilla/jss/tests/EnumerationZeroTest.java
+++ b/org/mozilla/jss/tests/EnumerationZeroTest.java
@@ -202,16 +202,11 @@ public class EnumerationZeroTest {
         return (X509CRL) cf.generateCRL(new ByteArrayInputStream(data));
     }
 
-    public static void main(String[] args) {
-        try {
-            X509CRL crl = buildCrl(false);
+    public static void main(String[] args) throws Exception {
+        X509CRL crl = buildCrl(false);
 
-            System.out.println(crl.toString());
+        System.out.println(crl.toString());
 
-            buildCrl(true);  // will throw exception
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-        }
+        buildCrl(true);  // will throw exception
     }
 }

--- a/org/mozilla/jss/tests/JCASymKeyGen.java
+++ b/org/mozilla/jss/tests/JCASymKeyGen.java
@@ -48,7 +48,6 @@ public class JCASymKeyGen {
      */
     public JCASymKeyGen( String certDbLoc, String passwdFile) {
         try {
-            CryptoManager.initialize(certDbLoc);
             CryptoManager cm  = CryptoManager.getInstance();
             CryptoToken token = cm.getInternalCryptoToken();
             if (cm.FIPSEnabled()) {
@@ -68,19 +67,7 @@ public class JCASymKeyGen {
                     System.exit(1);
                 }
             }
-        } catch (AlreadyInitializedException ex) {
-            ex.printStackTrace();
-            System.exit(1);
-        } catch (CertDatabaseException ex) {
-            ex.printStackTrace();
-            System.exit(1);
         } catch (NotInitializedException ex) {
-            ex.printStackTrace();
-            System.exit(1);
-        } catch (GeneralSecurityException ex) {
-            ex.printStackTrace();
-            System.exit(1);
-        } catch (KeyDatabaseException ex) {
             ex.printStackTrace();
             System.exit(1);
         }
@@ -446,6 +433,7 @@ public class JCASymKeyGen {
                 System.exit(1);
             }
         }
+
         JCASymKeyGen skg = new JCASymKeyGen(certDbLoc, passwdFile);
         System.out.println(otherProvider + ": " + p.getInfo());
         p = Security.getProvider(MOZ_PROVIDER_NAME);

--- a/org/mozilla/jss/tests/JSSProvider.java
+++ b/org/mozilla/jss/tests/JSSProvider.java
@@ -22,18 +22,21 @@ public class JSSProvider {
         assert(p.get(algo) == null);
     }
 
-    public static void main(String[] args) throws Exception {
-        // Before we initialize the CryptoManager, the JSS Provider shouldn't
-        // exist.
-        assert(Security.getProvider("Mozilla-JSS") == null);
+    public static void listProviders() {
+        System.err.println("Providers:");
+        for (Provider p : Security.getProviders()) {
+            System.err.println(" - " + p);
+        }
+        System.err.println();
+    }
 
-        CryptoManager.initialize(args[0]);
-        CryptoManager cm = CryptoManager.getInstance();
-        cm.setPasswordCallback(new FilePasswordCallback(args[1]));
+    public static void main(String[] args) throws Exception {
+        listProviders();
 
         // Validate that the CryptoManager registers us as the
         // default/first provider.
-        Provider p = Security.getProviders()[0];
+        Provider p = Security.getProvider("Mozilla-JSS");
+        assert(p != null);
         assert(p.getName().equals("Mozilla-JSS"));
         assert(p instanceof org.mozilla.jss.JSSProvider);
 

--- a/tools/java.security.in
+++ b/tools/java.security.in
@@ -1,0 +1,46 @@
+#
+# This is the "master security properties file".
+#
+# An alternate java.security properties file may be specified
+# from the command line via the system property
+#
+#    -Djava.security.properties=<URL>
+#
+# This properties file appends to the master security properties file.
+# If both properties files specify values for the same key, the value
+# from the command-line properties file is selected, as it is the last
+# one loaded.
+#
+# Also, if you specify
+#
+#    -Djava.security.properties==<URL> (2 equals),
+#
+# then that properties file completely overrides the master security
+# properties file.
+#
+# To disable the ability to specify an additional properties file from
+# the command line, set the key security.overridePropertiesFile
+# to false in the master security properties file. It is set to true
+# by default.
+
+#
+# List of providers and their preference orders:
+#
+# This differs from the master file in that we initialize JSS first.
+#
+security.provider.1=org.mozilla.jss.JSSProvider @JSS_CFG_PATH@
+security.provider.2=sun.security.provider.Sun
+security.provider.3=sun.security.rsa.SunRsaSign
+security.provider.4=sun.security.ec.SunEC
+security.provider.5=com.sun.net.ssl.internal.ssl.Provider
+security.provider.6=com.sun.crypto.provider.SunJCE
+security.provider.7=sun.security.jgss.SunProvider
+security.provider.8=com.sun.security.sasl.Provider
+security.provider.9=org.jcp.xml.dsig.internal.dom.XMLDSigRI
+security.provider.10=sun.security.smartcardio.SunPCSC
+
+# Note: JSS and a SunPKCS11-based provider would clash, because it too would
+# initialize NSS. If you see something of the following form in your
+# java.security, it is suggested to remove it:
+#
+# security.provider.11=sun.security.pkcs11.SunPKCS11 ${java.home}/lib/security/nss.cfg

--- a/tools/jss.cfg.in
+++ b/tools/jss.cfg.in
@@ -1,0 +1,3 @@
+nss.config_dir=${NSS_DB_PATH}
+nss.cooperate=true
+jss.password=${DB_PWD}

--- a/tools/run_test.sh.in
+++ b/tools/run_test.sh.in
@@ -9,10 +9,10 @@ export LD_LIBRARY_PATH="${NSS_LIBRARIES}:${CMAKE_BINARY_DIR}:${NSPR_LIBRARIES}"
 
 if [ "$1" == "--gdb" ]; then
     shift
-    gdb --args "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" "$@"
+    gdb --args "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="${CONFIG_OUTPUT_DIR}/java.security" "$@"
 elif [ "$1" == "--valgrind" ]; then
     shift
-    valgrind "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" "$@"
+    valgrind "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="${CONFIG_OUTPUT_DIR}/java.security" "$@"
 else
-    "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" "$@"
+    "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="${CONFIG_OUTPUT_DIR}/java.security" "$@"
 fi


### PR DESCRIPTION
When this works, it will eventually allow us to integrate more closely into the JDK ecosystem. In particular, it'll allow us to replace the providers in `java.security` with our own override list, which means FIPS mode will be more stable.

Eventually, this will also remove some of the need TomcatJSS's initialization logic. In particular, JSS will be already initialized by the JDK prior to starting TomcatJSS, so we can access the JSSProvider's SSLEngine already.