### PR TITLE
Enable SSLSession

### DIFF
--- a/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -145,6 +145,12 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     protected JSSSession session;
 
     /**
+     * Internal SSLFDProxy instance; useful for JSSSession support and any
+     * custom extensions the developer wishes to support.
+     */
+    protected SSLFDProxy ssl_fd;
+
+    /**
      * Whether or not the outbound portion of this connection is closed.
      */
     protected boolean is_outbound_closed;
@@ -164,7 +170,7 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     public JSSEngine() {
         super();
 
-        session = new JSSSession(BUFFER_SIZE);
+        session = new JSSSession(this, BUFFER_SIZE);
     }
 
     /**
@@ -177,7 +183,7 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     public JSSEngine(String peerHost, int peerPort) {
         super(peerHost, peerPort);
 
-        session = new JSSSession(BUFFER_SIZE);
+        session = new JSSSession(this, BUFFER_SIZE);
         session.setPeerHost(peerHost);
         session.setPeerPort(peerPort);
     }
@@ -198,9 +204,22 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
         cert = (PK11Cert) localCert;
         key = (PK11PrivKey) localKey;
 
-        session = new JSSSession(BUFFER_SIZE);
+        session = new JSSSession(this, BUFFER_SIZE);
         session.setPeerHost(peerHost);
         session.setPeerPort(peerPort);
+    }
+
+    /**
+     * Get the internal SSLFDProxy object; this should be preferred to
+     * directly accessing ssl_fd.
+     *
+     * Note that ssl_fd can be null at various times during SSLEngine
+     * initialization and destruction. This method should be used with
+     * caution as callers can risk damaging the SSLEngine and making it
+     * unusable or crash.
+     */
+    public SSLFDProxy getSSLFDProxy() {
+        return ssl_fd;
     }
 
     /**

--- a/org/mozilla/jss/tests/TestSSLEngine.java
+++ b/org/mozilla/jss/tests/TestSSLEngine.java
@@ -265,6 +265,12 @@ public class TestSSLEngine {
         if (counter == max_steps) {
             throw new RuntimeException("Unable to complete a handshake in " + max_steps + " steps; assuming we were stuck in an infinite loop: c2s_buffers.size=" + c2s_buffers.size() + " s2c_buffers.size=" + s2c_buffers.size());
         }
+
+        SSLSession c_session = client_eng.getSession();
+        SSLSession s_session = server_eng.getSession();
+
+        assert(c_session.getCipherSuite() == s_session.getCipherSuite());
+        assert(c_session.getProtocol() == s_session.getProtocol());
     }
 
     public static void sendTestData(SSLEngine send, SSLEngine recv, ByteBuffer mesg, ByteBuffer inter, ByteBuffer dest) throws Exception {


### PR DESCRIPTION
After ~#150~ and ~#432~ are merged, this can be rebased, reviewed, and merged.

This enables `SSLSession` in three commits:
 - Moves the `SSLFDProxy` from the specific instances to the `JSSEngine` interface. Also exposes access to it in a coordinated way. (`ssl_fd` is nullable, so callers should always use `getSSLFDProxy()` instead of caching the value).
 - Updates `JSSSession` with new values, sets the values from `JSSEngineReferenceImpl`, and adds some NSS-specific tricks.
 - Adds some basic tests for SSLSession to the test suite. 

This `SSLSession` implementation is definitely advanced enough for both JSS-specific callers and also generic enough to support Tomcat. 