### PR TITLE
Remove space from AlgorithmId.toString()

### DIFF
--- a/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
+++ b/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
@@ -629,7 +629,11 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * Returns a string describing the algorithm and its parameters.
      */
     public String toString() {
-        return (algName() + " " + paramsToString());
+        if (params == null) {
+            return algName();
+        }
+
+        return algName() + " " + paramsToString();
     }
 
     /**


### PR DESCRIPTION
In cadc299fa69554e2e7ab9226298be639219476ab and `v4.4.x` commit
e1ee07a3c19cd15d7dab1dedf383128a2b83b925, `AlgorithmId` was updated
to unconditionally add an extra space to `toString`, to separate the
algorithm name from the parameters. This suffices in some cases, but
`AlgorithmId.toString()` is used by PKI to compare against a tokenized
list of characters. Removing the extraneous whitespace was the solution
proposed in PKI commit [`dogtagpki/pki@53de7514`](https://github.com/dogtagpki/pki/commit/53de751485b04fe2a1555228342ed642c9a9e347), but
this should really be handled in JSS instead of PKI.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

See also: https://github.com/dogtagpki/pki/pull/364