### PR TITLE
Detect NSS with broken CMACs during configuration

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -345,4 +345,20 @@ macro(jss_config_symbols)
     if(NOT HAVE_NSS_KBKDF)
         message(WARNING "Your NSS version doesn't support NIST SP800-108 KBKDF; some features of JSS won't work.")
     endif()
+
+    try_run(CK_HAVE_WORKING_NSS
+            CK_HAVE_COMPILING_NSS
+            ${CMAKE_BINARY_DIR}/results
+            ${CMAKE_SOURCE_DIR}/tools/tests/cmac.c
+            CMAKE_FLAGS
+                "-DINCLUDE_DIRECTORIES=${CMAKE_REQUIRED_INCLUDES}"
+                "-DREQUIRED_FLAGS=${CMAKE_REQUIRED_FLAGS}"
+            COMPILE_OUTPUT_VARIABLE COMP_OUT
+            RUN_OUTPUT_VARIABLE RUN_OUT)
+
+    if (NOT CK_HAVE_WORKING_NSS STREQUAL "0" OR NOT CK_HAVE_COMPILING_NSS)
+        set(HAVE_NSS_CMAC FALSE)
+        set(HAVE_NSS_KBKDF FALSE)
+        message(WARNING "Your NSS version is broken: between NSS v3.47 and v3.50, the values of CKM_AES_CMAC and CKM_AES_CMAC_GENERAL were swapped. Disabling CMAC and KBKDF support.")
+    endif()
 endmacro()

--- a/tools/tests/cmac.c
+++ b/tools/tests/cmac.c
@@ -1,0 +1,10 @@
+#include "nspr.h"
+#include "nss.h"
+#include "pkcs11t.h"
+
+int main() {
+    int test = (CKM_AES_CMAC == 0x0000108AULL);
+    test = test && (CKM_AES_CMAC_GENERAL == 0x0000108BULL);
+
+    return test ? 0 : 1;
+}


### PR DESCRIPTION
NSS versions v3.47 to v3.50 included swapped values for `CKM_AES_CMAC` and
`CKM_AES_CMAC_GENERAL`. This adds feature detection to JSS, disabling CMAC
and KBKDF at compile time for the broken NSS versions.

Related: [`moz-bz#1611209`](https://bugzilla.mozilla.org/show_bug.cgi?id=1611209)

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`


---

Note that this doesn't add runtime detection. I'm still debating if that's worth adding, and what our response should be. Runtime detection would have to actually call the CMAC operation, which would likely involve generating a new key. In FIPS mode, that likely requires the token to be logged in already. 