### PR TITLE
Update Version Script

### DIFF
--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -23,3 +23,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Build and Run the Docker Image
       run: bash tools/run_container.sh "fedora_31"
+  symbolcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "symbolcheck"

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -402,6 +402,8 @@ Java_org_mozilla_jss_nss_SSL_AttachClientCertCallback;
 Java_org_mozilla_jss_CryptoManager_getJSSDebug;
 Java_org_mozilla_jss_util_GlobalRefProxy_releaseNativeResources;
 Java_org_mozilla_jss_nss_SSL_EnableAlertLoggingNative;
+Java_org_mozilla_jss_CryptoManager_verifyCertificateNowNative3;
+Java_org_mozilla_jss_nss_SSLFDProxy_releaseNativeResources;
     local:
         *;
 };
@@ -447,6 +449,10 @@ JSS_4.6.4 {
 Java_org_mozilla_jss_nss_SSL_GetChannelInfo;
 Java_org_mozilla_jss_nss_SSL_GetPreliminaryChannelInfo;
 Java_org_mozilla_jss_nss_SSL_InvalidateSession;
+Java_org_mozilla_jss_nss_SSL_CipherPrefGetDefault;
+Java_org_mozilla_jss_nss_SSL_CipherPrefSetDefault;
+Java_org_mozilla_jss_nss_SSL_VersionRangeGetDefaultNative;
+Java_org_mozilla_jss_nss_SSL_VersionRangeSetDefaultNative;
     local:
         *;
 };

--- a/tools/Dockerfiles/symbolcheck
+++ b/tools/Dockerfiles/symbolcheck
@@ -1,0 +1,27 @@
+FROM fedora:latest
+
+# Install generic dependencies to check symbols
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y diffutils grep coreutils \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# List all JNI symbols in the code and in the version script, comparing them,
+# and if the difference is non-empty (test ! -s /tmp/diff.txt), exit with
+# an error.
+WORKDIR /home/sandbox/jss
+CMD true \
+        && grep -iroh '^Java_org_mozilla[^(;]*' org/ | sort -u > /tmp/functions.txt \
+        && grep -iroh '^Java_org_mozilla[^(;]*' lib/ | sort -u > /tmp/version.txt \
+        && comm -23 --check-order /tmp/functions.txt /tmp/version.txt > /tmp/diff.txt \
+        && ( diff /tmp/functions.txt /tmp/version.txt || true ) \
+        && test ! -s /tmp/diff.txt \
+        && true


### PR DESCRIPTION
@edewata reported another issue with JSS, as caught by the PKI CI changes: some functions under `org.mozilla.jss.nss` lacked whitelisting in the version script (`lib/jss.map`). This results in JDK crashes due to missing symbols.

Fix all missing symbols and introduce a CI check to catch this in the future. 