### PR TITLE
Branch to v4.7.0 beta release 1

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -2,7 +2,7 @@ macro(jss_config)
     # Set the current JSS release number. Arguments are:
     #   MAJOR MINOR PATCH BETA
     # When BETA is zero, it isn't a beta release.
-    jss_config_version(4 6 3 0)
+    jss_config_version(4 7 0 1)
 
     # Configure output directories
     jss_config_outputs()

--- a/jss.spec
+++ b/jss.spec
@@ -6,9 +6,9 @@ Summary:        Java Security Services (JSS)
 URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
-Version:        4.6.3
+Version:        4.7.0
 Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
-# global         _phase -a1
+%global         _phase -b1
 
 # To generate the source tarball:
 # $ git clone https://github.com/dogtagpki/jss.git


### PR DESCRIPTION
Since `SSLEngine` is a breaking change introducing significant new
functionality (and strictly requiring NSS v3.44 or greater), move
to a new minor version.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

v4.6.3 was therefore the last `v4.6.x` release, so I created a new branch off of it and [cherry-picked](https://github.com/dogtagpki/jss/commits/v4.6.x) a few fixes onto it. 