### PR TITLE
CryptoManager - Remove initialization from test suite

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -167,7 +167,7 @@ macro(jss_tests)
     )
     jss_test_java(
         NAME "List_CA_certs"
-        COMMAND "org.mozilla.jss.tests.ListCACerts" "${RESULTS_NSSDB_OUTPUT_DIR}"
+        COMMAND "org.mozilla.jss.tests.ListCACerts" "${RESULTS_NSSDB_OUTPUT_DIR}" "Verbose"
         DEPENDS "Generate_known_DSS_cert_pair"
     )
     jss_test_java(

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -32,6 +32,7 @@ macro(jss_tests)
         NAME "Setup_DBs"
         COMMAND "org.mozilla.jss.tests.SetupDBs" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
         DEPENDS "Create_Setup_DBs"
+        MODE "NONE"
     )
 
     # Various FIPS related tests depend on FIPS being enabled; since this
@@ -49,6 +50,7 @@ macro(jss_tests)
         NAME "Setup_FIPS_DBs"
         COMMAND "org.mozilla.jss.tests.SetupDBs" "${RESULTS_NSSDB_FIPS_OUTPUT_DIR}" "${PASSWORD_FILE}"
         DEPENDS "Create_FIPS_Setup_DBs"
+        MODE "NONE"
     )
 
 
@@ -324,13 +326,13 @@ macro(jss_tests)
             NAME "Enable_FipsMODE"
             COMMAND "org.mozilla.jss.tests.FipsTest" "${RESULTS_NSSDB_FIPS_OUTPUT_DIR}" "enable"
             DEPENDS "Generate_FIPS_known_ECDSA_cert_pair"
-            MODE "FIPS"
+            MODE "NONE"
         )
         jss_test_java(
             NAME "check_FipsMODE"
             COMMAND "org.mozilla.jss.tests.FipsTest" "${RESULTS_NSSDB_FIPS_OUTPUT_DIR}" "chkfips"
             DEPENDS "Enable_FipsMODE"
-            MODE "FIPS"
+            MODE "NONE"
         )
 
         # The current version of NSS features partial support for TLS 1.3 in
@@ -395,7 +397,7 @@ macro(jss_tests)
             NAME "Disable_FipsMODE"
             COMMAND "org.mozilla.jss.tests.FipsTest" "${RESULTS_NSSDB_FIPS_OUTPUT_DIR}" "disable"
             DEPENDS "check_FipsMODE" "SSLClientAuth_FIPSMODE" "HMAC_FIPSMODE" "KeyWrapping_FIPSMODE" "Mozilla_JSS_JCA_Signature_FIPSMODE" "JSS_Signature_test_FipsMODE" "SSLEngine_RSA_FIPSMODE" "SSLEngine_ECDSA_FIPSMODE"
-            MODE "FIPS"
+            MODE "NONE"
         )
     endif()
 
@@ -460,7 +462,7 @@ function(jss_test_java)
     list(APPEND EXEC_COMMAND "-Djava.library.path=${CMAKE_BINARY_DIR}")
     if(TEST_JAVA_MODE STREQUAL "FIPS")
         list(APPEND EXEC_COMMAND "-Djava.security.properties=${CONFIG_OUTPUT_DIR}/fips.security")
-    else()
+    elseif(NOT TEST_JAVA_MODE STREQUAL "NONE")
         list(APPEND EXEC_COMMAND "-Djava.security.properties=${CONFIG_OUTPUT_DIR}/java.security")
     endif()
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/org/mozilla/jss/tests/BadSSL.java
+++ b/org/mozilla/jss/tests/BadSSL.java
@@ -29,7 +29,6 @@ public class BadSSL {
             ocsp = true;
         }
 
-        CryptoManager.initialize(args[0]);
         CryptoManager cm = CryptoManager.getInstance();
 
         if (ocsp) {

--- a/org/mozilla/jss/tests/CloseDBs.java
+++ b/org/mozilla/jss/tests/CloseDBs.java
@@ -26,8 +26,6 @@ public final class CloseDBs extends org.mozilla.jss.DatabaseCloser {
             System.exit(0);
         }
 
-        CryptoManager.initialize( args[0] );
-
         CryptoManager manager = CryptoManager.getInstance();
 
         Enumeration<CryptoToken> tokens = manager.getAllTokens();

--- a/org/mozilla/jss/tests/CrossHMACTest.java
+++ b/org/mozilla/jss/tests/CrossHMACTest.java
@@ -41,7 +41,6 @@ public class CrossHMACTest {
                     "<dbdir> [password file only needed in FIPS mode]");
             System.exit(1);
         }
-        CryptoManager.initialize(argv[0]);
         cm = CryptoManager.getInstance();
 
         if (cm.FIPSEnabled() == true) {

--- a/org/mozilla/jss/tests/DigestTest.java
+++ b/org/mozilla/jss/tests/DigestTest.java
@@ -100,7 +100,6 @@ public class DigestTest {
                         "<dbdir> <File>");
                 System.exit(1);
             }
-            String dbdir = argv[0];
             byte[] toBeDigested;
             int read;
 
@@ -110,8 +109,6 @@ public class DigestTest {
             }
 
             System.out.println(read + " bytes to be digested");
-
-            CryptoManager.initialize(dbdir);
 
             /////////////////////////////////////////////////////////////
             // Test all available algorithms

--- a/org/mozilla/jss/tests/GenerateTestCert.java
+++ b/org/mozilla/jss/tests/GenerateTestCert.java
@@ -127,7 +127,6 @@ public class GenerateTestCert {
         }
         
         try {
-            CryptoManager.initialize(args[0]);
             CryptoManager cm = CryptoManager.getInstance();
             
             CryptoToken tok = cm.getInternalKeyStorageToken();

--- a/org/mozilla/jss/tests/HmacTest.java
+++ b/org/mozilla/jss/tests/HmacTest.java
@@ -49,11 +49,6 @@ public class HmacTest {
   private static void configureCrypto(String[] args)
     throws Exception {
 
-    InitializationValues initializationValues =
-      new InitializationValues(args[0]);
-
-    CryptoManager.initialize(initializationValues);
-
     CryptoManager cryptoManager = CryptoManager.getInstance();
 
     CryptoToken cryptoToken =

--- a/org/mozilla/jss/tests/JCAKeyWrap.java
+++ b/org/mozilla/jss/tests/JCAKeyWrap.java
@@ -175,7 +175,6 @@ public class JCAKeyWrap {
      */
     public JCAKeyWrap(String certDbLoc, String passwdFile) {
         try {
-            CryptoManager.initialize(certDbLoc);
             CryptoManager cm = CryptoManager.getInstance();
             CryptoToken token = cm.getInternalKeyStorageToken();
             PasswordCallback cb = new FilePasswordCallback(passwdFile);
@@ -185,18 +184,6 @@ public class JCAKeyWrap {
                 System.out.println("in Fipsmode.");
             }
         } catch (IOException ex) {
-            ex.printStackTrace();
-            System.exit(1);
-        } catch (KeyDatabaseException ex) {
-            ex.printStackTrace();
-            System.exit(1);
-        } catch (CertDatabaseException ex) {
-            ex.printStackTrace();
-            System.exit(1);
-        } catch (AlreadyInitializedException ex) {
-            ex.printStackTrace();
-            System.exit(1);
-        } catch (GeneralSecurityException ex) {
             ex.printStackTrace();
             System.exit(1);
         } catch (IncorrectPasswordException ex) {

--- a/org/mozilla/jss/tests/JCASigTest.java
+++ b/org/mozilla/jss/tests/JCASigTest.java
@@ -77,10 +77,6 @@ public class JCASigTest {
         String dbdir = args[0];
         String file = args[1];
         try {
-            InitializationValues vals = new
-                                InitializationValues (dbdir );
-            vals.removeSunProvider = true;
-            CryptoManager.initialize(vals);
             manager = CryptoManager.getInstance();
             manager.setPasswordCallback( new FilePasswordCallback(file) );
 

--- a/org/mozilla/jss/tests/JSSE_SSLServer.java
+++ b/org/mozilla/jss/tests/JSSE_SSLServer.java
@@ -149,10 +149,7 @@ public class JSSE_SSLServer {
                 }
 
                 System.out.println("Initializing " + args[5]);
-                InitializationValues vals = new
-                    InitializationValues(configDir);
-                vals.removeSunProvider = false;
-                CryptoManager.initialize(vals);
+
                 manager = CryptoManager.getInstance();
                 manager.setPasswordCallback(
                     new FilePasswordCallback(pwFile) );

--- a/org/mozilla/jss/tests/JSS_FileUploadClient.java
+++ b/org/mozilla/jss/tests/JSS_FileUploadClient.java
@@ -211,7 +211,6 @@ public class JSS_FileUploadClient {
     public void doIt() throws Exception {
 
         try {
-            CryptoManager.initialize(fCertDbPath);
             cm  = CryptoManager.getInstance();
             tok = cm.getInternalKeyStorageToken();
             cb  = new FilePasswordCallback(fPasswordFile);

--- a/org/mozilla/jss/tests/JSS_FileUploadServer.java
+++ b/org/mozilla/jss/tests/JSS_FileUploadServer.java
@@ -76,7 +76,6 @@ public class JSS_FileUploadServer  {
                 fServerCertNick = args[3];
         } catch (Exception e) {}
 
-        CryptoManager.initialize(fCertDbPath);
         CryptoManager    cm = CryptoManager.getInstance();
         CryptoToken     tok = cm.getInternalKeyStorageToken();
         PasswordCallback cb = new FilePasswordCallback(fPasswordFile);

--- a/org/mozilla/jss/tests/JSS_SelfServClient.java
+++ b/org/mozilla/jss/tests/JSS_SelfServClient.java
@@ -532,9 +532,6 @@ public class JSS_SelfServClient implements ConstantsBase, Constants {
             return; /* JSS already initialized */
         }
         try {
-            InitializationValues vals = new
-                    InitializationValues(fCertDbPath);
-            CryptoManager.initialize(vals);
             cm  = CryptoManager.getInstance();
 
             if (cm.FIPSEnabled()) {
@@ -546,22 +543,10 @@ public class JSS_SelfServClient implements ConstantsBase, Constants {
             tok.login(cb);
             bJSS = true;
 
-        }catch (KeyDatabaseException ex) {
-            ex.printStackTrace();
-            System.exit(1);
-        } catch (CertDatabaseException ex) {
-            ex.printStackTrace();
-            System.exit(1);
         } catch (NotInitializedException ex) {
             ex.printStackTrace();
             System.exit(1);
         } catch (IOException ex) {
-            ex.printStackTrace();
-            System.exit(1);
-        } catch (AlreadyInitializedException ex) {
-            ex.printStackTrace();
-            System.exit(1);
-        } catch (GeneralSecurityException ex) {
             ex.printStackTrace();
             System.exit(1);
         } catch (TokenException ex) {

--- a/org/mozilla/jss/tests/JSS_SelfServServer.java
+++ b/org/mozilla/jss/tests/JSS_SelfServServer.java
@@ -127,7 +127,6 @@ public class JSS_SelfServServer  {
         }
 
         if (bVerbose) System.out.println("initializing JSS");
-        CryptoManager.initialize(fCertDbPath);
         CryptoManager    cm = CryptoManager.getInstance();
         CryptoToken     tok = cm.getInternalKeyStorageToken();
         PasswordCallback cb = new FilePasswordCallback(fPasswordFile);

--- a/org/mozilla/jss/tests/KeyFactoryTest.java
+++ b/org/mozilla/jss/tests/KeyFactoryTest.java
@@ -78,7 +78,6 @@ public class KeyFactoryTest {
 		 "<dbdir> <passwordFile>");
             System.exit(1);
         }
-        CryptoManager.initialize(argv[0]);
         CryptoToken tok = CryptoManager.getInstance().getInternalKeyStorageToken();
 	PasswordCallback cb = new FilePasswordCallback(argv[1]);
         tok.login(cb);

--- a/org/mozilla/jss/tests/KeyStoreTest.java
+++ b/org/mozilla/jss/tests/KeyStoreTest.java
@@ -46,7 +46,6 @@ public class KeyStoreTest {
             System.exit(1);
         }
 
-        String nss_db = argv[0];
         String password_file = argv[1];
         String op = argv[2];
 
@@ -56,7 +55,6 @@ public class KeyStoreTest {
             args[i - offset] = argv[i];
         }
 
-        CryptoManager.initialize(nss_db);
         CryptoManager cm = CryptoManager.getInstance();
 
 

--- a/org/mozilla/jss/tests/KeyWrapping.java
+++ b/org/mozilla/jss/tests/KeyWrapping.java
@@ -15,11 +15,7 @@ import java.security.KeyPair;
 
 public class KeyWrapping {
 
-    public static void main(String args[]) {
-
-      try {
-
-        CryptoManager.initialize(".");
+    public static void main(String args[]) throws Exception {
         CryptoManager cm = CryptoManager.getInstance();
         CryptoToken token = cm.getInternalCryptoToken();
         CryptoToken keyToken = cm.getInternalKeyStorageToken();
@@ -132,11 +128,6 @@ public class KeyWrapping {
         recovered = decryptor.doFinal(ciphertext);
         System.out.println("Recovered again:");
         displayByteArray(Cipher.unPad(recovered, 8));
-        
-
-      } catch(Exception e) {
-        e.printStackTrace();
-      }
     }
 
     public static void

--- a/org/mozilla/jss/tests/ListCACerts.java
+++ b/org/mozilla/jss/tests/ListCACerts.java
@@ -4,39 +4,28 @@ import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.crypto.*;
 
 public class ListCACerts {
-    
     public static void main(String args[]) throws Exception {
-        if( args.length > 2) {
+        if (args.length > 2) {
             System.out.println(
                 "Usage: java org.mozilla.jss.tests.ListCACerts <dbdir> [verbose]");
             System.exit(1);
         }
-        try {
-            CryptoManager.initialize(args[0]);
-            CryptoManager cm = CryptoManager.getInstance();
-            
-            X509Certificate[] certs = cm.getCACerts();
-            
-            //added verbose option to limited the output of the tinderbox
-            // and nightly QA.
-            
-            System.out.println("Number of CA certs: " + certs.length);
-            System.out.println("use option \"verbose\" if you want the CA " +
-                "certs printed out");
-            if (args.length == 2 && args[1].equalsIgnoreCase("verbose")) {
-                for(int i=0; i < certs.length; ++i ) {
-                    System.out.println(certs[i].getSubjectDN().toString());
-                    InternalCertificate ic = (InternalCertificate) certs[i];
-                    System.out.println("SSL: " + ic.getSSLTrust() + 
-                        ", Email: " + ic.getEmailTrust() + 
-                        ", Object Signing: " + ic.getObjectSigningTrust());
-                }
+
+        CryptoManager cm = CryptoManager.getInstance();
+
+        X509Certificate[] certs = cm.getCACerts();
+        System.out.println("Number of CA certs: " + certs.length);
+        System.out.println("use option \"verbose\" if you want the CA " +
+            "certs printed out");
+
+        if (args.length == 2 && args[1].equalsIgnoreCase("verbose")) {
+            for (int i = 0; i < certs.length; i++) {
+                System.out.println(certs[i].getSubjectDN().toString());
+                InternalCertificate ic = (InternalCertificate) certs[i];
+                System.out.println("SSL: " + ic.getSSLTrust() + 
+                    ", Email: " + ic.getEmailTrust() + 
+                    ", Object Signing: " + ic.getObjectSigningTrust());
             }
-            
-        } catch(Throwable e) {
-            e.printStackTrace();
-            System.exit(1);
         }
-        System.exit(0);
     }
 }

--- a/org/mozilla/jss/tests/ListCerts.java
+++ b/org/mozilla/jss/tests/ListCerts.java
@@ -28,10 +28,7 @@ public class ListCerts {
                 System.out.println("Usage: ListCerts <dbdir> <nickname>");
                 return;
             }
-            String dbdir = args[0];
             String nickname = args[1];
-
-            CryptoManager.initialize(dbdir);
 
             CryptoManager cm = CryptoManager.getInstance();
 

--- a/org/mozilla/jss/tests/SDR.java
+++ b/org/mozilla/jss/tests/SDR.java
@@ -18,8 +18,6 @@ public class SDR {
     public static void main(String[] args) {
 
       try {
-        CryptoManager.initialize(".");
-
         String cmd = args[0];
         String infile = args[1];
         String outfile = args[2];

--- a/org/mozilla/jss/tests/SSLClientAuth.java
+++ b/org/mozilla/jss/tests/SSLClientAuth.java
@@ -108,7 +108,6 @@ public class SSLClientAuth implements Runnable {
             System.exit(1);
         }
         
-        CryptoManager.initialize(args[0]);
         cm = CryptoManager.getInstance();
         CryptoToken tok = cm.getInternalKeyStorageToken();
         

--- a/org/mozilla/jss/tests/SelfTest.java
+++ b/org/mozilla/jss/tests/SelfTest.java
@@ -34,9 +34,6 @@ public class SelfTest {
             return;
         }
 
-        InitializationValues vals = new
-            InitializationValues( args[0] );
-        CryptoManager.initialize(vals);
         try {
             manager = CryptoManager.getInstance();
         } catch( NotInitializedException e ) {

--- a/org/mozilla/jss/tests/SetupDBs.java
+++ b/org/mozilla/jss/tests/SetupDBs.java
@@ -4,7 +4,7 @@
 
 package org.mozilla.jss.tests;
 
-import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.*;
 import org.mozilla.jss.crypto.*;
 import org.mozilla.jss.util.*;
 
@@ -15,9 +15,8 @@ import org.mozilla.jss.util.*;
 
 public class SetupDBs {
 
-    public static void main(String args[]) {
-      try {
-        if( args.length != 2 ) {
+    public static void main(String args[]) throws Exception {
+        if (args.length != 2) {
             System.err.println("Usage: java org.mozilla.jss.tests.SetupDBs " +
 			       "<dbdir> <passwordFile>\n" + 
                                "Password file should have format:\n " +
@@ -26,21 +25,20 @@ public class SetupDBs {
                                "Key=m1oZilla\n");
             System.exit(1);
         }
-        String dbdir = args[0];
-        
-        CryptoManager.initialize(dbdir);
+
+        // Initialize JSS, preferring the local CryptoManager initialization
+        // over the one from java.security.
+        InitializationValues ivs = new InitializationValues(args[0]);
+        CryptoManager.initialize(ivs);
         CryptoManager cm = CryptoManager.getInstance();
 
+        // Get the internal key storage token so we can set the password.
         CryptoToken tok = cm.getInternalKeyStorageToken();
-        tok.initPassword( new NullPasswordCallback(),
-            new FilePasswordCallback( args[1] )
-        );
-        
-        System.exit(0);
-      } catch(Exception e) {
-        e.printStackTrace();
-        System.exit(1);
-      }
-    }
 
+        // Set the user password to the one from the password file; the
+        // security officer password is empty.
+        PasswordCallback securityOfficerPassword = new NullPasswordCallback();
+        PasswordCallback userPassword = new FilePasswordCallback(args[1]);
+        tok.initPassword(securityOfficerPassword, userPassword);
+    }
 }

--- a/org/mozilla/jss/tests/SigTest.java
+++ b/org/mozilla/jss/tests/SigTest.java
@@ -48,12 +48,7 @@ public class SigTest {
                 usage();
                 System.exit(1);
             }
-            String dbdir = args[0];
 
-
-            InitializationValues vals =
-                    new InitializationValues(args[0]);
-            CryptoManager.initialize(vals);
             manager = CryptoManager.getInstance();
             manager.setPasswordCallback(new FilePasswordCallback(args[1]));
 

--- a/org/mozilla/jss/tests/SymKeyDeriving.java
+++ b/org/mozilla/jss/tests/SymKeyDeriving.java
@@ -74,9 +74,6 @@ public class SymKeyDeriving {
         }
 
         SymmetricKey macKeyDev = null;
-        InitializationValues vals = new InitializationValues(args[0]);
-        vals.removeSunProvider = true;
-        CryptoManager.initialize(vals);
         CryptoManager cm = CryptoManager.getInstance();
         cm.setPasswordCallback(new FilePasswordCallback(args[1]));
         CryptoToken token = cm.getInternalCryptoToken();

--- a/org/mozilla/jss/tests/SymKeyGen.java
+++ b/org/mozilla/jss/tests/SymKeyGen.java
@@ -207,18 +207,9 @@ public class SymKeyGen {
 
     private SymKeyGen( String certDbLoc) {
         try {
-            CryptoManager.initialize(certDbLoc);
             CryptoManager cm  = CryptoManager.getInstance();
             token = cm.getInternalCryptoToken();
-        } catch (AlreadyInitializedException ex) {
-            ex.printStackTrace();
-        } catch (CertDatabaseException ex) {
-            ex.printStackTrace();
         } catch (NotInitializedException ex) {
-            ex.printStackTrace();
-        } catch (GeneralSecurityException ex) {
-            ex.printStackTrace();
-        } catch (KeyDatabaseException ex) {
             ex.printStackTrace();
         }
     }

--- a/org/mozilla/jss/tests/TestBufferPRFD.java
+++ b/org/mozilla/jss/tests/TestBufferPRFD.java
@@ -95,7 +95,6 @@ public class TestBufferPRFD {
 
     public static void InitializeCM(String database, String password) throws Exception {
         CryptoManager manager;
-        CryptoManager.initialize(database);
         manager = CryptoManager.getInstance();
         manager.setPasswordCallback(new Password(password.toCharArray()));
     }

--- a/org/mozilla/jss/tests/TestCmac.java
+++ b/org/mozilla/jss/tests/TestCmac.java
@@ -17,7 +17,6 @@ public class TestCmac {
     private static final byte[] NIST_256 = Base64.getDecoder().decode("YD3rEBXKcb4rc67whX13gR81LAc7YQjXLZgQowkU3/Q=");
 
     public static void main(String[] args) throws Exception {
-        CryptoManager.initialize(args[0]);
         CryptoManager cm = CryptoManager.getInstance();
         CryptoToken tok = cm.getInternalKeyStorageToken();
         PasswordCallback cb = new FilePasswordCallback(args[1]);

--- a/org/mozilla/jss/tests/TestKBKDF.java
+++ b/org/mozilla/jss/tests/TestKBKDF.java
@@ -15,7 +15,6 @@ import org.mozilla.jss.util.*;
 
 public class TestKBKDF {
     public static void main(String[] args) throws Exception {
-        CryptoManager.initialize(args[0]);
         CryptoManager cm = CryptoManager.getInstance();
         TokenSupplier ts = TokenSupplierManager.getTokenSupplier();
         ts.setThreadToken(cm.getInternalCryptoToken());

--- a/org/mozilla/jss/tests/TestKeyGen.java
+++ b/org/mozilla/jss/tests/TestKeyGen.java
@@ -46,7 +46,6 @@ public class TestKeyGen {
             System.exit(1);
         }
 
-        CryptoManager.initialize(args[0]);
         manager = CryptoManager.getInstance();
         manager.setPasswordCallback( new FilePasswordCallback(args[1]) );
 

--- a/org/mozilla/jss/tests/TestSDR.java
+++ b/org/mozilla/jss/tests/TestSDR.java
@@ -23,7 +23,7 @@ public class TestSDR {
         if( args.length != 2 ) {
             throw new Exception("Usage: java TestSDR <dbdir> <pwfile>");
         }
-        CryptoManager.initialize(args[0]);
+
         CryptoManager cm = CryptoManager.getInstance();
         cm.setPasswordCallback( new FilePasswordCallback(args[1]) );
 

--- a/org/mozilla/jss/tests/TestSSLEngine.java
+++ b/org/mozilla/jss/tests/TestSSLEngine.java
@@ -15,8 +15,6 @@ import org.mozilla.jss.provider.javax.crypto.*;
 
 public class TestSSLEngine {
     public static void initialize(String[] args) throws Exception {
-        InitializationValues ivs = new InitializationValues(args[0]);
-        CryptoManager.initialize(ivs);
         CryptoManager cm = CryptoManager.getInstance();
         cm.setPasswordCallback(new FilePasswordCallback(args[1]));
     }

--- a/org/mozilla/jss/tests/VerifyCert.java
+++ b/org/mozilla/jss/tests/VerifyCert.java
@@ -95,7 +95,6 @@ public class VerifyCert {
                 vals.ocspResponderCertNickname = ResponderNickname;
                 vals.ocspResponderURL = ResponderURL;
             }
-            CryptoManager.initialize(vals);
             CryptoManager cm = CryptoManager.getInstance();
             PasswordCallback pwd = new Password(password.toCharArray());
             cm.setPasswordCallback(pwd);

--- a/org/mozilla/jss/tests/X509CertTest.java
+++ b/org/mozilla/jss/tests/X509CertTest.java
@@ -65,7 +65,6 @@ public class X509CertTest {
         Date notAfter = cal.getTime();
 
         //Generate ca keyPair
-        CryptoManager.initialize(dbdir);
         CryptoManager cryptoManager = CryptoManager.getInstance();
         CryptoToken token = cryptoManager.getInternalKeyStorageToken();
         PasswordCallback cb = new FilePasswordCallback(passwordfile);


### PR DESCRIPTION
In an unrelated effort to add another test to JSS, the following bug was discovered:

`CryptoManager.getInstance()` throws a `NotInitializedException` when the `Mozilla-JSS` provider hasn't yet loaded. This means that the following basic test case will fail:

```
instance = CryptoManager.getInstance()
```

Because the provider isn't yet loaded from the `java.security` file. There are four commits here:

 1. Add the above check, and update `CryptoManager.initialize(...)` to be aware of `java.security`.  
 2. Migrate two tests to using this new form of initialize, as they need to be configured specially. (One creates new NSS DBs).
 3. Ensure these tests don't get passed a `java.security` file anyways.
 4. Remove `CryptoManager.initialize(...)` from all other existing tests, to prove the `JSSLoader` really does work. :-)

Some justification and discussion for these changes is given [here](https://gist.github.com/cipherboy/308229616364946df94b382cc93bb5a3). 