### PR TITLE
Remove token key checks

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11Cipher.java
+++ b/org/mozilla/jss/pkcs11/PK11Cipher.java
@@ -262,10 +262,6 @@ public final class PK11Cipher extends org.mozilla.jss.crypto.Cipher {
         if( key==null ) {
             throw new InvalidKeyException("Key is null");
         }
-        if( ! key.getOwningToken().equals(token) ) {
-            throw new InvalidKeyException("Key does not reside on the "+
-                "current token");
-        }
         if( ! (key instanceof PK11SymKey) ) {
             throw new InvalidKeyException("Key is not a PKCS #11 key");
         }

--- a/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
+++ b/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
@@ -168,10 +168,6 @@ public final class PK11KeyWrapper implements KeyWrapper {
             throw new InvalidKeyException("Key is null");
         }
         try {
-            if( ! key.getOwningToken().equals(token) ) {
-                throw new InvalidKeyException("Key does not reside on the current token: key owning token="+
-                    key.getOwningToken().getName());
-            }
             if( ! (key instanceof PK11SymKey) ) {
                 throw new InvalidKeyException("Key is not a PKCS #11 key");
             }
@@ -195,10 +191,6 @@ public final class PK11KeyWrapper implements KeyWrapper {
     {
         if( key==null ) {
             throw new InvalidKeyException("Key is null");
-        }
-        if( ! key.getOwningToken().equals(token) ) {
-            throw new InvalidKeyException("Key does not reside on the "+
-                "current token");
         }
         if( ! (key instanceof PK11PrivKey) ) {
             throw new InvalidKeyException("Key is not a PKCS #11 key");
@@ -299,13 +291,6 @@ public final class PK11KeyWrapper implements KeyWrapper {
             throw new InvalidKeyException("key to be wrapped is not a "+
                 "PKCS #11 key");
         }
-/* NSS is capable of moving keys appropriately,
-   so this call is prematurely bailing
-        if( ! symKey.getOwningToken().equals(token) ) {
-            throw new InvalidKeyException("key to be wrapped does not live"+
-                " on the same token as the wrapping key");
-        }
-*/
     }
 
     /**
@@ -320,13 +305,6 @@ public final class PK11KeyWrapper implements KeyWrapper {
             throw new InvalidKeyException("key to be wrapped is not a "+
                 "PKCS #11 key");
         }
-/* NSS is capable of moving keys appropriately,
-   so this call is prematurely bailing
-        if( ! privKey.getOwningToken().equals(token) ) {
-            throw new InvalidKeyException("key to be wrapped does not live"+
-                " on the same token as the wrapping key");
-        }
-*/
     }
 
     /**

--- a/org/mozilla/jss/pkcs11/PK11MessageDigest.java
+++ b/org/mozilla/jss/pkcs11/PK11MessageDigest.java
@@ -47,13 +47,6 @@ public final class PK11MessageDigest extends JSSMessageDigest {
         }
 
         hmacKey = (PK11SymKey) key;
-
-        if( ! key.getOwningToken().equals(token) ) {
-            hmacKey = null;
-            throw new InvalidKeyException(
-                "HMAC key does not live on the same token as this digest");
-        }
-
         this.digestProxy = initHMAC(token, alg, hmacKey);
     }
 


### PR DESCRIPTION
Previously we enforced strict token key matching: the primary key used
for the operation must strictly reside on the current PKCS#11 token,
otherwise JSS would bail. However, NSS has the ability to move the key
to whichever token best supports the given operation. This means that
we'd prematurely bail when the operation would succeed if it were
actually executed. By removing these checks, we still leave the ability
to generate keys on a specific token, we just allow them to be used on
whatever token supports the given operation (and the key is allowed to
be moved to).

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`