### PR TITLE
SSLEngine - PostHandshake Authentication / Renegotation

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -467,6 +467,10 @@ Java_org_mozilla_jss_nss_SSL_getSSLEnableFallbackSCSV;
 Java_org_mozilla_jss_nss_SSL_ReHandshake;
 Java_org_mozilla_jss_nss_SSL_EnableHandshakeCallback;
 Java_org_mozilla_jss_nss_SSL_SendCertificateRequest;
+Java_org_mozilla_jss_nss_SSL_getSSLRequireNever;
+Java_org_mozilla_jss_nss_SSL_getSSLRequireAlways;
+Java_org_mozilla_jss_nss_SSL_getSSLRequireFirstHandshake;
+Java_org_mozilla_jss_nss_SSL_getSSLRequireNoError;
     local:
         *;
 };

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -464,6 +464,7 @@ Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateUnrestricted;
 Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateRequiresXtn;
 Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateTransitional;
 Java_org_mozilla_jss_nss_SSL_getSSLEnableFallbackSCSV;
+Java_org_mozilla_jss_nss_SSL_ReHandshake;
     local:
         *;
 };

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -457,6 +457,13 @@ Java_org_mozilla_jss_util_GlobalRefProxy_refOf;
 Java_org_mozilla_jss_CryptoManager_shutdownNative;
 Java_org_mozilla_jss_nss_SSL_RemoveCallbacks;
 Java_org_mozilla_jss_nss_SSL_getSSLEnablePostHandshakeAuth;
+Java_org_mozilla_jss_nss_SSL_getSSLEnableRenegotiation;
+Java_org_mozilla_jss_nss_SSL_getSSLRequireSafeNegotiation;
+Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateNever;
+Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateUnrestricted;
+Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateRequiresXtn;
+Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateTransitional;
+Java_org_mozilla_jss_nss_SSL_getSSLEnableFallbackSCSV;
     local:
         *;
 };

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -471,6 +471,7 @@ Java_org_mozilla_jss_nss_SSL_getSSLRequireNever;
 Java_org_mozilla_jss_nss_SSL_getSSLRequireAlways;
 Java_org_mozilla_jss_nss_SSL_getSSLRequireFirstHandshake;
 Java_org_mozilla_jss_nss_SSL_getSSLRequireNoError;
+Java_org_mozilla_jss_nss_SSL_KeyUpdate;
     local:
         *;
 };

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -466,6 +466,7 @@ Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateTransitional;
 Java_org_mozilla_jss_nss_SSL_getSSLEnableFallbackSCSV;
 Java_org_mozilla_jss_nss_SSL_ReHandshake;
 Java_org_mozilla_jss_nss_SSL_EnableHandshakeCallback;
+Java_org_mozilla_jss_nss_SSL_SendCertificateRequest;
     local:
         *;
 };

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -456,6 +456,7 @@ Java_org_mozilla_jss_nss_SSL_VersionRangeSetDefaultNative;
 Java_org_mozilla_jss_util_GlobalRefProxy_refOf;
 Java_org_mozilla_jss_CryptoManager_shutdownNative;
 Java_org_mozilla_jss_nss_SSL_RemoveCallbacks;
+Java_org_mozilla_jss_nss_SSL_getSSLEnablePostHandshakeAuth;
     local:
         *;
 };

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -465,6 +465,7 @@ Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateRequiresXtn;
 Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateTransitional;
 Java_org_mozilla_jss_nss_SSL_getSSLEnableFallbackSCSV;
 Java_org_mozilla_jss_nss_SSL_ReHandshake;
+Java_org_mozilla_jss_nss_SSL_EnableHandshakeCallback;
     local:
         *;
 };

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -2,6 +2,7 @@
 #include <nss.h>
 #include <ssl.h>
 #include <sslerr.h>
+#include <sslexp.h>
 #include <limits.h>
 #include <stdint.h>
 #include <jni.h>
@@ -765,6 +766,22 @@ Java_org_mozilla_jss_nss_SSL_PeerCertificateChain(JNIEnv *env, jclass clazz,
     }
 
     return JSS_PK11_wrapCertChain(env, &chain);
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_SendCertificateRequest(JNIEnv *env, jclass clazz,
+    jobject fd)
+{
+    PRFileDesc *real_fd = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+    PR_SetError(0, 0);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    return SSL_SendCertificateRequest(real_fd);
 }
 
 JNIEXPORT jint JNICALL

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -871,3 +871,9 @@ Java_org_mozilla_jss_nss_SSL_getSSLSECWouldBlock(JNIEnv *env, jclass clazz)
 {
     return SECWouldBlock;
 }
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLEnablePostHandshakeAuth(JNIEnv *env, jclass clazz)
+{
+    return SSL_ENABLE_POST_HANDSHAKE_AUTH;
+}

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -973,3 +973,27 @@ Java_org_mozilla_jss_nss_SSL_getSSLEnableFallbackSCSV(JNIEnv *env, jclass clazz)
 {
     return SSL_ENABLE_FALLBACK_SCSV;
 }
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLRequireNever(JNIEnv *env, jclass clazz)
+{
+    return SSL_REQUIRE_NEVER;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLRequireAlways(JNIEnv *env, jclass clazz)
+{
+    return SSL_REQUIRE_ALWAYS;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLRequireFirstHandshake(JNIEnv *env, jclass clazz)
+{
+    return SSL_REQUIRE_FIRST_HANDSHAKE;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLRequireNoError(JNIEnv *env, jclass clazz)
+{
+    return SSL_REQUIRE_NO_ERROR;
+}

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -859,6 +859,27 @@ Java_org_mozilla_jss_nss_SSL_RemoveCallbacks(JNIEnv *env, jclass clazz,
 }
 
 JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_EnableHandshakeCallback(JNIEnv *env, jclass clazz,
+    jobject fd)
+{
+    PRFileDesc *real_fd = NULL;
+    jobject fd_ref = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+    PR_SetError(0, 0);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    if (JSS_NSS_getGlobalRef(env, fd, &fd_ref) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    return SSL_HandshakeCallback(real_fd, JSSL_SSLFDHandshakeComplete, fd_ref);
+}
+
+JNIEXPORT jint JNICALL
 Java_org_mozilla_jss_nss_SSL_getSSLRequestCertificate(JNIEnv *env, jclass clazz)
 {
     return SSL_REQUEST_CERTIFICATE;

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -785,6 +785,22 @@ Java_org_mozilla_jss_nss_SSL_SendCertificateRequest(JNIEnv *env, jclass clazz,
 }
 
 JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_KeyUpdate(JNIEnv *env, jclass clazz,
+    jobject fd, jboolean requestUpdate)
+{
+    PRFileDesc *real_fd = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+    PR_SetError(0, 0);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    return SSL_KeyUpdate(real_fd, requestUpdate == JNI_TRUE ? PR_TRUE : PR_FALSE);
+}
+
+JNIEXPORT jint JNICALL
 Java_org_mozilla_jss_nss_SSL_AttachClientCertCallback(JNIEnv *env, jclass clazz,
     jobject fd)
 {

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -599,6 +599,22 @@ Java_org_mozilla_jss_nss_SSL_ResetHandshake(JNIEnv *env, jclass clazz,
 }
 
 JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_SSL_ReHandshake(JNIEnv *env, jclass clazz,
+    jobject fd, jboolean flushCache)
+{
+    PRFileDesc *real_fd = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+    PR_SetError(0, 0);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    return SSL_ReHandshake(real_fd, flushCache);
+}
+
+JNIEXPORT int JNICALL
 Java_org_mozilla_jss_nss_SSL_ForceHandshake(JNIEnv *env, jclass clazz,
     jobject fd)
 {

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -877,3 +877,45 @@ Java_org_mozilla_jss_nss_SSL_getSSLEnablePostHandshakeAuth(JNIEnv *env, jclass c
 {
     return SSL_ENABLE_POST_HANDSHAKE_AUTH;
 }
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLEnableRenegotiation(JNIEnv *env, jclass clazz)
+{
+    return SSL_ENABLE_RENEGOTIATION;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLRequireSafeNegotiation(JNIEnv *env, jclass clazz)
+{
+    return SSL_REQUIRE_SAFE_NEGOTIATION;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateNever(JNIEnv *env, jclass clazz)
+{
+    return SSL_RENEGOTIATE_NEVER;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateUnrestricted(JNIEnv *env, jclass clazz)
+{
+    return SSL_RENEGOTIATE_UNRESTRICTED;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateRequiresXtn(JNIEnv *env, jclass clazz)
+{
+    return SSL_RENEGOTIATE_REQUIRES_XTN;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLRenegotiateTransitional(JNIEnv *env, jclass clazz)
+{
+    return SSL_RENEGOTIATE_TRANSITIONAL;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_getSSLEnableFallbackSCSV(JNIEnv *env, jclass clazz)
+{
+    return SSL_ENABLE_FALLBACK_SCSV;
+}

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -121,6 +121,39 @@ public class SSL {
     public static final int ENABLE_FALLBACK_SCSV = getSSLEnableFallbackSCSV();
 
     /**
+     * Value for never requiring a certificate. Value for use with
+     * SSL_REQUIRE_CERTIFICATE with OptionGet and OptionSet.
+     *
+     * See also: SSL_REQUIRE_NEVER in /usr/include/nss3/ssl.h
+     */
+    public static final int REQUIRE_NEVER = getSSLRequireNever();
+
+    /**
+     * Value for always requiring a certificate. Value for use with
+     * SSL_REQUIRE_CERTIFICATE with OptionGet and OptionSet.
+     *
+     * See also: SSL_REQUIRE_ALWAYS in /usr/include/nss3/ssl.h
+     */
+    public static final int REQUIRE_ALWAYS = getSSLRequireAlways();
+
+    /**
+     * Value for requiring a certificate only on the first handshake. Value
+     * for use with SSL_REQUIRE_CERTIFICATE with OptionGet and OptionSet.
+     *
+     * See also: SSL_REQUIRE_FIRST_HANDSHAKE in /usr/include/nss3/ssl.h
+     */
+    public static final int REQUIRE_FIRST_HANDSHAKE = getSSLRequireFirstHandshake();
+
+    /**
+     * Value for requiring a certificate but not erring if the peer doesn't
+     * provide one. Value for use with SSL_REQUIRE_CERTIFICATE with OptionGet
+     * and OptionSet.
+     *
+     * See also: SSL_REQUIRE_NO_ERROR in /usr/include/nss3/ssl.h
+     */
+    public static final int REQUIRE_NO_ERROR = getSSLRequireNoError();
+
+    /**
      * Import a file descriptor to create a new SSL file descriptor out of it.
      *
      * See also: SSL_ImportFD in /usr/include/nss3/ssl.h
@@ -415,4 +448,8 @@ public class SSL {
     private static native int getSSLRenegotiateRequiresXtn();
     private static native int getSSLRenegotiateTransitional();
     private static native int getSSLEnableFallbackSCSV();
+    private static native int getSSLRequireNever();
+    private static native int getSSLRequireAlways();
+    private static native int getSSLRequireFirstHandshake();
+    private static native int getSSLRequireNoError();
 }

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -53,6 +53,14 @@ public class SSL {
     public static final int SECWouldBlock = getSSLSECWouldBlock();
 
     /**
+     * Enable post-handshake authentication extension. Value for use with
+     * OptionGet.
+     *
+     * See also: SSL_ENABLE_POST_HANDSHAKE_AUTH in /usr/include/nss3/ssl.h
+     */
+    public static final int ENABLE_POST_HANDSHAKE_AUTH = getSSLEnablePostHandshakeAuth();
+
+    /**
      * Import a file descriptor to create a new SSL file descriptor out of it.
      *
      * See also: SSL_ImportFD in /usr/include/nss3/ssl.h
@@ -318,4 +326,5 @@ public class SSL {
     private static native int getSSLSECSuccess();
     private static native int getSSLSECFailure();
     private static native int getSSLSECWouldBlock();
+    private static native int getSSLEnablePostHandshakeAuth();
 }

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -286,6 +286,13 @@ public class SSL {
     public static native int ResetHandshake(SSLFDProxy fd, boolean asServer);
 
     /**
+     * Rehandshake an existing socket, optionally flushing the cache line.
+     *
+     * See also: SSL_ReHandshake in /usr/include/nss3/ssl.h
+     */
+    public static native int ReHandshake(SSLFDProxy fd, boolean flushCache);
+
+    /**
      * Force a handshake to occur if not started, else step one.
      *
      * See also: SSL_ForceHandshake in /usr/include/nss3/ssl.h

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -387,6 +387,13 @@ public class SSL {
      */
     public static native void RemoveCallbacks(SSLFDProxy fd);
 
+    /*
+     * Enable handshake completion status checking.
+     *
+     * See also: SSL_HandshakeCallback in /usr/include/nss3/ssl.h
+     */
+    public static native int EnableHandshakeCallback(SSLFDProxy fd);
+
     /* Internal methods for querying constants. */
     private static native int getSSLRequestCertificate();
     private static native int getSSLRequireCertificate();

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -388,6 +388,13 @@ public class SSL {
     public static native int SendCertificateRequest(SSLFDProxy fd);
 
     /**
+     * Send the TLS 1.3 KeyUpdate Request; experimental.
+     *
+     * See also: SSL_KeyUpdate in /usr/include/nss3/sslexp.h
+     */
+    public static native int KeyUpdate(SSLFDProxy fd, boolean requestUpdate);
+
+    /**
      * Use client authentication; set client certificate from SSLFDProxy.
      *
      * See also: SSL_GetClientAuthDataHook in /usr/include/nss3/ssl.h,

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -348,6 +348,13 @@ public class SSL {
     public static native PK11Cert[] PeerCertificateChain(SSLFDProxy fd) throws Exception;
 
     /**
+     * Send the TLS 1.3 Certificate Request as a server; experimental.
+     *
+     * See also: SSL_SendCertificateRequest in /usr/include/nss3/sslexp.h
+     */
+    public static native int SendCertificateRequest(SSLFDProxy fd);
+
+    /**
      * Use client authentication; set client certificate from SSLFDProxy.
      *
      * See also: SSL_GetClientAuthDataHook in /usr/include/nss3/ssl.h,

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -61,6 +61,66 @@ public class SSL {
     public static final int ENABLE_POST_HANDSHAKE_AUTH = getSSLEnablePostHandshakeAuth();
 
     /**
+     * Option for configuring renegotiation after initial handshake. Value for
+     * use with OptionGet and OptionSet.
+     *
+     * See also: SSL_ENABLE_RENEGOTIATION in /usr/include/nss3/ssl.h
+     */
+    public static final int ENABLE_RENEGOTIATION = getSSLEnableRenegotiation();
+
+    /**
+     * Option for requiring safe negotiation. Value for use with OptionGet and
+     * OptionSet.
+     *
+     * See also: SSL_REQUIRE_SAFE_NEGOTIATION in /usr/include/nss3/ssl.h
+     */
+    public static final int REQUIRE_SAFE_NEGOTIATION = getSSLRequireSafeNegotiation();
+
+    /**
+     * Value for never allowing renegotiation after initial handshake. Value
+     * for use with ENABLE_RENEGOTIATION with OptionGet and OptionSet.
+     *
+     * See also: SSL_RENEGOTIATE_NEVER in /usr/include/nss3/ssl.h
+     */
+    public static final int RENEGOTIATE_NEVER = getSSLRenegotiateNever();
+
+    /**
+     * Value for always allowing renegotiation after initial handshake,
+     * regardless of whether or not the peer's client hellow bears the
+     * renegotiation info extension; unsafe. Value for use with
+     * ENABLE_RENEGOTIATION with OptionGet and OptionSet.
+     *
+     * See also: SSL_RENEGOTIATE_UNRESTRICTED in /usr/include/nss3/ssl.h
+     */
+    public static final int RENEGOTIATE_UNRESTRICTED = getSSLRenegotiateUnrestricted();
+
+    /**
+     * Value for allowing renegotiation after initial handshake with the TLS
+     * renegotiation_info extension; safe. Value for use with
+     * ENABLE_RENEGOTIATION with OptionGet and OptionSet.
+     *
+     * See also: SSL_RENEGOTIATE_REQUIRES_XTN in /usr/include/nss3/ssl.h
+     */
+    public static final int RENEGOTIATE_REQUIRES_XTN = getSSLRenegotiateRequiresXtn();
+
+    /**
+     * Value for disallowing unsafe renegotiation in server sockets only, but
+     * allows clients to continue to renegotiate with vulnerable servers.
+     * Value for use with ENABLE_RENEGOTIATION with OptionGet and OptionSet.
+     *
+     * See also: SSL_RENEGOTIATE_TRANSITIONAL in /usr/include/nss3/ssl.h
+     */
+    public static final int RENEGOTIATE_TRANSITIONAL = getSSLRenegotiateTransitional();
+
+    /**
+     * Option for sending SCSV in handshakes. Value for use with OptionGet and
+     * OptionSet.
+     *
+     * See also: SSL_ENABLE_FALLBACK_SCSV in /usr/include/nss3/ssl.h
+     */
+    public static final int ENABLE_FALLBACK_SCSV = getSSLEnableFallbackSCSV();
+
+    /**
      * Import a file descriptor to create a new SSL file descriptor out of it.
      *
      * See also: SSL_ImportFD in /usr/include/nss3/ssl.h
@@ -327,4 +387,11 @@ public class SSL {
     private static native int getSSLSECFailure();
     private static native int getSSLSECWouldBlock();
     private static native int getSSLEnablePostHandshakeAuth();
+    private static native int getSSLEnableRenegotiation();
+    private static native int getSSLRequireSafeNegotiation();
+    private static native int getSSLRenegotiateNever();
+    private static native int getSSLRenegotiateUnrestricted();
+    private static native int getSSLRenegotiateRequiresXtn();
+    private static native int getSSLRenegotiateTransitional();
+    private static native int getSSLEnableFallbackSCSV();
 }

--- a/org/mozilla/jss/nss/SSLFDProxy.c
+++ b/org/mozilla/jss/nss/SSLFDProxy.c
@@ -240,3 +240,33 @@ JSSL_SSLFDCertSelectionCallback(void *arg,
     *pRetKey = privkey;
     return SECSuccess;
 }
+
+void
+JSSL_SSLFDHandshakeComplete(PRFileDesc *fd, void *client_data)
+{
+    JNIEnv *env = NULL;
+    jobject sslfd_proxy = (jobject)client_data;
+    jclass sslfdProxyClass;
+    jfieldID handshakeCompleteField;
+
+    if (fd == NULL || client_data == NULL || JSS_javaVM == NULL) {
+        return;
+    }
+
+    if ((*JSS_javaVM)->AttachCurrentThread(JSS_javaVM, (void**)&env, NULL) != JNI_OK || env == NULL) {
+        return;
+    }
+
+    sslfdProxyClass = (*env)->GetObjectClass(env, sslfd_proxy);
+    if (sslfdProxyClass == NULL) {
+        return;
+    }
+
+    handshakeCompleteField = (*env)->GetFieldID(env, sslfdProxyClass,
+                                                "handshakeComplete", "Z");
+    if (handshakeCompleteField == NULL) {
+        return;
+    }
+
+    (*env)->SetBooleanField(env, sslfd_proxy, handshakeCompleteField, JNI_TRUE);
+}

--- a/org/mozilla/jss/nss/SSLFDProxy.h
+++ b/org/mozilla/jss/nss/SSLFDProxy.h
@@ -26,3 +26,6 @@ JSSL_SSLFDCertSelectionCallback(void *arg,
                                 CERTDistNames *caNames,
                                 CERTCertificate **pRetCert,
                                 SECKEYPrivateKey **pRetKey);
+
+void
+JSSL_SSLFDHandshakeComplete(PRFileDesc *fd, void *client_data);

--- a/org/mozilla/jss/nss/SSLFDProxy.java
+++ b/org/mozilla/jss/nss/SSLFDProxy.java
@@ -18,6 +18,8 @@ public class SSLFDProxy extends PRFDProxy {
     public ArrayList<SSLAlertEvent> outboundAlerts;
     public int outboundOffset;
 
+    public boolean handshakeComplete;
+
     public SSLFDProxy(byte[] pointer) {
         super(pointer);
 

--- a/org/mozilla/jss/tests/TestSSLEngine.java
+++ b/org/mozilla/jss/tests/TestSSLEngine.java
@@ -64,7 +64,7 @@ public class TestSSLEngine {
         return tms;
     }
 
-    public static void testHandshake(SSLEngine client_eng, SSLEngine server_eng) throws Exception {
+    public static void testHandshake(SSLEngine client_eng, SSLEngine server_eng, boolean allowFirst) throws Exception {
         // Ensure we exit in case of a bug... :-)
         int counter = 0;
         int max_steps = 20;
@@ -127,7 +127,7 @@ public class TestSSLEngine {
                         break;
                     }
                 }
-            } else if (counter > 1 && !client_done && (client_state == SSLEngineResult.HandshakeStatus.FINISHED || client_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING)) {
+            } else if ((counter > 1 || allowFirst) && !client_done && (client_state == SSLEngineResult.HandshakeStatus.FINISHED || client_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING)) {
                 System.err.println("Client: " + server_eng.getHandshakeStatus());
                 client_done = true;
             } else if (!client_done && client_state == SSLEngineResult.HandshakeStatus.NEED_TASK) {
@@ -212,7 +212,7 @@ public class TestSSLEngine {
                         break;
                     }
                 }
-            } else if (counter > 1 && !server_done && (server_state == SSLEngineResult.HandshakeStatus.FINISHED || server_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING)) {
+            } else if ((counter > 1 || allowFirst) && !server_done && (server_state == SSLEngineResult.HandshakeStatus.FINISHED || server_state == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING)) {
                 System.err.println("Server: " + server_eng.getHandshakeStatus());
                 server_done = true;
             } else if (!server_done && server_state == SSLEngineResult.HandshakeStatus.NEED_TASK) {
@@ -271,6 +271,10 @@ public class TestSSLEngine {
 
         assert(c_session.getCipherSuite() == s_session.getCipherSuite());
         assert(c_session.getProtocol() == s_session.getProtocol());
+
+        if (server_eng.getNeedClientAuth()) {
+            assert(s_session.getPeerCertificates() != null);
+        }
     }
 
     public static void sendTestData(SSLEngine send, SSLEngine recv, ByteBuffer mesg, ByteBuffer inter, ByteBuffer dest) throws Exception {
@@ -439,10 +443,15 @@ public class TestSSLEngine {
         System.err.println("Passed close test!");
     }
 
-    public static void testBasicHandshake(SSLEngine client_eng, SSLEngine server_eng) throws Exception {
-        testHandshake(client_eng, server_eng);
+    public static void testBasicHandshake(SSLEngine client_eng, SSLEngine server_eng, boolean allowFirst) throws Exception {
+        testHandshake(client_eng, server_eng, allowFirst);
         testPostHandshakeTransfer(client_eng, server_eng);
         testClose(client_eng, server_eng);
+    }
+
+    public static void testInitialHandshake(SSLEngine client_eng, SSLEngine server_eng) throws Exception {
+        testHandshake(client_eng, server_eng, false);
+        testPostHandshakeTransfer(client_eng, server_eng);
     }
 
     public static void configureSSLEngine(SSLEngine eng, String protocol, String cipher_suite) throws Exception {
@@ -507,7 +516,7 @@ public class TestSSLEngine {
                 configureSSLEngine(server_eng, protocol, cipher_suite);
 
                 try {
-                    testBasicHandshake(client_eng, server_eng);
+                    testBasicHandshake(client_eng, server_eng, false);
                 } catch (Exception e) {
                     client_eng.cleanup();
                     server_eng.cleanup();
@@ -566,8 +575,64 @@ public class TestSSLEngine {
                 configureSSLEngine(server_eng, protocol, cipher_suite);
 
                 try {
-                    testBasicHandshake(client_eng, server_eng);
+                    testBasicHandshake(client_eng, server_eng, false);
                 } catch (Exception e) {
+                    server_eng.cleanup();
+                    throw e;
+                }
+            }
+        }
+    }
+
+    public static void testPostHandshakeAuth(SSLContext ctx, String client_alias, String server_alias) throws Exception {
+        SSLEngine dummy = ctx.createSSLEngine();
+        assert(dummy != null);
+
+        for (String protocol : dummy.getSupportedProtocols()) {
+            if (protocol != "TLSv1.2" && protocol != "TLSv1.3") {
+                continue;
+            }
+
+            for (String cipher_suite : dummy.getSupportedCipherSuites()) {
+                if (skipProtocolCipherSuite(protocol, cipher_suite, client_alias, server_alias)) {
+                    continue;
+                }
+
+                System.err.println("Testing: " + protocol + " with " + cipher_suite);
+
+                String context = protocol + "/" + cipher_suite;
+
+                JSSEngine client_eng = (JSSEngine) ctx.createSSLEngine();
+                client_eng.setSSLParameters(createParameters(client_alias));
+                client_eng.setUseClientMode(true);
+
+                if (client_eng instanceof JSSEngineReferenceImpl) {
+                    ((JSSEngineReferenceImpl) client_eng).setName("JSS Client " + context);
+                }
+
+                JSSEngine server_eng = (JSSEngine) ctx.createSSLEngine();
+                server_eng.setSSLParameters(createParameters(server_alias));
+                server_eng.setUseClientMode(false);
+
+                if (server_eng instanceof JSSEngineReferenceImpl) {
+                    ((JSSEngineReferenceImpl) server_eng).setName("JSS Server " + context);
+                    ((JSSEngineReferenceImpl) server_eng).enableSafeDebugLogging(7377);
+                }
+
+                configureSSLEngine(client_eng, protocol, cipher_suite);
+                configureSSLEngine(server_eng, protocol, cipher_suite);
+
+                try {
+                    System.err.println("Starting initial handshake");
+                    testInitialHandshake(client_eng, server_eng);
+
+                    // Require client auth and re-handshake
+                    server_eng.setWantClientAuth(true);
+                    server_eng.setNeedClientAuth(true);
+                    System.err.println("Starting second handshake");
+                    testBasicHandshake(client_eng, server_eng, true);
+                } catch (Exception e) {
+                    client_eng.cleanup();
                     server_eng.cleanup();
                     throw e;
                 }
@@ -596,6 +661,7 @@ public class TestSSLEngine {
 
         testAllHandshakes(ctx, client_alias, server_alias, false);
         testAllHandshakes(ctx, client_alias, server_alias, true);
+        testPostHandshakeAuth(ctx, client_alias, server_alias);
         testJSSEToJSSHandshakes(ctx, server_alias);
     }
 


### PR DESCRIPTION
This should address some of the certificate issues we've seen in PKI CI. This is in several parts:

 - Expose a bunch of new SSL options
 - Expose `SSL_ReHandshake` (Necessary for renegotiation in TLS < 1.3)
 - Expose `SSL_SendCertificateRequest` (necessary for PHA in TLS >= 1.3). Currently experimental, added in NSS v3.44.
 - Expose the "real" handshake completion status in `SSLFDProxy`. Note that `SecurityStatusResult.on` reports `on` before the finish message is sent/received.
 - Add support for NSS configuration, PHA in `JSSEngine`/`JSSEngineReferenceImpl`.
 - Test everything! :D