### PR TITLE
Improve Memory Management

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -455,6 +455,7 @@ Java_org_mozilla_jss_nss_SSL_VersionRangeGetDefaultNative;
 Java_org_mozilla_jss_nss_SSL_VersionRangeSetDefaultNative;
 Java_org_mozilla_jss_util_GlobalRefProxy_refOf;
 Java_org_mozilla_jss_CryptoManager_shutdownNative;
+Java_org_mozilla_jss_nss_SSL_RemoveCallbacks;
     local:
         *;
 };

--- a/org/mozilla/jss/nss/PR.c
+++ b/org/mozilla/jss/nss/PR.c
@@ -90,7 +90,7 @@ Java_org_mozilla_jss_nss_PR_NewBufferPRFD(JNIEnv *env, jclass clazz,
 }
 
 JNIEXPORT int JNICALL
-Java_org_mozilla_jss_nss_PR_Close(JNIEnv *env, jclass clazz, jobject fd)
+Java_org_mozilla_jss_nss_PR_Close(JNIEnv *env, jclass clazz, jobject fd, jboolean clear)
 {
     PRFileDesc *real_fd = NULL;
 
@@ -106,7 +106,7 @@ Java_org_mozilla_jss_nss_PR_Close(JNIEnv *env, jclass clazz, jobject fd)
     }
 
     PRStatus ret = PR_Close(real_fd);
-    if (ret == PR_SUCCESS) {
+    if (ret == PR_SUCCESS && clear == JNI_TRUE) {
         JSS_clearPtrFromProxy(env, fd);
     }
 

--- a/org/mozilla/jss/nss/PRFDProxy.java
+++ b/org/mozilla/jss/nss/PRFDProxy.java
@@ -5,7 +5,7 @@ public class PRFDProxy extends org.mozilla.jss.util.NativeProxy {
         super(pointer);
     }
 
-    protected native void releaseNativeResources();
+    protected native void releaseNativeResources() throws Exception;
 
     protected void finalize() throws Throwable {
         super.finalize();

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -795,7 +795,7 @@ Java_org_mozilla_jss_nss_SSL_EnableAlertLoggingNative(JNIEnv *env, jclass clazz,
         return ret;
     }
 
-    if (JSS_NSS_addGlobalRef(env, fd, &fd_ref) != PR_SUCCESS) {
+    if (JSS_NSS_getGlobalRef(env, fd, &fd_ref) != PR_SUCCESS) {
         return ret;
     }
 
@@ -822,6 +822,24 @@ Java_org_mozilla_jss_nss_SSL_ConfigJSSDefaultCertAuthCallback(JNIEnv *env, jclas
     }
 
     return SSL_AuthCertificateHook(real_fd, JSSL_DefaultCertAuthCallback, NULL);
+}
+
+JNIEXPORT void JNICALL
+Java_org_mozilla_jss_nss_SSL_RemoveCallbacks(JNIEnv *env, jclass clazz,
+    jobject fd)
+{
+    PRFileDesc *real_fd = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+    PR_SetError(0, 0);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return;
+    }
+
+    SSL_AlertReceivedCallback(real_fd, NULL, NULL);
+    SSL_AlertSentCallback(real_fd, NULL, NULL);
+    SSL_AuthCertificateHook(real_fd, NULL, NULL);
 }
 
 JNIEXPORT jint JNICALL

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -307,6 +307,11 @@ public class SSL {
      */
     public static native int ConfigJSSDefaultCertAuthCallback(SSLFDProxy fd);
 
+    /**
+     * Removes all enabled callbacks.
+     */
+    public static native void RemoveCallbacks(SSLFDProxy fd);
+
     /* Internal methods for querying constants. */
     private static native int getSSLRequestCertificate();
     private static native int getSSLRequireCertificate();

--- a/org/mozilla/jss/nss/SSLFDProxy.h
+++ b/org/mozilla/jss/nss/SSLFDProxy.h
@@ -12,9 +12,7 @@ PRStatus JSS_NSS_getSSLAlertReceivedList(JNIEnv *env, jobject sslfd_proxy, jobje
 
 PRStatus JSS_NSS_addSSLAlert(JNIEnv *env, jobject sslfd_proxy, jobject list, const SSLAlert *alert);
 
-PRStatus JSS_NSS_addGlobalRef(JNIEnv *env, jobject sslfd_proxy, jobject *global_ref);
-
-void JSS_NSS_removeGlobalRef(JNIEnv *env, jobject sslfd_proxy);
+PRStatus JSS_NSS_getGlobalRef(JNIEnv *env, jobject sslfd_proxy, jobject *global_ref);
 
 void
 JSSL_SSLFDAlertReceivedCallback(const PRFileDesc *fd, void *arg, const SSLAlert *alert);

--- a/org/mozilla/jss/nss/SSLFDProxy.java
+++ b/org/mozilla/jss/nss/SSLFDProxy.java
@@ -20,6 +20,8 @@ public class SSLFDProxy extends PRFDProxy {
 
     public SSLFDProxy(byte[] pointer) {
         super(pointer);
+
+        globalRef = new GlobalRefProxy(this);
     }
 
     public void SetClientCert(X509Certificate cert) throws IllegalArgumentException {
@@ -30,9 +32,16 @@ public class SSLFDProxy extends PRFDProxy {
         clientCert = (PK11Cert)cert;
     }
 
-    protected native void releaseNativeResources();
-
-    protected void finalize() throws Throwable {
-        super.finalize();
+    @Override
+    protected synchronized void releaseNativeResources() throws Exception {
+        synchronized (globalRef) {
+            if (globalRef != null) {
+                try {
+                    globalRef.close();
+                } finally {
+                    globalRef = null;
+                }
+            }
+        }
     }
 }

--- a/org/mozilla/jss/pkcs11/PK11Cert.c
+++ b/org/mozilla/jss/pkcs11/PK11Cert.c
@@ -182,9 +182,10 @@ Java_org_mozilla_jss_pkcs11_CertProxy_releaseNativeResources
 		PR_ASSERT( PR_FALSE );
 		goto finish;
 	}
-	PR_ASSERT(cert != NULL);
 
-	CERT_DestroyCertificate(cert);
+	if (cert != NULL) {
+		CERT_DestroyCertificate(cert);
+	}
 
 finish:
 	PR_DetachThread();

--- a/org/mozilla/jss/pkcs11/PK11Cert.c
+++ b/org/mozilla/jss/pkcs11/PK11Cert.c
@@ -169,7 +169,7 @@ JNIEXPORT void JNICALL
 Java_org_mozilla_jss_pkcs11_CertProxy_releaseNativeResources
   (JNIEnv *env, jobject this)
 {
-	CERTCertificate *cert;
+	CERTCertificate *cert = NULL;
 	PRThread * VARIABLE_MAY_NOT_BE_USED pThread;
 
 	PR_ASSERT(env!=NULL && this!=NULL);

--- a/org/mozilla/jss/pkcs11/PK11Cipher.c
+++ b/org/mozilla/jss/pkcs11/PK11Cipher.c
@@ -325,7 +325,8 @@ Java_org_mozilla_jss_pkcs11_CipherContextProxy_releaseNativeResources
 {
     PK11Context *context;
 
-    if( JSS_PK11_getCipherContext(env, this, &context) == PR_SUCCESS ) {
+    if (JSS_PK11_getCipherContext(env, this, &context) == PR_SUCCESS &&
+            context != NULL) {
         PK11_DestroyContext(context, PR_TRUE /*freeit*/);
     }
 }

--- a/org/mozilla/jss/pkcs11/PK11Cipher.java
+++ b/org/mozilla/jss/pkcs11/PK11Cipher.java
@@ -19,7 +19,10 @@ import org.mozilla.jss.crypto.IllegalBlockSizeException;
 import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.TokenException;
 
-public final class PK11Cipher extends org.mozilla.jss.crypto.Cipher {
+public final class PK11Cipher
+    extends org.mozilla.jss.crypto.Cipher
+    implements java.lang.AutoCloseable
+{
 
     // set once in the constructor
     private PK11Token token;
@@ -280,4 +283,19 @@ public final class PK11Cipher extends org.mozilla.jss.crypto.Cipher {
         }
     }
 
+    @Override
+    public void finalize() throws Throwable {
+        close();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (contextProxy != null) {
+            try {
+                contextProxy.close();
+            } finally {
+                contextProxy = null;
+            }
+        }
+    }
 }

--- a/org/mozilla/jss/pkcs11/PK11Key.java
+++ b/org/mozilla/jss/pkcs11/PK11Key.java
@@ -12,7 +12,10 @@ import java.io.IOException;
 import org.mozilla.jss.util.AssertionException;
 
 
-abstract class PK11Key implements java.security.Key {
+abstract class PK11Key
+    implements java.security.Key,
+               java.lang.AutoCloseable
+{
 
     //////////////////////////////////////////////////////////
     // Public Interface
@@ -58,4 +61,19 @@ abstract class PK11Key implements java.security.Key {
     /////////////////////////////////////////////////////////////
     protected KeyProxy keyProxy;
 
+    @Override
+    public void finalize() throws Throwable {
+        close();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (keyProxy != null) {
+            try {
+                keyProxy.close();
+            } finally {
+                keyProxy = null;
+            }
+        }
+    }
 }

--- a/org/mozilla/jss/pkcs11/PK11MessageDigest.java
+++ b/org/mozilla/jss/pkcs11/PK11MessageDigest.java
@@ -12,7 +12,10 @@ import java.security.InvalidKeyException;
 /**
  * Message Digesting with PKCS #11.
  */
-public final class PK11MessageDigest extends JSSMessageDigest {
+public final class PK11MessageDigest
+    extends JSSMessageDigest
+    implements java.lang.AutoCloseable
+{
 
     private PK11Token token;
     private CipherContextProxy digestProxy;
@@ -115,4 +118,19 @@ public final class PK11MessageDigest extends JSSMessageDigest {
     private static native int
     digest(CipherContextProxy proxy, byte[] outbuf, int offset, int len);
 
+    @Override
+    public void finalize() throws Throwable {
+        close();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (digestProxy != null) {
+            try {
+                digestProxy.close();
+            } finally {
+                digestProxy = null;
+            }
+        }
+    }
 }

--- a/org/mozilla/jss/pkcs11/PK11Module.c
+++ b/org/mozilla/jss/pkcs11/PK11Module.c
@@ -220,16 +220,14 @@ JNIEXPORT void JNICALL
 Java_org_mozilla_jss_pkcs11_ModuleProxy_releaseNativeResources
     (JNIEnv *env, jobject this)
 {
-    SECMODModule *module;
+    SECMODModule *module = NULL;
 
     if (JSS_getPtrFromProxy(env, this, (void **)&module) != PR_SUCCESS) {
         ASSERT_OUTOFMEM(env);
-        goto finish;
+        return;
     }
-    PR_ASSERT(module != NULL);
 
-    SECMOD_DestroyModule(module);
-
-finish:
-    return;
+    if (module != NULL) {
+        SECMOD_DestroyModule(module);
+    }
 }

--- a/org/mozilla/jss/pkcs11/PK11PrivKey.c
+++ b/org/mozilla/jss/pkcs11/PK11PrivKey.c
@@ -239,9 +239,10 @@ Java_org_mozilla_jss_pkcs11_PrivateKeyProxy_releaseNativeResources
         PR_ASSERT( PR_FALSE );
         goto finish;
     }
-    PR_ASSERT(privk != NULL);
 
-    SECKEY_DestroyPrivateKey(privk);
+    if (privk != NULL) {
+        SECKEY_DestroyPrivateKey(privk);
+    }
 
 finish:
     PR_DetachThread();

--- a/org/mozilla/jss/pkcs11/PK11PrivKey.c
+++ b/org/mozilla/jss/pkcs11/PK11PrivKey.c
@@ -226,7 +226,7 @@ JNIEXPORT void JNICALL
 Java_org_mozilla_jss_pkcs11_PrivateKeyProxy_releaseNativeResources
   (JNIEnv *env, jobject this)
 {
-    SECKEYPrivateKey *privk;
+    SECKEYPrivateKey *privk = NULL;
     PRThread * VARIABLE_MAY_NOT_BE_USED pThread;
 
     PR_ASSERT(env!=NULL && this!=NULL);

--- a/org/mozilla/jss/pkcs11/PK11PubKey.c
+++ b/org/mozilla/jss/pkcs11/PK11PubKey.c
@@ -42,9 +42,10 @@ JNIEXPORT void JNICALL Java_org_mozilla_jss_pkcs11_PublicKeyProxy_releaseNativeR
         PR_ASSERT( PR_FALSE );
         goto finish;
     }
-    PR_ASSERT(pubk != NULL);
 
-    SECKEY_DestroyPublicKey(pubk);
+    if (pubk != NULL) {
+        SECKEY_DestroyPublicKey(pubk);
+    }
 
 finish:
     PR_DetachThread();

--- a/org/mozilla/jss/pkcs11/PK11Signature.c
+++ b/org/mozilla/jss/pkcs11/PK11Signature.c
@@ -776,18 +776,16 @@ JNIEXPORT void JNICALL
 Java_org_mozilla_jss_pkcs11_SigContextProxy_releaseNativeResources
   (JNIEnv *env, jobject this)
 {
-    SigContextProxy *proxy;
+    SigContextProxy *proxy = NULL;
 
     /* Retrieve the proxy pointer */
-    if( JSS_getPtrFromProxy(env, this, (void**)&proxy) != PR_SUCCESS) {
-#ifdef DEBUG
-        PR_ASSERT( (*env)->ExceptionOccurred(env) != NULL);
-        PR_fprintf(PR_STDERR,
-                    "ERROR: native signature context was not released\n");
-#endif
-        goto finish;
+    if (JSS_getPtrFromProxy(env, this, (void**)&proxy) != PR_SUCCESS) {
+        return;
     }
-    PR_ASSERT(proxy!=NULL);
+
+    if (proxy == NULL) {
+        return;
+    }
 
     /* Free the context and the proxy */
     if(proxy->type == SGN_CONTEXT) {
@@ -800,9 +798,6 @@ Java_org_mozilla_jss_pkcs11_SigContextProxy_releaseNativeResources
     proxy->arena = NULL;
 
     PR_Free(proxy);
-
-finish:
-    ;
 }
 
 /***********************************************************************

--- a/org/mozilla/jss/pkcs11/PK11Signature.java
+++ b/org/mozilla/jss/pkcs11/PK11Signature.java
@@ -20,7 +20,10 @@ import org.mozilla.jss.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class PK11Signature extends org.mozilla.jss.crypto.SignatureSpi {
+public final class PK11Signature
+    extends org.mozilla.jss.crypto.SignatureSpi
+    implements java.lang.AutoCloseable
+{
 
     public PK11Signature(PK11Token token, SignatureAlgorithm algorithm)
         throws NoSuchAlgorithmException, TokenException
@@ -392,6 +395,22 @@ public final class PK11Signature extends org.mozilla.jss.crypto.SignatureSpi {
         }
 
         return false;
+    }
+
+    @Override
+    public void finalize() throws Throwable {
+        close();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (sigContext != null) {
+            try {
+                sigContext.close();
+            } finally {
+                sigContext = null;
+            }
+        }
     }
 
     protected PK11Token token;

--- a/org/mozilla/jss/pkcs11/PK11SymKey.c
+++ b/org/mozilla/jss/pkcs11/PK11SymKey.c
@@ -369,10 +369,8 @@ Java_org_mozilla_jss_pkcs11_SymKeyProxy_releaseNativeResources
 
     PR_ASSERT(env!=NULL && this!=NULL);
 
-    if( JSS_getPtrFromProxy(env, this, (void**)&key) == PR_SUCCESS) {
+    if (JSS_getPtrFromProxy(env, this, (void**)&key) == PR_SUCCESS &&
+        key != NULL) {
         PK11_FreeSymKey(key);
-    } else {
-        /* can't really throw an exception from a destructor */
-        PR_ASSERT(PR_FALSE);
     }
 }

--- a/org/mozilla/jss/pkcs11/PK11Token.c
+++ b/org/mozilla/jss/pkcs11/PK11Token.c
@@ -795,7 +795,7 @@ JNIEXPORT void JNICALL
 Java_org_mozilla_jss_pkcs11_TokenProxy_releaseNativeResources
   (JNIEnv *env, jobject this)
 {
-    PK11SlotInfo *slot;
+    PK11SlotInfo *slot = NULL;
 
     PR_ASSERT(env!=NULL && this!=NULL);
 

--- a/org/mozilla/jss/ssl/SocketBase.java
+++ b/org/mozilla/jss/ssl/SocketBase.java
@@ -106,13 +106,17 @@ class SocketBase {
     static final int SSL_AF_INET6 = 51;
 
     void close() throws IOException {
-        socketClose();
-    }
+        try {
+            sockProxy.close();
+        } catch (Exception e) {
+            String msg = "Unexpected exception while trying to finalize ";
+            msg += "SocketProxy: " + e.getMessage();
 
-    // SSLServerSocket and SSLSocket close methods
-    // have their own synchronization control that
-    // protects SocketBase.socketClose.
-    native void socketClose() throws IOException;
+            throw new IOException(msg, e);
+        } finally {
+            sockProxy = null;
+        }
+    }
 
     private boolean requestingClientAuth = false;
 

--- a/org/mozilla/jss/util/GlobalRefProxy.c
+++ b/org/mozilla/jss/util/GlobalRefProxy.c
@@ -40,6 +40,7 @@ finish:
     if (refObj == NULL && *ref != NULL) {
         /* Something didn't work, so free resources. */
         (*env)->DeleteGlobalRef(env, *ref);
+        *ref = NULL;
     }
 
     PR_ASSERT(refObj || (*env)->ExceptionOccurred(env));
@@ -56,7 +57,7 @@ JNIEXPORT void JNICALL
 Java_org_mozilla_jss_util_GlobalRefProxy_releaseNativeResources
     (JNIEnv *env, jobject this)
 {
-    jobject ref;
+    jobject ref = NULL;
 
     PR_ASSERT(env != NULL && this != NULL);
 
@@ -64,7 +65,9 @@ Java_org_mozilla_jss_util_GlobalRefProxy_releaseNativeResources
         return;
     }
 
-    (*env)->DeleteGlobalRef(env, ref);
+    if (ref != NULL) {
+        (*env)->DeleteGlobalRef(env, ref);
+    }
 }
 
 JNIEXPORT jbyteArray JNICALL

--- a/org/mozilla/jss/util/GlobalRefProxy.java
+++ b/org/mozilla/jss/util/GlobalRefProxy.java
@@ -11,5 +11,7 @@ public class GlobalRefProxy extends NativeProxy {
 
     private static native byte[] refOf(Object target);
 
-    protected native void releaseNativeResources();
+    protected synchronized void releaseNativeResources() {
+        clear();
+    }
 }

--- a/org/mozilla/jss/util/NativeProxy.java
+++ b/org/mozilla/jss/util/NativeProxy.java
@@ -9,8 +9,11 @@ import java.util.HashSet;
 import java.lang.AutoCloseable;
 import java.lang.Thread;
 import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.netscape.security.util.Utils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,10 +54,13 @@ public abstract class NativeProxy implements AutoCloseable
      */
     protected NativeProxy(byte[] pointer, boolean track) {
         mPointer = pointer;
+        mHashCode = registryIndex.getAndIncrement();
+        if (mPointer != null) {
+            mHashCode += Arrays.hashCode(mPointer);
+        }
 
         if (track) {
             assert(pointer != null);
-
             registry.add(this);
 
             if (saveStacktraces) {
@@ -70,18 +76,31 @@ public abstract class NativeProxy implements AutoCloseable
      *      a different underlying native pointer.
      */
     public boolean equals(Object obj) {
-        if(obj==null) {
+        if (obj == null) {
             return false;
         }
-        if( ! (obj instanceof NativeProxy) ) {
+        if (!(obj instanceof NativeProxy)) {
             return false;
         }
-        if (((NativeProxy)obj).mPointer == null) {
-            /* If mPointer is null, we have no way to compare the values
-             * of the pointers, so assume they're unequal. */
+        NativeProxy nObj = (NativeProxy) obj;
+        if (this.mPointer == null || nObj.mPointer == null) {
             return false;
         }
-        return Arrays.equals(((NativeProxy)obj).mPointer, mPointer);
+
+        return Arrays.equals(this.mPointer, nObj.mPointer);
+    }
+
+    /**
+     * Hash code based around mPointer value.
+     *
+     * Note that Object.hashCode() isn't sufficient as it tries to determine
+     * the Object's value based on all internal variables. Because we want a
+     * single static hashCode that is unique to each instance of nativeProxy,
+     * we construct it up front based on an incrementing counter and cache it
+     * throughout the lifetime of this object.
+     */
+    public int hashCode() {
+        return mHashCode;
     }
 
     /**
@@ -127,11 +146,11 @@ public abstract class NativeProxy implements AutoCloseable
      */
     public final void close() throws Exception {
         try {
-            if (registry.remove(this) && mPointer != null) {
+            if (mPointer != null) {
                 releaseNativeResources();
             }
         } finally {
-            mPointer = null;
+            clear();
         }
     }
 
@@ -153,6 +172,7 @@ public abstract class NativeProxy implements AutoCloseable
      * Byte array containing native pointer bytes.
      */
     private byte mPointer[];
+    private int mHashCode;
 
     /**
      * String containing backtrace of pointer generation.
@@ -173,6 +193,15 @@ public abstract class NativeProxy implements AutoCloseable
      * releaseNativeResources() gets called.
      */
     static HashSet<NativeProxy> registry = new HashSet<NativeProxy>();
+    static AtomicInteger registryIndex = new AtomicInteger();
+
+    public String toString() {
+        if (mPointer == null) {
+            return this.getClass().getName() + "[" + mHashCode + "@null]";
+        }
+
+        return this.getClass().getName() + "[" + mHashCode + "@" + Utils.HexEncode(mPointer) + "]";
+    }
 
     /**
      * Internal helper to check whether or not assertions are enabled in the

--- a/org/mozilla/jss/util/NativeProxy.java
+++ b/org/mozilla/jss/util/NativeProxy.java
@@ -113,7 +113,7 @@ public abstract class NativeProxy implements AutoCloseable
      *
      * If you free these resources explicitly, call clear(); instead.
      */
-    protected abstract void releaseNativeResources();
+    protected abstract void releaseNativeResources() throws Exception;
 
     /**
      * Finalize this NativeProxy by releasing its native resources.
@@ -166,6 +166,13 @@ public abstract class NativeProxy implements AutoCloseable
     public final void clear() {
         this.mPointer = null;
         registry.remove(this);
+    }
+
+    /**
+     * Whether or not this is a null pointer.
+     */
+    public boolean isNull() {
+        return this.mPointer == null;
     }
 
     /**


### PR DESCRIPTION
This is built on top of #472.

There are a few new fixes:
 - `PK11Cert`, `PK11Cipher`, `PK11Key`, `PK11MessageDigest`, and `PK11Signature` all now have `AutoCloseable` for their internal CertProxies.
 - Fix `NativeProxy` registry tracking, candidate for backport.
 - Improve `SSLFDProxy`'s `globalRef` access.
 - Fix handling of `NULL` pointers in various places.