### PR TITLE
Add optional CI to check if PKI build is broken

### DIFF
--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -65,3 +65,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Build and Run the Docker Image
       run: bash tools/run_container.sh "centos_8" || echo "::warning ::Job exited with status $?"
+  buildpki:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "pki_build" || echo "::warning ::Job exited with status $?"

--- a/tools/Dockerfiles/pki_build
+++ b/tools/Dockerfiles/pki_build
@@ -1,0 +1,33 @@
+FROM fedora:latest
+
+# Install generic dependencies to build jss and pki
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/master} \
+        && dnf build-dep -y jss pki-core \
+        && mkdir -p /home/sandbox \
+        && git clone https://github.com/dogtagpki/pki /home/sandbox/pki \
+        && dnf clean -y all \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Install dependencies from the spec file in case they've changed
+# since the last release on this platform.
+RUN true \
+        && dnf build-dep -y --spec /home/sandbox/jss/jss.spec \
+        && dnf build-dep -y --spec /home/sandbox/pki/pki.spec \
+        && true
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && bash ./build.sh --with-timestamp --with-commit-id rpm \
+        && dnf install -y /root/build/jss/RPMS/*.rpm \
+        && cd /home/sandbox/pki \
+        && bash ./build.sh --with-timestamp --with-commit-id rpm \
+        && dnf install -y /root/build/pki/RPMS/*.rpm \
+        && true


### PR DESCRIPTION
This adds an optional CI check that builds JSS and then builds PKI,
installing both sets of RPMs.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

@SilleBille -- is it possible to execute a PKI job inside this? I'd like to at least spawn a few subsystems, but that requires an init system. Got any thoughts for me? 