### PR TITLE
Add documentation about JSSEngine usage and design

### DIFF
--- a/docs/usage/jssengine.md
+++ b/docs/usage/jssengine.md
@@ -54,6 +54,13 @@ used by the SSLEngine and all supported SSLParameters, respectively.
 
 For more information about configuring the `JSSEngine`, see the section below.
 
+Note that the `Mozilla-JSS` provider's `SSLContext` instance also provides
+methods for creating `SSLSocket` factories which conform to the same
+`javax.net.ssl` interfaces. These sockets utilize the `JSSEngine` internally
+and expose many of the same configuration methods under the `JSSSocket` class
+namespace. The results of these factories can be directly cast to `JSSSocket`
+or `JSSServerSocket` as appropriate.
+
 
 ### Direct Utilization
 
@@ -490,7 +497,11 @@ terminate eventually.
 
 Currently we've only implemented the `JSSEngineReferenceImpl`; the optimized
 implementation still needs to be written. In particular, the performance of
-multiple JNI calls per step (`wrap` or `unwrap`) needs to be evaluated.
+multiple JNI calls per step (`wrap` or `unwrap`) needs to be evaluated. We
+could replace this with a copy of the contents of the underlying ByteBuffer,
+perform a PR_Read or PR_Write operation, and then (in the event of a write),
+copy the modified data back. This would give us better performance for large
+buffers.
 
 We only have a single `JSSKeyManager` that doesn't understand SNI; we should
 make sure we support SNI from a client and server perspective.

--- a/docs/usage/jssengine.md
+++ b/docs/usage/jssengine.md
@@ -65,18 +65,18 @@ First, get an instance of `JSSEngine`:
 
 ```java
 /* If no session resumption hints are provided: */
-// JSSEngine engine = JSSEngine<$Impl>();
+// JSSEngine engine = new JSSEngine<$Impl>();
 
 /* If we already know the peer's host and port: */
 // String peerHost;
 // int peerPort;
-// JSSEngine engine = JSSEngine<$Impl>(peerHost, peerPort);
+// JSSEngine engine = new JSSEngine<$Impl>(peerHost, peerPort);
 
 /* Or laastly, if we know the peer's host and port, and want to set
  * a certificate and key to use for our side of the connection: */
 // X509Certificate localCert;
 // PrivateKey localKey;
-JSSEngine engine = JSSEngine<$Impl>(peerHost, peerPort, localCert, localKey);
+JSSEngine engine = new JSSEngine<$Impl>(peerHost, peerPort, localCert, localKey);
 ```
 
 Replace `JSSEngine<$Impl>` with one of the implementing classes below.
@@ -102,7 +102,39 @@ Checking the current mode can be done via `getUseClientMode(...)`.
 
 #### Choosing Key Material
 
-Key material can be chosen in several ways.
+Key material can be chosen in several ways. In every scenario, a JSSKeyManager
+instance needs to be passed to the JSSEngine:
+
+```java
+// JSSEngine inst;
+inst.setKeyManager(new JSSKeyManager());
+```
+
+For direct selection of key from an existing instance, call `setKeyMaterials`:
+
+```java
+// JSSEngine inst;
+inst.setKeyMaterials(myPK11Cert, myPK11PrivKey);
+```
+
+Note that these must be instances of [`PK11Cert`][jss.pk11-cert] and
+[`PK11PrivKey`][jss.pk11-privkey] respectively. These can be obtained from
+the [`CryptoManager`][jss.cryptomanager] and casting `X509Certificate` to
+`PK11Cert` and `PrivateKey` to `PK11PrivKey`.
+
+For selection of a key via an alias in the certificate database, call
+`setCertFromAlias`:
+
+```java
+// JSSEngine inst;
+inst.setCertFromAlias("server-cert-alias");
+```
+
+Lastly, key material could've been provided when the `JSSEngine` was
+constructed; see the section on direct utilization above.
+
+Note that SNI support isn't yet added so the key selection must occur prior
+to the initial handshake.
 
 #### Choosing TLS protocol version
 
@@ -380,6 +412,8 @@ peer's certificates.
 [javax.ssl-context]: https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html "javax.net.ssl.SSLContext"
 [javax.ssl-engine]: https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLEngine.html "javax.net.ssl.SSLEngine"
 [javax.x509trustmanager]: https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/X509TrustManager.html "javax.net.ssl.X509TrustManager"
+[jss.pk11-cert]: https://dogtagpki.github.io/jss/master/javadocs/org/mozilla/jss/pkcs11/PK11Cert.html "org.mozilla.jss.pkcs11.PK11Cert"
+[jss.pk11-privkey]: https://dogtagpki.github.io/jss/master/javadocs/org/mozilla/jss/pkcs11/PK11PrivKey.html "org.mozilla.jss.pkcs11.PK11PrivKey"
 [jss.ssl-socket]: https://dogtagpki.github.io/jss/master/javadocs/org/mozilla/jss/ssl/SSLSocket.html "org.mozilla.jss.ssl.SSLSocket"
 [rfc.tls-1.2]: https://tools.ietf.org/html/rfc5246 "TLSv1.2 RFC 5246"
 [rfc.tls-renegotiation]: https://tools.ietf.org/html/rfc5746#section-5

--- a/docs/usage/jssengine.md
+++ b/docs/usage/jssengine.md
@@ -183,6 +183,15 @@ values as parameters; see the `JSSEngine` javadoc for more information.
 
 #### Using `JSSParameters`
 
+`JSSParameters` largely aligns with `SSLParameters` except that it allows
+two important introductions:
+
+ 1. Selection of key material, like above. See the javadocs on `JSSParameters`
+    for more information.
+ 2. Setting the peer's hostname, for use with validation of certificates. This
+    allows us to tie into NSS's hostname verification directly, instead of
+    responding after the fact by closing the connection.
+
 #### Session Control
 
 The `JSSEngine` lacks many of the session control functions other `SSLEngine`

--- a/docs/usage/jssengine.md
+++ b/docs/usage/jssengine.md
@@ -138,11 +138,63 @@ to the initial handshake.
 
 #### Choosing TLS protocol version
 
+There are two ways to choose TLS protocol version. The first is via the Java
+Provider interface, selecting the TLS version directly. The `Mozilla-JSS`
+provider understands the following aliases:
+
+ - `SSL` and `TLS`, enabling any allowed SSL and TLS protocol version,
+ - `TLSv1.1` to enable only TLS version 1.1 by default,
+ - `TLSv1.2` to enable only TLS version 1.2 by default, and
+ - `TLSv1.3` to enable only TLS version 1.3 by default.
+
+Alternatively, the standard `SSLEngine` configuration method of passing
+a list of protocols to `setEnabledProtocols` is also allowed. Note that this
+will override any value passed via the Provider interface. Additionally, due
+to restrictions in NSS, a contiguous range of protocols will be enabled. For
+example, the following call:
+
+```java
+// SSLEngine inst;
+inst.setEnabledProtocols(new String[] { "TLSv1.1", "TLSv1.3" });
+```
+
+will enable TLSv1.1, TLSv1.2, and TLSv1.3.
+
+Alternative methods are available that take JSS standard `SSLVersion` and
+`SSLVersionRange` values as parameters; see the `JSSEngine` javadoc for
+more information.
+
 #### Choosing Cipher Suite
+
+Configuring cipher suites is performed using the standard `SSLEngine`
+configuration method of passing a list of cipher suites to
+`setEnabledCipherSuites`. We filter the list of passed cipher suites to
+only those allowed by local policy. For example:
+
+```java
+// SSLEngine inst;
+inst.setEnabledCipherSuites(new String[] { "TLS_AES_128_GCM_SHA256" });
+```
+
+will enable only a single TLSv1.3 cipher suite.
+
+Alternative methods are available that take JSS standard `SSLCipher`
+values as parameters; see the `JSSEngine` javadoc for more information.
 
 #### Using `JSSParameters`
 
 #### Session Control
+
+The `JSSEngine` lacks many of the session control functions other `SSLEngine`
+implementations might have. In particular, we:
+
+ - Always enable session resumption; this cannot be disabled.
+ - Allow forced expiration of a session as long as the `SSLEngine`'s
+   connection isn't yet closed.
+ - Report accurate creation/expiration/last accessed times.
+
+However, other features of sessions (such as configuring location and size of
+the session cache) aren't yet configurable.
 
 
 ## Design of the `JSSEngine`


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

This complements PR #150 and adds usage and design documentation about the SSLEngine.

This is still WIP because its missing documentation on:

 - [x] Configuring JSSEngine
 - [x] Non-blocking configuration (Buffer PRFD)
 - [x] Performance issues
 - [x] Handshake Theory
 - [x] PHA/rehandshake
 - [x] Large wrap/unwraps. 

View the documentation [here](https://github.com/cipherboy/jss/blob/jss-engine-docs/docs/usage/jssengine.md).