### PR TITLE
Move from _NETSCAPE_ to _NSS_ PKCS#11 constants

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11SymKey.c
+++ b/org/mozilla/jss/pkcs11/PK11SymKey.c
@@ -14,6 +14,11 @@
 #include <jssutil.h>
 #include "pk11util.h"
 
+/* For PKCS#11 v3.0 compatibility */
+#ifndef CKM_NSS_PBE_SHA1_DES_CBC
+#define CKM_NSS_PBE_SHA1_DES_CBC (CKM_NETSCAPE_PBE_SHA1_DES_CBC)
+#endif
+
 /***********************************************************************
  *
  * J S S _ P K 1 1 _ w r a p S y m K e y
@@ -262,7 +267,7 @@ Java_org_mozilla_jss_pkcs11_PK11SymKey_getKeyType
       /* PBE mechanisms have to be handled by hand */
       case CKM_PBE_MD2_DES_CBC:
       case CKM_PBE_MD5_DES_CBC:
-      case CKM_NETSCAPE_PBE_SHA1_DES_CBC:
+      case CKM_NSS_PBE_SHA1_DES_CBC:
         typeFieldName = DES_KEYTYPE_FIELD;
         break;
       case CKM_PBE_SHA1_RC4_128:


### PR DESCRIPTION
In NSS v3.52, support is coming for PKCS#11 v3.0. This deprecates the
`_NETSCAPE_` namespace for PKCS#11 constants in favor of `_NSS_`. The few
remaining `_NETSCAPE_` constants will be moved to `_NSS_`. We only use one,
`CKM_NETSCAPE_PBE_SHA1_DES_CBC`. Add an `#ifdef` for compatibility with the
new preferred name.

See also: [`moz-bz#1603628`](https://bugzilla.mozilla.org/show_bug.cgi?id=1603628)

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`