### PR TITLE
Release JSS v4.4.9

### DIFF
--- a/jss.spec.in
+++ b/jss.spec.in
@@ -6,7 +6,7 @@ Summary:        Java Security Services (JSS)
 URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
-Version:        4.4.8
+Version:        4.4.9
 Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
 
 # To generate the source tarball:

--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -1461,7 +1461,7 @@ public final class CryptoManager implements TokenSupplier
 
 
     public static final String
-    JAR_JSS_VERSION     = "JSS_VERSION = JSS_4_4_8_RTM";
+    JAR_JSS_VERSION     = "JSS_VERSION = JSS_4_4_9_RTM";
     public static final String
     JAR_JDK_VERSION     = "JDK_VERSION = N/A";
     public static final String

--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -19,7 +19,7 @@ public final class JSSProvider extends java.security.Provider {
     /* QUESTION: When do we change MINOR and PATCH to 4 and 0? */
     private static int JSS_MAJOR_VERSION  = 4;
     private static int JSS_MINOR_VERSION  = 4;
-    private static int JSS_PATCH_VERSION  = 8;
+    private static int JSS_PATCH_VERSION  = 9;
     private static double JSS_VERSION     = JSS_MAJOR_VERSION +
                                            (JSS_MINOR_VERSION * 100 +
                                             JSS_PATCH_VERSION)/10000.0;

--- a/org/mozilla/jss/util/jssver.h
+++ b/org/mozilla/jss/util/jssver.h
@@ -25,10 +25,10 @@
 /*                                                                  */
 /********************************************************************/
 
-#define JSS_VERSION  "4.4.8"
+#define JSS_VERSION  "4.4.9"
 #define JSS_VMAJOR   4
 #define JSS_VMINOR   4
-#define JSS_VPATCH   8
+#define JSS_VPATCH   9
 #define JSS_BETA     PR_FALSE
 
 #endif


### PR DESCRIPTION
This version offers two improvements over v4.4.8:

 - Change to dynamic-first libjss4.so linking, mirroring the behavior of
   later JSS releases, and
 - Introduces RSA-PSS signature support.

Thanks to Jack Magne for the RSA-PSS code!

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`