### PR TITLE
Accept NULL in CryptoManager.setPasswordCallback()

### DIFF
--- a/org/mozilla/jss/CryptoManager.c
+++ b/org/mozilla/jss/CryptoManager.c
@@ -520,7 +520,7 @@ finish:
 void
 JSS_setPasswordCallback(JNIEnv *env, jobject callback)
 {
-    PR_ASSERT(env!=NULL && callback!=NULL);
+    PR_ASSERT(env != NULL);
 
     /* Free the previously-registered password callback */
     if( globalPasswordCallback != NULL ) {
@@ -528,10 +528,12 @@ JSS_setPasswordCallback(JNIEnv *env, jobject callback)
         globalPasswordCallback = NULL;
     }
 
-    /* Store the new password callback */
-    globalPasswordCallback = (*env)->NewGlobalRef(env, callback);
-    if(globalPasswordCallback == NULL) {
-        JSS_throw(env, OUT_OF_MEMORY_ERROR);
+    if (callback != NULL) {
+        /* Store the new password callback */
+        globalPasswordCallback = (*env)->NewGlobalRef(env, callback);
+        if (globalPasswordCallback == NULL) {
+            JSS_throw(env, OUT_OF_MEMORY_ERROR);
+        }
     }
 }
 


### PR DESCRIPTION
In the javadocs for `CryptoManager.setPasswordCallback()`, it says:

> The callback may be `NULL`, in which case password callbacks will
> fail gracefully.

However, `setNativePasswordCallback()` will assert on a `NULL` callback.
Fix this to handle NULL gracefully.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

Note that there is a workaround: use a [`NullPasswordCallback`](https://dogtagpki.github.io/jss/master/javadocs/org/mozilla/jss/util/NullPasswordCallback.html) instance instead.