### PR TITLE
Add support for versioned features

### DIFF
--- a/org/mozilla/jss/tests/TestRawSSL.java
+++ b/org/mozilla/jss/tests/TestRawSSL.java
@@ -119,7 +119,6 @@ public class TestRawSSL {
         SSLChannelInfo r = SSL.GetChannelInfo(ssl_fd);
         assert(r != null);
         assert(r.protocolVersion == null);
-        assert(r.haveNSS334 == true);
 
         System.out.println(r.toString());
 

--- a/org/mozilla/jss/util/VersionedFeature.java
+++ b/org/mozilla/jss/util/VersionedFeature.java
@@ -1,0 +1,95 @@
+package org.mozilla.jss.util;
+
+/**
+ * Representation of a feature supported only by recent enough NSS versions.
+ *
+ * This class controls access to data present only in later NSS versions. It
+ * provides a mechanism for callers to access data when present, returning
+ * null when the data isn't present. This lets callers make an informed decision
+ * about whether or not the given data is available. In the even it isn't, a
+ * recommended NSS version can be suggested.
+ */
+public class VersionedFeature<T> {
+    /**
+     * Whether or not this given field is present.
+     */
+    private boolean present;
+
+    /**
+     * Minimum NSS version this feature is present in.
+     */
+    private String version;
+
+    /**
+     * Version-locked value.
+     */
+    private T value;
+
+    /**
+     * Constructs this feature, knowing only the version it is present in;
+     * defaults to false presence.
+     */
+    public VersionedFeature(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Constructs this feature without a value.
+     */
+    public VersionedFeature(boolean present, String version) {
+        this.present = present;
+        this.version = version;
+    }
+
+    /**
+     * Constructs this feature from a given value.
+     */
+    public VersionedFeature(boolean present, String version, T value) {
+        this.present = present;
+        this.version = version;
+        if (present) {
+            this.value = value;
+        }
+    }
+
+    /**
+     * Sets the value for the feature, when present.
+     *
+     * Also marks this feature as present.
+     */
+    public void setValue(T value) {
+        this.value = value;
+    }
+
+    /**
+     * Marks this feature as present.
+     */
+    public void markPresent() {
+        present = true;
+    }
+
+    /**
+     * Check whether or not this feature is present.
+     */
+    public boolean haveFeature() {
+        return present;
+    }
+
+    /**
+     * Get the minimum NSS version which contains this feature.
+     */
+    public String getMinimumVersion() {
+        return version;
+    }
+
+    /**
+     * Get the value, when present; returns null otherwise.
+     */
+    public T getValue() {
+        if (present) {
+            return value;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
This is one approach to resolve some of the discussion in #432 and #440.

Using `haveNSS<version>` was undesirable for two reasons:

 - As we found out, sometimes these versions are wrong (see #440).
 - Checking a parallel property (versus a property of the value itself) is undesirable.

This allows us to be clear about what the minimum NSS version is to use this feature (+/- OS's backporting is), and should improve clarity in all code which uses this. 

In particular, our interface now wraps values, allowing them to be checked (`haveFeature(...)`) before being accessed (`getValue(...)`) -- with a sane default (`null`) in the case where this feature isn't present.

The one downside is that each value must be individually checked -- in `SSLPreliminaryChannelInfo` we have 3 values with the same NSS version guard that we now much wrap separately. I think this is a fine trade off.