### PR TITLE
Move to proper feature checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 
 # These files are automatically generated from their .in equivalents
 org/mozilla/jss/util/jssver.h
+org/mozilla/jss/jssconfig.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,10 @@ include(Shims)
 # Since we found Java, include UseJava to provide the find_jar function.
 include(UseJava)
 
-# This include is required for the macro check_symbol_exists in jss_config()
+# These includes are required for the macro check_symbol_exists and
+# check_struct_has_member in jss_config().
 include(CheckSymbolExists)
+include(CheckStructHasMember)
 
 # Load JSSConfig module; this defines the jss_config() macro which defines
 # JSS-specific configuration values.

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -17,11 +17,11 @@ macro(jss_config)
     # Configure test variables
     jss_config_tests()
 
-    # Template auto-generated files
-    jss_config_template()
-
     # Check symbols to see what tests we run
     jss_config_symbols()
+
+    # Template auto-generated files
+    jss_config_template()
 endmacro()
 
 macro(jss_config_version MAJOR MINOR PATCH BETA)
@@ -326,6 +326,10 @@ endmacro()
 macro(jss_config_template)
     # Template files
     configure_file(
+        "${PROJECT_SOURCE_DIR}/org/mozilla/jss/jssconfig.h.in"
+        "${PROJECT_SOURCE_DIR}/org/mozilla/jss/jssconfig.h"
+    )
+    configure_file(
         "${PROJECT_SOURCE_DIR}/org/mozilla/jss/util/jssver.h.in"
         "${PROJECT_SOURCE_DIR}/org/mozilla/jss/util/jssver.h"
     )
@@ -397,6 +401,13 @@ macro(jss_config_symbols)
         set(HAVE_NSS_KBKDF FALSE)
         message(WARNING "Your NSS version is broken: between NSS v3.47 and v3.50, the values of CKM_AES_CMAC and CKM_AES_CMAC_GENERAL were swapped. Disabling CMAC and KBKDF support.")
     endif()
+
+    check_struct_has_member(
+        SSLCipherSuiteInfo
+        kdfHash
+        ssl.h
+        HAVE_NSS_CIPHER_SUITE_INFO_KDFHASH
+    )
 endmacro()
 
 macro(jss_config_tests)

--- a/org/mozilla/jss/jssconfig.h.in
+++ b/org/mozilla/jss/jssconfig.h.in
@@ -1,0 +1,6 @@
+#ifndef _CONFIG_H
+#define _CONFIG_H
+
+#cmakedefine HAVE_NSS_CIPHER_SUITE_INFO_KDFHASH 1
+
+#endif


### PR DESCRIPTION
`SSLCipher` was the first use of a feature which could appear in a later
version of NSS than we support. Rather than bumping the minimum NSS
version, we chose to use compile-time detection of the NSS version and
limit our code accordingly. However, this sets a precedence for ignoring
the features actually present in the NSS system. Certain downstream
distributions are fond of backporting features, which means our code
could've executed but didn't.

Switching to feature detection (via the `check_struct_has_member` macro)
allows us to be sure we execute this code on as many platforms as
possible.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`