### PR TITLE
Prevent post-handshake configuration changes

### DIFF
--- a/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -398,7 +398,13 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
      * Sets the list of enabled cipher suites from a a list of SSLCipher enum
      * instances.
      */
-    public void setEnabledCipherSuites(SSLCipher[] suites) {
+    public void setEnabledCipherSuites(SSLCipher[] suites) throws IllegalArgumentException {
+        if (ssl_fd != null) {
+            String msg = "Unable to process setEnabledCipherSuites(...) ";
+            msg += "after handshake has started!";
+            throw new IllegalArgumentException(msg);
+        }
+
         if (suites == null || suites.length == 0) {
             logger.warn("JSSEngine.setEnabledCipherSuites(...) given a null list of cipher suites.");
             return;
@@ -508,6 +514,13 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
         if ((min_protocol == null && max_protocol != null) || (min_protocol != null && max_protocol == null)) {
             throw new IllegalArgumentException("Expected min and max to either both be null or both be not-null; not mixed: (" + min + ", " + max + ")");
         }
+
+        if (ssl_fd != null) {
+            String msg = "Unable to process setEnabledProtocols(...) after ";
+            msg += "handshake has started!";
+            throw new IllegalArgumentException(msg);
+        }
+
         min_protocol = min;
         max_protocol = max;
     }
@@ -719,6 +732,12 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
      */
     public void setUseClientMode(boolean mode) throws IllegalArgumentException {
         logger.debug("JSSEngine.setUseClientMode(" + mode + ")");
+        if (ssl_fd != null) {
+            String msg = "Unable to process setUseClientMode(" + mode + ") ";
+            msg += "after handshake has started!";
+            throw new IllegalArgumentException(msg);
+        }
+
         as_server = !mode;
     }
 


### PR DESCRIPTION
Certain parameters cannot be modified after the handshake begins. These
are which mode we're using (client/server), cipher suites, and protocol
versions. Throw an exception when these are changed after the handshake
has begun.
    
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

Discussed in a [comment](https://github.com/dogtagpki/jss/pull/150#discussion_r394689897) on #150. Depends on #434, hence separate PR. 
