### PR TITLE
Fix latest jss.map entry to v4.7.0

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -444,7 +444,7 @@ Java_org_mozilla_jss_nss_PRErrors_getSocketShutdownError;
     local:
         *;
 };
-JSS_4.6.4 {
+JSS_4.7.0 {
     global:
 Java_org_mozilla_jss_nss_SSL_GetChannelInfo;
 Java_org_mozilla_jss_nss_SSL_GetPreliminaryChannelInfo;


### PR DESCRIPTION
When `v4.6.x` was branched off of `v4.6.3`, `jss.map` wasn't updated to
reflect the next version on the master branch.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`