### PR TITLE
Add CentOS-based CI

### DIFF
--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -51,3 +51,17 @@ jobs:
       uses: actions/checkout@v2
     - name: Build and Run the Docker Image
       run: bash tools/run_container.sh "fedora_sandbox" || echo "::warning ::Job exited with status $?"
+  centos7:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "centos_7" || echo "::warning ::Job exited with status $?"
+  centos8:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "centos_8" || echo "::warning ::Job exited with status $?"

--- a/tools/Dockerfiles/centos_7
+++ b/tools/Dockerfiles/centos_7
@@ -1,0 +1,34 @@
+FROM centos:7
+
+# Install generic dependencies to build jss
+RUN true \
+        && yum update -y \
+        && yum install -y epel-release yum-utils \
+        && yum install -y gcc make cmake3 \
+        && yum-builddep -y jss \
+        && mkdir -p /home/sandbox \
+        && yum clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Install dependencies from the spec file in case they've changed
+# since the last release on this platform.
+RUN true \
+        && yum-builddep -y /home/sandbox/jss/jss.spec \
+        && true
+
+# Perform the actual build from source, not from RPM
+WORKDIR /home/sandbox/jss
+CMD true \
+        && rm -rf build \
+        && mkdir build \
+        && cd build \
+        && cmake3 .. \
+        && make all \
+        && ctest --output-on-failure \
+        && true

--- a/tools/Dockerfiles/centos_8
+++ b/tools/Dockerfiles/centos_8
@@ -1,0 +1,35 @@
+FROM centos:8
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+        && dnf config-manager --enable PowerTools \
+        && dnf module enable -y pki-deps maven javapackages-tools \
+        && dnf build-dep -y jss \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Install dependencies from the spec file in case they've changed
+# since the last release on this platform.
+RUN true \
+        && dnf build-dep -y --spec /home/sandbox/jss/jss.spec \
+        && true
+
+# Perform the actual build from source, not from RPM
+WORKDIR /home/sandbox/jss
+CMD true \
+        && rm -rf build \
+        && mkdir build \
+        && cd build \
+        && cmake .. \
+        && make all \
+        && ctest --output-on-failure \
+        && true


### PR DESCRIPTION
~This will be rebased on top of #440 once that is reviewed and merged.~

----

This adds CentOS 7 and 8 CI to the master branch of JSS, under the optional section. This means it isn't required for merge and if necessary, we can break it. However, adding both CentOS 7 and CentOS 8 should give us a wider range of NSS versions to test on, which I think is a good thing for detecting when we truly need to bump the minimum NSS version in the spec file. 