### PR TITLE
Add test for GlobalRefProxy

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -91,6 +91,11 @@ macro(jss_tests)
         NAME "JSS_Test_Buffer"
         COMMAND "org.mozilla.jss.tests.TestBuffer"
     )
+    jss_test_java(
+        NAME "JSS_Test_GlobalRefProxy"
+        COMMAND "org.mozilla.jss.tests.TestGlobalReference"
+        MODE "NONE"
+    )
     if ((${Java_VERSION_MAJOR} EQUAL 1) AND (${Java_VERSION_MINOR} LESS 9))
         jss_test_java(
             NAME "Test_PKCS11Constants.java_for_Sun_compatibility"

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -453,6 +453,7 @@ Java_org_mozilla_jss_nss_SSL_CipherPrefGetDefault;
 Java_org_mozilla_jss_nss_SSL_CipherPrefSetDefault;
 Java_org_mozilla_jss_nss_SSL_VersionRangeGetDefaultNative;
 Java_org_mozilla_jss_nss_SSL_VersionRangeSetDefaultNative;
+Java_org_mozilla_jss_util_GlobalRefProxy_refOf;
     local:
         *;
 };

--- a/org/mozilla/jss/tests/TestGlobalReference.java
+++ b/org/mozilla/jss/tests/TestGlobalReference.java
@@ -1,0 +1,35 @@
+package org.mozilla.jss.tests;
+
+import org.mozilla.jss.util.*;
+
+public class TestGlobalReference {
+    public static void main(String[] args) throws Exception {
+        String arg = "Something";
+
+        for (int i = 0; i < 100; i++) {
+            GlobalRefProxy proxy = new GlobalRefProxy(arg);
+            // This should free the global reference.
+            proxy.close();
+            // This call makes sure the NativeProxy was removed from the
+            // reference tracker; otherwise, the JVM would crash due to a
+            // double free.
+            proxy.close();
+            // This call makes sure clear behaves correctly after a call to
+            // close was also made.
+            proxy.clear();
+        }
+
+        for (int i = 1; i <= 4; i++) {
+            // This attempts to provoke the GC into running, hopefully
+            // executing GlobalRefProxy.finalize(...) on the above objects.
+            // This will be another attempt to trigger a double free, but
+            // we shouldn't crash.
+            System.gc();
+            Thread.sleep(i * 500);
+        }
+
+        // Since we didn't initialize JSS and we freed all our GlobalRefProxy
+        // instances we created, we expect the registry to be empty.
+        NativeProxy.assertRegistryEmpty();
+    }
+}

--- a/org/mozilla/jss/util/GlobalRefProxy.c
+++ b/org/mozilla/jss/util/GlobalRefProxy.c
@@ -66,3 +66,22 @@ Java_org_mozilla_jss_util_GlobalRefProxy_releaseNativeResources
 
     (*env)->DeleteGlobalRef(env, ref);
 }
+
+JNIEXPORT jbyteArray JNICALL
+Java_org_mozilla_jss_util_GlobalRefProxy_refOf
+    (JNIEnv *env, jobject clazz, jobject obj)
+{
+    jobject globalRef;
+
+    PR_ASSERT(env != NULL && clazz != NULL && obj != NULL);
+    if (obj == NULL) {
+        return NULL;
+    }
+
+    globalRef = (*env)->NewGlobalRef(env, obj);
+    if (globalRef == NULL) {
+        return NULL;
+    }
+
+    return JSS_ptrToByteArray(env, globalRef);
+}

--- a/org/mozilla/jss/util/GlobalRefProxy.java
+++ b/org/mozilla/jss/util/GlobalRefProxy.java
@@ -5,5 +5,11 @@ public class GlobalRefProxy extends NativeProxy {
         super(pointer);
     }
 
+    public GlobalRefProxy(Object target) {
+        super(GlobalRefProxy.refOf(target));
+    }
+
+    private static native byte[] refOf(Object target);
+
     protected native void releaseNativeResources();
 }


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

This just adds a test case for `GlobalRefProxy`, since I've been hitting issues with it while trying to address some memory issues in `NativeProxy`. I don't think there is anything wrong with this class, but since I wrote the test, we might as well keep it. 