### PR TITLE
Enable Shutdown of NSS and CryptoManager

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -454,6 +454,7 @@ Java_org_mozilla_jss_nss_SSL_CipherPrefSetDefault;
 Java_org_mozilla_jss_nss_SSL_VersionRangeGetDefaultNative;
 Java_org_mozilla_jss_nss_SSL_VersionRangeSetDefaultNative;
 Java_org_mozilla_jss_util_GlobalRefProxy_refOf;
+Java_org_mozilla_jss_CryptoManager_shutdownNative;
     local:
         *;
 };

--- a/org/mozilla/jss/CryptoManager.c
+++ b/org/mozilla/jss/CryptoManager.c
@@ -1035,3 +1035,10 @@ Java_org_mozilla_jss_CryptoManager_getJSSDebug(JNIEnv *env, jobject this)
 #endif
 }
 
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_CryptoManager_shutdownNative(JNIEnv *env, jobject this)
+{
+    if (NSS_IsInitialized()) {
+        NSS_Shutdown();
+    }
+}

--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -36,6 +36,7 @@ import org.mozilla.jss.pkcs11.PK11Token;
 import org.mozilla.jss.provider.java.security.JSSMessageDigestSpi;
 import org.mozilla.jss.util.Assert;
 import org.mozilla.jss.util.InvalidNicknameException;
+import org.mozilla.jss.util.NativeProxy;
 import org.mozilla.jss.util.PasswordCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1390,4 +1391,19 @@ public final class CryptoManager implements TokenSupplier
     private native void setOCSPTimeoutNative(
         int ocsp_timeout )
                     throws GeneralSecurityException;
+
+    /**
+     * Shutdowns this CryptoManager instance and the associated NSS
+     * initialization.
+     */
+    public synchronized void shutdown() throws Exception {
+        try {
+            NativeProxy.purgeAllInRegistry();
+        } finally {
+            shutdownNative();
+            CryptoManager.instance = null;
+        }
+    }
+
+    public native void shutdownNative();
 }

--- a/org/mozilla/jss/tests/SetupDBs.java
+++ b/org/mozilla/jss/tests/SetupDBs.java
@@ -40,5 +40,7 @@ public class SetupDBs {
         PasswordCallback securityOfficerPassword = new NullPasswordCallback();
         PasswordCallback userPassword = new FilePasswordCallback(args[1]);
         tok.initPassword(securityOfficerPassword, userPassword);
+
+        cm.shutdown();
     }
 }

--- a/tools/run_test.sh.in
+++ b/tools/run_test.sh.in
@@ -12,7 +12,7 @@ if [ "$1" == "--gdb" ]; then
     gdb --args "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="${CONFIG_OUTPUT_DIR}/java.security" "$@"
 elif [ "$1" == "--valgrind" ]; then
     shift
-    valgrind "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="${CONFIG_OUTPUT_DIR}/java.security" "$@"
+    valgrind --leak-check=full --track-origins=yes --show-leak-kinds=all "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="${CONFIG_OUTPUT_DIR}/java.security" "$@"
 else
     "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="${CONFIG_OUTPUT_DIR}/java.security" "$@"
 fi


### PR DESCRIPTION
I'm still trying to decide the semantics I want for this and how far we want to go with it.

This pull request enables shutdown of a `CryptoManager` instance, shutting down NSS in the process. This first frees all remaining `NativeProxy` references, since they're (implicitly?) references to NSS values, which won't work after `NSS_Shutdown` is called. The result is that any attempt to use them will likely throw a `NullPointerException` _somewhere_. 

I did this because in #467, I wanted cleaner memory checking. In particular, I wanted to remove all `NativeProxy` references and clean up after NSS, so the only things that remain are true C level leaks.

Thoughts? 