### PR TITLE
Enable BadSSL Tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ if(NOT (DEFINED CMAKE_BUILD_TYPE))
     set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
+if (DEFINED ENV{WITH_INTERNET})
+    set(TEST_WITH_INTERNET_ENV TRUE)
+endif()
+option(TEST_WITH_INTERNET "When enabled, runs various tests which require an internet connection. " ${TEST_WITH_INTERNET_ENV})
+
 # Find NSPR and NSS Libraries.
 find_package(NSPR REQUIRED)
 find_package(NSS REQUIRED)

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -76,6 +76,7 @@ macro(jss_config_outputs)
     set(RESULTS_DATA_OUTPUT_DIR "${CMAKE_BINARY_DIR}/results/data")
     set(RESULTS_NSSDB_OUTPUT_DIR "${CMAKE_BINARY_DIR}/results/nssdb")
     set(RESULTS_NSSDB_FIPS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/results/fips")
+    set(RESULTS_NSSDB_INTERNET_OUTPUT_DIR "${CMAKE_BINARY_DIR}/results/internet")
 
     # This is a temporary location for building the reproducible jar
     set(REPRODUCIBLE_TEMP_DIR "${CMAKE_BINARY_DIR}/reproducible")
@@ -364,6 +365,17 @@ macro(jss_config_template)
         @ONLY
     )
     set(NSS_DB_PATH "${RESULTS_NSSDB_FIPS_OUTPUT_DIR}")
+    configure_file(
+        "${PROJECT_SOURCE_DIR}/tools/jss.cfg.in"
+        "${JSS_CFG_PATH}"
+    )
+    set(JSS_CFG_PATH "${CONFIG_OUTPUT_DIR}/jss-internet.cfg")
+    configure_file(
+        "${PROJECT_SOURCE_DIR}/tools/java.security.in"
+        "${CONFIG_OUTPUT_DIR}/internet.security"
+        @ONLY
+    )
+    set(NSS_DB_PATH "${RESULTS_NSSDB_INTERNET_OUTPUT_DIR}")
     configure_file(
         "${PROJECT_SOURCE_DIR}/tools/jss.cfg.in"
         "${JSS_CFG_PATH}"

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -53,6 +53,18 @@ macro(jss_tests)
         MODE "NONE"
     )
 
+    # NSS DB for internet connected tests; imports global root CA certs.
+    if(TEST_WITH_INTERNET)
+        jss_test_exec(
+            NAME "Clean_Internet_Setup_DBs"
+            COMMAND "cmake" "-E" "remove_directory" "${RESULTS_NSSDB_INTERNET_OUTPUT_DIR}"
+        )
+        jss_test_exec(
+            NAME "Import_Internet_Certs"
+            COMMAND "${CMAKE_SOURCE_DIR}/tools/common_roots.sh" "${RESULTS_NSSDB_INTERNET_OUTPUT_DIR}"
+            DEPENDS "Clean_Internet_Setup_DBs"
+        )
+    endif()
 
     jss_test_exec(
         NAME "TestBufferPRFD"
@@ -414,6 +426,20 @@ macro(jss_tests)
         COMMAND "org.junit.runner.JUnitCore" "org.mozilla.jss.tests.PrintableConverterTest"
     )
 
+    if(TEST_WITH_INTERNET)
+        jss_test_java(
+            NAME "BadSSL"
+            COMMAND "org.mozilla.jss.tests.BadSSL" "${RESULTS_NSSDB_INTERNET_OUTPUT_DIR}"
+            DEPENDS "Import_Internet_Certs"
+            MODE "INTERNET"
+        )
+        jss_test_java(
+            NAME "BadSSL_Leaf_And_Chain"
+            COMMAND "org.mozilla.jss.tests.BadSSL" "${RESULTS_NSSDB_INTERNET_OUTPUT_DIR}" "LEAF_AND_CHAIN"
+            DEPENDS "Import_Internet_Certs"
+            MODE "INTERNET"
+        )
+    endif()
 
     # For compliance with several existing clients
     add_custom_target(
@@ -462,6 +488,8 @@ function(jss_test_java)
     list(APPEND EXEC_COMMAND "-Djava.library.path=${CMAKE_BINARY_DIR}")
     if(TEST_JAVA_MODE STREQUAL "FIPS")
         list(APPEND EXEC_COMMAND "-Djava.security.properties=${CONFIG_OUTPUT_DIR}/fips.security")
+    elseif(TEST_JAVA_MODE STREQUAL "INTERNET")
+        list(APPEND EXEC_COMMAND "-Djava.security.properties=${CONFIG_OUTPUT_DIR}/internet.security")
     elseif(NOT TEST_JAVA_MODE STREQUAL "NONE")
         list(APPEND EXEC_COMMAND "-Djava.security.properties=${CONFIG_OUTPUT_DIR}/java.security")
     endif()

--- a/docs/build_system.md
+++ b/docs/build_system.md
@@ -84,6 +84,10 @@ command line with `-D<VAR>=<VALUE>` syntax, or in the environment.
     is quite slow. By default it passes two arguments: `--track-origins=yes`
     and `--leak-check=full`. Modify `cmake/JSSTests.cmake` (macro:
     `jss_test_exec`) to change these options.
+ - `WITH_INTERNET` -- run tests which require an internet connection. This
+    exposes your system to other hosts on the internet, including badssl.com
+    and www.mozilla.org. Correct execution requires a working `common_roots.sh`
+    script under `tools/`; update for your system as necessary.
 
 ### Adding a Test Case
 

--- a/tools/Dockerfiles/fedora_rawhide
+++ b/tools/Dockerfiles/fedora_rawhide
@@ -22,6 +22,7 @@ COPY . /home/sandbox/jss
 WORKDIR /home/sandbox/jss
 CMD true \
         && export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk \
+        && export WITH_INTERNET=1 \
         && rm -rf build \
         && mkdir build \
         && cd build \


### PR DESCRIPTION
Enables a new CMake variable, `WITH_INTERNET`, to enable tests which require an internet connection. This currently includes only the BadSSL test, but could include other tests in the future (such as some under `org.mozilla.jss.ssl` currently). 