### PR TITLE
JSSContext: Default Parameters

### DIFF
--- a/org/mozilla/jss/provider/javax/net/JSSContextSpi.java
+++ b/org/mozilla/jss/provider/javax/net/JSSContextSpi.java
@@ -15,6 +15,7 @@ import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.pkcs11.PK11PrivKey;
 import org.mozilla.jss.ssl.javax.JSSEngine;
 import org.mozilla.jss.ssl.javax.JSSEngineReferenceImpl;
+import org.mozilla.jss.ssl.javax.JSSParameters;
 import org.mozilla.jss.ssl.SSLVersion;
 
 public class JSSContextSpi extends SSLContextSpi {
@@ -94,6 +95,13 @@ public class JSSContextSpi extends SSLContextSpi {
     public SSLSocketFactory engineGetSocketFactory() {
         logger.debug("JSSContextSpi.engineGetSocketFactory() - not implemented");
         return null;
+    }
+
+    public SSLParameters engineGetSupportedSSLParameters() {
+        JSSParameters params = new JSSParameters();
+        params.setCipherSuites(JSSEngine.queryEnabledCipherSuites());
+        params.setProtocols(JSSEngine.queryEnabledProtocols());
+        return params;
     }
 
     public class TLSv11 extends JSSContextSpi {

--- a/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -417,7 +417,7 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
      * Queries the list of cipher suites enabled by default, if a
      * corresponding setEnabledCIpherSuites call hasn't yet been made.
      */
-    private SSLCipher[] queryEnabledCipherSuites() {
+    public static SSLCipher[] queryEnabledCipherSuites() {
         logger.debug("JSSEngine: queryEnabledCipherSuites()");
         ArrayList<SSLCipher> enabledCiphers = new ArrayList<SSLCipher>();
 
@@ -545,7 +545,7 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
      *
      * Only used when setEnabledProtocols(...) hasn't yet been called.
      */
-    private SSLVersionRange queryEnabledProtocols() {
+    public static SSLVersionRange queryEnabledProtocols() {
         logger.debug("JSSEngine: queryEnabledProtocols()");
 
         SSLVersionRange vrange;


### PR DESCRIPTION
The default JDK implementation assumes that all `SSLContextSpi`
implementations expose a `SSLSocket`; it doesn't use a `SSLEngine`
when a `SSLSocket` is unavailable, instead throwing an NPE. Lack
of an overridden `SSLParameters` breaks Tomcat.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

--- 

An alternative is to enumerate `SSLCipher` and check the `supported` field and use `crypto.Policy` to get the default `SSLVersion` values. Thoughts? 