### PR TITLE
JSS RSA-PSS support first cut.

### DIFF
--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -59,6 +59,28 @@ public final class JSSProvider extends java.security.Provider {
         put("Alg.Alias.Signature.SHA256/RSA", "SHA-256/RSA");
         put("Alg.Alias.Signature.SHA256withRSA", "SHA-256/RSA");
 
+        put("Signature.RSASSA-PSS",
+            "org.mozilla.jss.provider.java.security.JSSSignatureSpi$RSAPSSSignature");
+
+        put("Alg.Alias.Signature.1.2.840.113549.1.1.10",     "RSASSA-PSS");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.10", "RSASSA-PSS");
+
+        put("Signature.SHA-256/RSA/PSS",
+            "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA256RSAPSS");
+
+        put("Alg.Alias.Signature.SHA256withRSA/PSS","SHA-256/RSA/PSS");
+
+        put("Signature.SHA-384/RSA/PSS",
+            "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA384RSAPSS");
+
+        put("Alg.Alias.Signature.SHA384withRSA/PSS","SHA-384/RSA/PSS");
+
+        put("Signature.SHA-512/RSA/PSS",
+            "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA512RSAPSS");
+
+        put("Alg.Alias.Signature.SHA512withRSA/PSS","SHA-512/RSA/PSS");
+
+
         put("Signature.SHA-384/RSA",
             "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA384RSA");
         put("Alg.Alias.Signature.SHA384/RSA", "SHA-384/RSA");
@@ -155,6 +177,9 @@ public final class JSSProvider extends java.security.Provider {
             "org.mozilla.jss.provider.java.security.IvAlgorithmParameters");
         put("AlgorithmParameters.RC2AlgorithmParameters",
             "org.mozilla.jss.provider.java.security.RC2AlgorithmParameters");
+
+        put("AlgorithmParameters.RSAPSSAlgorithmParameters",
+            "org.mozilla.jss.provider.java.security.RSAPSSAlgorithmParameters");
 
         /////////////////////////////////////////////////////////////
         // Cipher

--- a/org/mozilla/jss/crypto/Algorithm.c
+++ b/org/mozilla/jss/crypto/Algorithm.c
@@ -95,7 +95,8 @@ JSS_AlgInfo JSS_AlgTable[NUM_ALGS] = {
 /* 64 */    {SEC_OID_AES_256_CBC, SEC_OID_TAG},
 /* the CKM_AES_KEY_WRAP_* have different defs than CKM_NSS_AES_KEY_WRAP_*  */
 /* 65 */    {CKM_AES_KEY_WRAP, PK11_MECH},
-/* 66 */    {CKM_AES_KEY_WRAP_PAD, PK11_MECH}
+/* 66 */    {CKM_AES_KEY_WRAP_PAD, PK11_MECH},
+/* 67 */    {SEC_OID_PKCS1_RSA_PSS_SIGNATURE, SEC_OID_TAG}
 /* REMEMBER TO UPDATE NUM_ALGS!!! */
 };
 

--- a/org/mozilla/jss/crypto/Algorithm.h
+++ b/org/mozilla/jss/crypto/Algorithm.h
@@ -24,7 +24,7 @@ typedef struct JSS_AlgInfoStr {
     JSS_AlgType type;
 } JSS_AlgInfo;
 
-#define NUM_ALGS 67
+#define NUM_ALGS 68
 
 extern JSS_AlgInfo JSS_AlgTable[];
 extern CK_ULONG JSS_symkeyUsage[];

--- a/org/mozilla/jss/crypto/Algorithm.java
+++ b/org/mozilla/jss/crypto/Algorithm.java
@@ -227,4 +227,7 @@ public class Algorithm {
     // These underlying defs are currently different from the NSS AES KeyWrap
     protected static final short CKM_AES_KEY_WRAP=65;
     protected static final short CKM_AES_KEY_WRAP_PAD=66;
+    // RSA-PSS
+    protected static final short SEC_OID_PKCS1_RSA_PSS_SIGNATURE = 67;
+
 }

--- a/org/mozilla/jss/crypto/SignatureAlgorithm.java
+++ b/org/mozilla/jss/crypto/SignatureAlgorithm.java
@@ -65,11 +65,44 @@ public class SignatureAlgorithm extends Algorithm {
         }
         return digestAlg;
     }
+
+    public DigestAlgorithm setDigestAlg(DigestAlgorithm alg) throws NoSuchAlgorithmException {
+        if( alg == null ) {
+            throw new NoSuchAlgorithmException();
+        }
+        return digestAlg = alg;
+    }
+
     private DigestAlgorithm digestAlg;
 
     //////////////////////////////////////////////////////////////////////
     // Signature Algorithms
     //////////////////////////////////////////////////////////////////////
+
+    /**********************************************************************
+     * PSS Versions of RSA for different digests.
+     *
+     */
+
+    // PSS Signature with not yet specified Digest
+    //
+
+    //Version with no digest set. Must call setDigestAlg() after initialization
+    //to choose the proper variant
+    public static final SignatureAlgorithm
+    RSAPSSSignature = new SignatureAlgorithm(SEC_OID_PKCS1_RSA_PSS_SIGNATURE, "RSAPSSSignature",
+            null, null, OBJECT_IDENTIFIER.PKCS1.subBranch(10) );
+    public static final SignatureAlgorithm
+    RSAPSSSignatureWithSHA256Digest = new SignatureAlgorithm(SEC_OID_PKCS1_RSA_PSS_SIGNATURE, "RSAPSSSignatureWithSHA256Digest",
+            null, DigestAlgorithm.SHA256, OBJECT_IDENTIFIER.PKCS1.subBranch(10) );
+
+    public static final SignatureAlgorithm
+    RSAPSSSignatureWithSHA384Digest = new SignatureAlgorithm(SEC_OID_PKCS1_RSA_PSS_SIGNATURE, "RSAPSSSignatureWithSHA384Digest",
+            null, DigestAlgorithm.SHA384, OBJECT_IDENTIFIER.PKCS1.subBranch(10) );
+
+    public static final SignatureAlgorithm
+    RSAPSSSignatureWithSHA512Digest = new SignatureAlgorithm(SEC_OID_PKCS1_RSA_PSS_SIGNATURE, "RSAPSSSignatureWithSHA512Digest",
+            null, DigestAlgorithm.SHA384, OBJECT_IDENTIFIER.PKCS1.subBranch(10) );
 
     /**********************************************************************
      * Raw RSA signing. This algorithm does not do any hashing, it merely

--- a/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
+++ b/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
@@ -22,6 +22,10 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.security.AlgorithmParameters;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.spec.InvalidParameterSpecException;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
 
 import org.mozilla.jss.netscape.security.util.DerEncoder;
 import org.mozilla.jss.netscape.security.util.DerInputStream;
@@ -63,7 +67,9 @@ public class AlgorithmId implements Serializable, DerEncoder {
     private ObjectIdentifier algid = null;
 
     // The (parsed) parameters
-    private AlgorithmParameters algParams;
+    private AlgorithmParameters algParams = null;
+    // Use this for the various flavors of the RSA PSS alg.
+    private String cachedAlgName = null;
 
     /**
      * Parameters for this algorithm. These are stored in unparsed
@@ -97,11 +103,13 @@ public class AlgorithmId implements Serializable, DerEncoder {
     public static AlgorithmId get(String algname)
             throws NoSuchAlgorithmException {
         ObjectIdentifier oid = algOID(algname);
-
         if (oid == null)
             throw new NoSuchAlgorithmException("unrecognized algorithm name: " + algname);
-
-        return new AlgorithmId(oid);
+        try {
+            return new AlgorithmId(oid,algname);
+        } catch (Exception e) {
+            throw new NoSuchAlgorithmException(e);
+        }
     }
 
     /**
@@ -150,7 +158,11 @@ public class AlgorithmId implements Serializable, DerEncoder {
                 !algid.equals(sha512WithEC_oid)) {
             alg = new AlgorithmId(algid, params);
         } else {
-            alg = new AlgorithmId(algid);
+            try {
+                alg = new AlgorithmId(algid);
+            } catch (Exception e) {
+                throw new IOException(e);
+            }
         }
         if (params != null)
             alg.decodeParams();
@@ -177,12 +189,83 @@ public class AlgorithmId implements Serializable, DerEncoder {
     }
 
     /**
-     * Constructs a parameterless algorithm ID.
+     * Constructs an algorithm ID with a fully encoded params object
+     * @ param oid the identifier for the algorithm
+     * @ param params the fully encoded AlgorithmIdentifier Object
+     * @throws NoSuchAlgorithmException
+     * @throws IOException
+     */
+    public AlgorithmId(ObjectIdentifier oid, AlgorithmParameters params)
+        throws IOException, NoSuchAlgorithmException {
+        algid = oid;
+        algParams = params;
+
+        if(algParams == null) {
+            throw new NoSuchAlgorithmException("AlgorithmId: unsupported Alg Params.");
+        }
+        this.params = new DerValue(algParams.getEncoded());
+    }
+
+    /**
+     * Constructor that takes the oid and name, so the name can be cachedf or laster use.
+     * @throws NoSuchAlgorithmException
+     * @throws IOException
+     *
+     */
+    public AlgorithmId(ObjectIdentifier oid, String algName) 
+        throws  IOException, NoSuchAlgorithmException {
+        algid = oid;
+        cachedAlgName = algName;
+        /* Create the params if our algorithm is RSA PSS related */
+        if (algName != null && algName.contains("PSS")) {
+            this.algParams = getPSSParams(algName);
+            this.params = new DerValue(this.algParams.getEncoded());
+        }
+    }
+
+    /**
+     * Constructs an  algorithm ID with possible RSAPSS params.
      *
      * @param oid the identifier for the algorithm
      */
     public AlgorithmId(ObjectIdentifier oid) {
         algid = oid;
+        String algName = algName();
+
+        /* Create the params if our algorithm is RSA PSS related */
+        if (algName != null && algName.contains("PSS")) {
+            try {
+                this.algParams = getPSSParams(algName);
+
+                if (this.algParams != null) {
+                    try {
+                        this.params = new DerValue(this.algParams.getEncoded());
+                    } catch (IOException e) {
+                        throw new IOException(e);
+                    }
+                }
+            } catch (Exception e) {
+                //Preserve original signature...
+                System.out.println("Unable to create pssPrams in Algorithmid(ObjectIdentifier oid");
+                this.algParams = null;
+            }
+        }
+    }
+
+    private AlgorithmParameters getPSSParams(String algName)
+            throws NoSuchAlgorithmException, IOException {
+        cachedAlgName = algName;
+
+        AlgorithmParameters ret = null;
+        /* Create the params if our algorithm is RSA PSS related */
+        try {
+            ret = createPSSAlgorithmParameters(algName);
+        } catch (Exception e) {
+            throw new NoSuchAlgorithmException(e);
+        }
+
+        return ret;
+
     }
 
     private AlgorithmId(ObjectIdentifier oid, DerValue params)
@@ -204,8 +287,17 @@ public class AlgorithmId implements Serializable, DerEncoder {
 
     protected void decodeParams() throws IOException {
         try {
-            this.algParams = AlgorithmParameters.getInstance
-                    (this.algid.toString());
+
+            if (algid.equals(AlgorithmId.rsaPSS_oid)) {
+                try {
+                    this.algParams = createPSSAlgorithmParametersFromData(this.params.toByteArray());
+                    return;
+                } catch (Exception e) {
+                    throw new IOException(e);
+                }
+            } else {
+                this.algParams = AlgorithmParameters.getInstance(this.algid.toString());
+            }
         } catch (NoSuchAlgorithmException e) {
             /*
              * This algorithm parameter type is not supported, so we cannot
@@ -229,7 +321,6 @@ public class AlgorithmId implements Serializable, DerEncoder {
     /**
      * DER encode this object onto an output stream.
      * Implements the <code>DerEncoder</code> interface.
-     *
      * @param out
      *            the output stream on which to write the DER encoding.
      *
@@ -255,6 +346,47 @@ public class AlgorithmId implements Serializable, DerEncoder {
             out.write(tmp.toByteArray());
         }
     }
+
+    /**
+     * DER encode this object onto an output stream.
+     * Implements the <code>DerEncoder</code> interface.
+     *
+     * @param out
+     *            the output stream on which to write the DER encoding params,using context value.
+     *
+     * @exception IOException on encoding error.
+     */
+    public void derEncodeWithContext(OutputStream out,int contextVal) throws IOException {
+        try (DerOutputStream tmp = new DerOutputStream()) {
+            DerOutputStream bytes = new DerOutputStream();
+            bytes.putOID(algid);
+
+            byte val = (byte) contextVal;
+            // omit parameter field for ECDSA
+            if (!algid.equals(sha224WithEC_oid) &&
+                    !algid.equals(sha256WithEC_oid) &&
+                    !algid.equals(sha384WithEC_oid) &&
+                    !algid.equals(sha512WithEC_oid)) {
+                if (params == null) {
+                    bytes.putNull();
+                } else
+                    bytes.putDerValue(params);
+            }
+
+            DerOutputStream seq = new DerOutputStream();
+
+            seq.write(DerValue.tag_Sequence, bytes);
+
+            tmp.write(DerValue.createTag(DerValue.TAG_CONTEXT,
+                                             true, val), seq);
+
+
+
+            out.write(tmp.toByteArray());
+        }
+    }
+
+
 
     // XXXX cleaning required
     /**
@@ -369,6 +501,8 @@ public class AlgorithmId implements Serializable, DerEncoder {
         if (name.equals("SHAwithDSA") || name.equals("SHA1withDSA")
                 || name.equals("SHA/DSA") || name.equals("SHA1/DSA"))
             return AlgorithmId.sha1WithDSA_oid;
+        if (name.equals("SHA256withRSA/PSS") || name.equals("SHA384withRSA/PSS") || name.equals("SHA512withRSA/PSS"))
+            return AlgorithmId.rsaPSS_oid;
 
         return null;
     }
@@ -385,7 +519,6 @@ public class AlgorithmId implements Serializable, DerEncoder {
      */
     private String algName() {
         // Common message digest algorithms
-
         if (algid.equals(AlgorithmId.MD5_oid))
             return "MD5"; // RFC 1423
         if (algid.equals(AlgorithmId.MD2_oid))
@@ -398,6 +531,28 @@ public class AlgorithmId implements Serializable, DerEncoder {
             return "SHA384";
         if (algid.equals(AlgorithmId.SHA512_oid))
             return "SHA512";
+
+        if (algid.equals(AlgorithmId.rsaPSS_oid)) {
+            if (cachedAlgName != null) {
+                return cachedAlgName;
+            }
+            // Get alg variant from params info
+            String paramStr = paramsToString();
+            if (paramStr != null && paramStr.contains("HashAlg: SHA-")) {
+                if (paramStr.contains("HashAlg: SHA-256"))
+                    cachedAlgName = "SHA256withRSA/PSS";
+                else if (paramStr.contains("HashAlg: SHA-384"))
+                    cachedAlgName = "SHA384withRSA/PSS";
+                else if (paramStr.contains("HashAlg: SHA-512"))
+                    cachedAlgName = "SHA512withRSA/PSS";
+                else
+                    cachedAlgName = "SHA256withRSA/PSS";
+
+                return cachedAlgName;
+            }
+            cachedAlgName = "SHA256withRSA/PSS";
+            return cachedAlgName;
+        }
 
         // Common key types
 
@@ -472,7 +627,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * Returns a string describing the algorithm and its parameters.
      */
     public String toString() {
-        return (algName() + paramsToString());
+        return (algName() + " " + paramsToString());
     }
 
     /**
@@ -552,7 +707,64 @@ public class AlgorithmId implements Serializable, DerEncoder {
         return algid.equals(id);
     }
 
+    public static AlgorithmParameters createPSSAlgorithmParametersFromData(byte[] der) throws Exception {
+        if (der == null) {
+            throw new Exception("Invalid input data.");
+        }
+        AlgorithmParameters pssParams = null;
+        try {
+            pssParams = AlgorithmParameters.getInstance("RSAPSSAlgorithmParameters", "Mozilla-JSS");
+        } catch (NoSuchProviderException e) {
+            throw new Exception(e);
+        }
 
+        try {
+            pssParams.init(der);
+        } catch (IOException e) {
+            throw new Exception("Error intializing RSAPSS parameters: " + e);
+        }
+        return pssParams;
+    }
+    /* Used to create the PSS algorithm params needed for RSA PSS signatures
+     * for now only support the RSAPSS algoritm with the SHA256 digest
+     * this can be extended to support SHA384 and 512 PSS digests.
+    */
+    public static AlgorithmParameters createPSSAlgorithmParameters(String algName) throws Exception {
+        if (algName == null) {
+            throw new Exception("Invalid Algorithm name input.");
+        }
+        AlgorithmParameters pssParams = null;
+        PSSParameterSpec pssSpec = null;
+        // Make sure we are in the RSA PSS family
+        
+        if (!algName.contains("PSS")) {
+           throw new Exception("PSS Algorithm name not supported.");
+        }
+
+        //Only support for now RSAPSS with SHA256 , 384, and 512
+        //Resulting in different PSSParameterSpec values
+        if ("SHA256withRSA/PSS".equals(algName)) {
+            // Support the most often used SHA-256 hash alg version .
+            pssSpec = new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
+        } else if ("SHA384withRSA/PSS".equals(algName)) {
+            pssSpec = new PSSParameterSpec("SHA-384", "MGF1", MGF1ParameterSpec.SHA384, 48, 1);
+
+        } else if ("SHA384withRSA/PSS".equals(algName)) {
+            pssSpec = new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512, 64, 1);
+        }
+        try {
+            pssParams = AlgorithmParameters.getInstance("RSAPSSAlgorithmParameters", "Mozilla-JSS");
+        } catch (NoSuchProviderException e) {
+            throw new Exception(e);
+        }
+        try {
+            pssParams.init(pssSpec);
+        } catch (InvalidParameterSpecException e) {
+            throw new Exception("Error intializing RSAPSS parameters: " + e);
+        }
+
+        return pssParams;
+    }
 
     /*****************************************************************/
 
@@ -566,7 +778,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
     private static final int SHA256_data[] = { 2, 16, 840, 1, 101, 3, 4, 2, 1 };
     private static final int SHA384_data[] = { 2, 16, 840, 1, 101, 3, 4, 2, 2 };
     private static final int SHA512_data[] = { 2, 16, 840, 1, 101, 3, 4, 2, 3 };
-
+    private static final int MGF1_data[] = { 1,2,840,113549,1,1,8 };
     /**
      * Algorithm ID for the MD2 Message Digest Algorthm, from RFC 1319.
      * OID = 1.2.840.113549.2.2
@@ -592,6 +804,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
 
     public static final ObjectIdentifier SHA512_oid = new ObjectIdentifier(SHA512_data);
 
+    public static final ObjectIdentifier MGF1_oid = new ObjectIdentifier(MGF1_data);
     /*
      * COMMON PUBLIC KEY TYPES
      */
@@ -702,6 +915,10 @@ public class AlgorithmId implements Serializable, DerEncoder {
     private static final int dsaWithSHA1_PKIX_data[] =
                                    { 1, 2, 840, 10040, 4, 3 };
 
+    private static final int rsaPSS_data[] =
+                                   { 1, 2, 840, 113549, 1, 1, 10 };
+
+
     public static final ObjectIdentifier sha1WithEC_oid = new
             ObjectIdentifier(sha1WithEC_data);
 
@@ -716,6 +933,10 @@ public class AlgorithmId implements Serializable, DerEncoder {
 
     public static final ObjectIdentifier sha512WithEC_oid = new
             ObjectIdentifier(sha512WithEC_data);
+
+
+    public static final ObjectIdentifier rsaPSS_oid = new
+            ObjectIdentifier(rsaPSS_data);
 
     /**
      * Identifies a signing algorithm where an MD2 digest is encrypted
@@ -798,7 +1019,8 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * Supported signing algorithms for a RSA key.
      */
     public static final String[] RSA_SIGNING_ALGORITHMS = new String[]
-    { "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withRSA" };
+    { "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withRSA","SHA256withRSA/PSS","SHA384withRSA/PSS","SHA512withRSA/PSS"
+    };
 
     public static final String[] EC_SIGNING_ALGORITHMS = new String[]
     { "SHA256withEC", "SHA384withEC", "SHA512withEC", "SHA1withEC" };
@@ -808,7 +1030,24 @@ public class AlgorithmId implements Serializable, DerEncoder {
      */
     public static final String[] ALL_SIGNING_ALGORITHMS = new String[]
     {
-        "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withRSA",
-        "SHA256withEC", "SHA384withEC", "SHA512withEC", "SHA1withEC"
-    };
+            "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withRSA","SHA256withRSA/PSS","SHA384withRSA/PSS","SHA5121withRSA/PSS",
+            "SHA256withEC", "SHA384withEC", "SHA512withEC", "SHA1withEC" };
+
+    public static void dumpBytes(byte[] data)
+    {
+        String newLine = System.getProperty("line.separator");
+        System.out.println(newLine + "Byte Array Contents: " + newLine);
+        String line = "";
+        for (int i = 0; i < data.length; i++) {
+            int val = data[i] & 0xff;
+            line += Integer.toHexString(val) + " ";
+            if (((i % 8) == 7)) {
+                System.out.println(line);
+                line = "";
+                System.out.println(newLine);
+            }
+        }
+        System.out.println(line);
+        System.out.println(newLine);
+    }
 }

--- a/org/mozilla/jss/pkcs11/KeyType.java
+++ b/org/mozilla/jss/pkcs11/KeyType.java
@@ -111,6 +111,10 @@ public final class KeyType {
     RSA     = new KeyType (new Algorithm[]
                     {
                     SignatureAlgorithm.RSASignature,
+                    SignatureAlgorithm.RSAPSSSignature,
+                    SignatureAlgorithm.RSAPSSSignatureWithSHA256Digest,
+                    SignatureAlgorithm.RSAPSSSignatureWithSHA384Digest,
+                    SignatureAlgorithm.RSAPSSSignatureWithSHA512Digest,
                     SignatureAlgorithm.RSASignatureWithMD2Digest,
                     SignatureAlgorithm.RSASignatureWithMD5Digest,
                     SignatureAlgorithm.RSASignatureWithSHA1Digest,

--- a/org/mozilla/jss/pkcs11/pk11util.h
+++ b/org/mozilla/jss/pkcs11/pk11util.h
@@ -415,7 +415,7 @@ JSS_PK11_getSigContext(JNIEnv *env, jobject proxy, void**pContext,
  *  or NULL if an exception was thrown.
  */
 jobject
-JSS_PK11_wrapSigContextProxy(JNIEnv *env, void **ctxt, SigContextType type);
+JSS_PK11_wrapSigContextProxy(JNIEnv *env, void **ctxt, SigContextType type, PRArenaPool *arena);
 
 /***********************************************************************
  *

--- a/org/mozilla/jss/provider/java/security/JSSSignatureSpi.java
+++ b/org/mozilla/jss/provider/java/security/JSSSignatureSpi.java
@@ -12,6 +12,7 @@ class JSSSignatureSpi extends java.security.SignatureSpi {
 
     org.mozilla.jss.crypto.Signature sig;
     SignatureAlgorithm alg;
+    AlgorithmParameterSpec paramSpec;
 
     private JSSSignatureSpi() { }
 
@@ -35,12 +36,18 @@ class JSSSignatureSpi extends java.security.SignatureSpi {
     {
         try {
             sig = getSigContext(privateKey);
+            if(paramSpec != null) {
+                sig.setParameter(paramSpec);
+            }
             sig.initSign((PrivateKey)privateKey);
         } catch(java.security.NoSuchAlgorithmException e) {
             throw new InvalidKeyException("Algorithm not supported");
         } catch(TokenException e) {
             throw new InvalidKeyException("Token exception occurred");
+        } catch(InvalidAlgorithmParameterException e) {
+            throw new InvalidKeyException("AlgorithmParameterSpec not supported");
         }
+        
     }
 
     private org.mozilla.jss.crypto.Signature
@@ -145,12 +152,12 @@ class JSSSignatureSpi extends java.security.SignatureSpi {
     public void engineSetParameter(AlgorithmParameterSpec params)
         throws InvalidAlgorithmParameterException
     {
-        try {
-            sig.setParameter(params);
-        } catch( TokenException e ) {
+        if(params == null) {
             throw new InvalidAlgorithmParameterException(
-                "TokenException: "+e.toString());
+                "TokenException: parameterspec is null");
         }
+
+        paramSpec = params;
     }
 
     public Object engineGetParameter(String param)
@@ -212,6 +219,29 @@ class JSSSignatureSpi extends java.security.SignatureSpi {
             super(SignatureAlgorithm.RSASignatureWithSHA256Digest);
         }
     }
+    public static class RSAPSSSignature extends JSSSignatureSpi {
+        public RSAPSSSignature() {
+            super(SignatureAlgorithm.RSAPSSSignature);
+        }
+    }
+    public static class SHA256RSAPSS extends JSSSignatureSpi {
+        public SHA256RSAPSS() {
+            super(SignatureAlgorithm.RSAPSSSignatureWithSHA256Digest);
+        }
+    }
+
+    public static class SHA384RSAPSS extends JSSSignatureSpi {
+        public SHA384RSAPSS() {
+            super(SignatureAlgorithm.RSAPSSSignatureWithSHA384Digest);
+        }
+    }
+
+    public static class SHA512RSAPSS extends JSSSignatureSpi {
+        public SHA512RSAPSS() {
+            super(SignatureAlgorithm.RSAPSSSignatureWithSHA512Digest);
+        }
+    }
+
     public static class SHA384RSA extends JSSSignatureSpi {
         public SHA384RSA() {
             super(SignatureAlgorithm.RSASignatureWithSHA384Digest);

--- a/org/mozilla/jss/provider/java/security/RSAPSSAlgorithmParameters.java
+++ b/org/mozilla/jss/provider/java/security/RSAPSSAlgorithmParameters.java
@@ -1,0 +1,245 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*  RSASSA-PSS-params ::= SEQUENCE {
+   hashAlgorithm      [0] OAEP-PSSDigestAlgorithms  DEFAULT sha1,
+   maskGenAlgorithm   [1] PKCS1MGFAlgorithms  DEFAULT mgf1SHA1,
+   saltLength         [2] INTEGER  DEFAULT 20,
+   trailerField       [3] INTEGER  DEFAULT 1
+ }
+
+where
+
+ OAEP-PSSDigestAlgorithms    ALGORITHM-IDENTIFIER ::= {
+   { OID id-sha1 PARAMETERS NULL   }|
+   { OID id-sha224 PARAMETERS NULL   }|
+   { OID id-sha256 PARAMETERS NULL }|
+   { OID id-sha384 PARAMETERS NULL }|
+   { OID id-sha512 PARAMETERS NULL },
+   ...  -- Allows for future expansion --
+ }
+
+ PKCS1MGFAlgorithms    ALGORITHM-IDENTIFIER ::= {
+   { OID id-mgf1 PARAMETERS OAEP-PSSDigestAlgorithms },
+   ...  -- Allows for future expansion --
+ }
+*/
+
+package org.mozilla.jss.provider.java.security;
+
+import java.security.*;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+import java.security.spec.PSSParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
+import java.io.IOException;
+import org.mozilla.jss.util.Assert;
+import org.mozilla.jss.netscape.security.util.BigInt;
+import org.mozilla.jss.netscape.security.x509.AlgorithmId;
+import org.mozilla.jss.netscape.security.util.DerOutputStream;
+import org.mozilla.jss.netscape.security.util.DerInputStream;
+import org.mozilla.jss.netscape.security.util.DerValue;
+import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
+import org.mozilla.jss.asn1.ASN1Template;
+import org.mozilla.jss.asn1.ASN1Value;
+import org.mozilla.jss.asn1.INTEGER;
+import org.mozilla.jss.asn1.InvalidBERException;
+import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
+import org.mozilla.jss.asn1.OCTET_STRING;
+import org.mozilla.jss.asn1.SEQUENCE;
+import org.mozilla.jss.asn1.Tag;
+
+public class RSAPSSAlgorithmParameters extends AlgorithmParametersSpi {
+
+    public final static AlgorithmId defaultHashAlg = new AlgorithmId(AlgorithmId.SHA_oid);
+    public final static AlgorithmId defaultMaskGenFunc  = new AlgorithmId(AlgorithmId.MGF1_oid);
+    public final static BigInt          defaultSaltLen = new BigInt(20);
+    public final static BigInt          defaultTrailerField = new BigInt(1);
+
+    private PSSParameterSpec spec = PSSParameterSpec.DEFAULT;
+    private AlgorithmId hashAlg = defaultHashAlg;
+    private AlgorithmId maskGenFunc = defaultMaskGenFunc;
+    private BigInt saltLen = defaultSaltLen;
+    private BigInt trailerField = defaultTrailerField;
+
+    public RSAPSSAlgorithmParameters() {
+    }
+
+    @Override
+    protected void engineInit(AlgorithmParameterSpec paramSpec)
+            throws InvalidParameterSpecException {
+        spec = (PSSParameterSpec) paramSpec;
+        populateFromSpec();
+    }
+    
+    @Override
+    protected  AlgorithmParameterSpec engineGetParameterSpec(Class paramSpec) 
+            throws InvalidParameterSpecException  {
+        if (paramSpec == PSSParameterSpec.class || paramSpec == AlgorithmParameterSpec.class) {
+            return spec;
+        }
+
+        throw new InvalidParameterSpecException("unknown parameter spec passed to PSS parameters object.");
+    }
+
+    @Override
+    protected void engineInit(byte[] params) throws IOException {
+        decode(new DerInputStream(params), params);
+    }
+
+    @Override
+    protected void engineInit(byte[] params, String format) throws IOException {
+        //Assume Der for now.
+        Assert.notReached("engineInit(byte[],String) not supported");
+        throw new IOException("engineInit(byte[],String) not supported");
+    }
+ 
+    @Override
+    protected byte[] engineGetEncoded() throws IOException {
+        DerOutputStream out = new DerOutputStream();
+        encode(out);
+        return out.toByteArray();
+
+    }
+
+    @Override
+    protected byte[] engineGetEncoded(String format) throws IOException {
+        //Assume Der for now.
+        Assert.notReached("engineGetEncoded(String format)) not supported");
+        throw new IOException("engineGetEncoded(String format)) not supported");
+    }
+
+    @Override
+    protected String engineToString() {
+        String str = new String("Mozilla-JSS PSSAlgorithmParameters " +  getClass().getName() + " HashAlg: " + spec.getDigestAlgorithm() + " MaskGenAlg: " + spec.getMGFAlgorithm() );
+        return str;
+    }
+
+    private void decode(DerInputStream in , byte[] encoded) throws IOException {
+        if(in == null) {
+           throw new IOException("Invalid input.");
+        }
+
+        // Sequence has 3 members, trailer field ignored
+        DerValue seq[] = in.getSequence(3);
+
+        if(seq.length != 3) {
+            throw new IOException("Invalid data!");
+        }
+
+        if(seq[0].isContextSpecific((byte)0)) {
+             seq[0]  = seq[0].data.getDerValue();
+        } else
+             throw new IOException("Invalid encoded data.");
+
+        AlgorithmId algid = AlgorithmId.parse(seq[0]);
+
+        String specAlgName = getSpecAlgName(algid.getName());
+
+        String specMGF1Name = "";
+        // Now the MFG1 parameter hash fun is the same as the main hash func.
+        MGF1ParameterSpec specMFG1ParamSpec = new MGF1ParameterSpec(specAlgName);
+
+        if(seq[1].isContextSpecific((byte)1)) {
+            seq[1]  = seq[1].data.getDerValue();
+        } else
+            throw new IOException("Invalid encoded data.");
+
+        DerInputStream mgf1Str = new DerInputStream(seq[1].toByteArray());
+        DerValue[] seqMgf1 = mgf1Str.getSequence(2);
+
+        ObjectIdentifier mgf1OID = seqMgf1[0].getOID();
+
+        if(!mgf1OID.equals(AlgorithmId.MGF1_oid)) 
+           throw new IOException("Invalid encoded data.");
+        else
+           specMGF1Name = "MGF1";
+               
+        if(seq[2].isContextSpecific((byte)2))
+            seq[2]  = seq[2].data.getDerValue();
+        else
+            throw new IOException("Invalid encoded data.");
+
+        BigInt sLength = seq[2].getInteger();
+
+        this.spec = new PSSParameterSpec(specAlgName, specMGF1Name, specMFG1ParamSpec, sLength.toInt(), 1 /*always defaut trailer */);
+              
+        populateFromSpec(); 
+    }
+ 
+    private void encode(DerOutputStream out) throws IOException {
+
+        try(  
+            DerOutputStream tmp = new DerOutputStream();
+            DerOutputStream mgf = new DerOutputStream();
+            DerOutputStream seq1 = new DerOutputStream();
+            DerOutputStream intStream = new DerOutputStream();
+        ) {
+            // Hash algorithm
+
+            hashAlg.derEncodeWithContext(tmp,0);
+
+            // Mask Gen Function Sequence
+            mgf.putOID(maskGenFunc.getOID());
+
+            // MGF hash alg is the same as the hash Alg at this point.
+
+            hashAlg.encode(mgf);
+            seq1.write(DerValue.tag_Sequence,mgf);
+            tmp.write(DerValue.createTag(DerValue.TAG_CONTEXT,
+                                             true, (byte) 1), seq1);
+
+            // Salt Length
+            intStream.putInteger(saltLen);
+
+            tmp.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte) 2),
+                    intStream);
+
+            //Ignore trailer field, it never changes
+
+            // over all sequence tag
+            out.write(DerValue.tag_Sequence, tmp);
+
+            byte[] data = out.toByteArray();
+        }
+    }
+
+    private void populateFromSpec() {
+        if(spec == null || hashAlg == null) {
+            return;
+        }
+
+        String hashAlgName = spec.getDigestAlgorithm();
+        String maskGenName = spec.getMGFAlgorithm();
+
+        int saltLen = spec.getSaltLength();
+        this.saltLen = new BigInt(saltLen);
+        int trailer = spec.getTrailerField();
+
+        // Create the hash alg and mask gen func objects
+
+        if(hashAlgName.equals("SHA-256")) {
+           hashAlg =  new AlgorithmId(AlgorithmId.SHA256_oid);
+        }  else if(hashAlgName.equals("SHA-512")) {
+           hashAlg =  new AlgorithmId(AlgorithmId.SHA512_oid);
+        }  else if(hashAlgName.equals("SHA-384")) {
+           hashAlg =  new AlgorithmId(AlgorithmId.SHA384_oid);
+        } else {
+           hashAlg =  new AlgorithmId(AlgorithmId.SHA_oid);
+        }
+    }
+
+    private String getSpecAlgName(String algName) {
+    
+        if("SHA256".equals(algName)) 
+            return "SHA-256"; 
+        else if("SHA384".equals(algName))
+            return "SHA-384";
+        else if("SHA512".equals(algName))
+            return "SHA-512";
+        else //default
+            return "SHA-1";
+
+    }
+}

--- a/org/mozilla/jss/tests/JCASigTest.java
+++ b/org/mozilla/jss/tests/JCASigTest.java
@@ -5,6 +5,7 @@
 package org.mozilla.jss.tests;
 
 import java.security.*;
+import java.security.spec.*;
 import java.io.*;
 import org.mozilla.jss.util.*;
 import org.mozilla.jss.*;
@@ -25,6 +26,11 @@ public class JCASigTest {
         try {
             signer = Signature.getInstance(alg);
 
+            if(alg.equals("RSASSA-PSS")) { //Set some params, go for SHA256 version.
+                signer.setParameter(new PSSParameterSpec("SHA-256", "MGF1",
+                    new MGF1ParameterSpec("SHA-256"), 32, 1));
+            }
+
             System.out.println("Created a signing context");
             Provider provider = signer.getProvider();
             System.out.println("The provider used for the signer " 
@@ -38,7 +44,6 @@ public class JCASigTest {
             signer.initSign(
                    (org.mozilla.jss.crypto.PrivateKey)keyPair.getPrivate());
             System.out.println("initialized the signing operation");
-
             signer.update(data);
             System.out.println("updated signature with data");
             signature = signer.sign();
@@ -106,6 +111,10 @@ public class JCASigTest {
             sigTest("SHA-256/RSA", keyPair);
             sigTest("SHA-384/RSA", keyPair);
             sigTest("SHA-512/RSA", keyPair);
+            sigTest("SHA256withRSA/PSS", keyPair);
+            sigTest("SHA384withRSA/PSS", keyPair);
+            sigTest("SHA512withRSA/PSS", keyPair);
+            sigTest("RSASSA-PSS",keyPair);
 
             // Generate an DSA keypair
             kpgen = KeyPairGenerator.getInstance("DSA");

--- a/org/mozilla/jss/tests/all.pl
+++ b/org/mozilla/jss/tests/all.pl
@@ -637,7 +637,7 @@ $testname = "Disable FipsMODE";
 $command = "$java -cp $jss_classpath org.mozilla.jss.tests.FipsTest $testdir disable";
 run_test($testname, $command);
 
-$testname = "Test Big Object Identifiers"
+$testname = "Test Big Object Identifiers";
 $command = "$java -cp $jss_classpath -ea org.mozilla.jss.tests.BigObjectIdentifier";
 run_test($testname, $command);
 

--- a/org/mozilla/jss/util/java_ids.h
+++ b/org/mozilla/jss/util/java_ids.h
@@ -195,6 +195,7 @@ PR_BEGIN_EXTERN_C
 #define SIG_CONTEXT_PROXY_FIELD "sigContext"
 #define SIG_CONTEXT_PROXY_SIG "Lorg/mozilla/jss/pkcs11/SigContextProxy;"
 #define SIG_ALGORITHM_FIELD "algorithm"
+#define SIG_DIGEST_ALGORITHM_FIELD "digestAlgorithm"
 #define SIG_ALGORITHM_SIG "Lorg/mozilla/jss/crypto/Algorithm;"
 #define SIG_PW_FIELD "pwExtractor"
 #define SIG_PW_SIG "Lorg/mozilla/jss/crypto/PasswordExtractor;"


### PR DESCRIPTION
Provide support for the various SHAxxxwithRSAPSS algorithms.

Supprt for 256, 384, and 512 variants included.
Included test case for SHA256withRSA/PSS.

This fix also requires a corresponding fix to the pki server in
order to exercise this functionality in the context of a pki
ca server.