### PR TITLE
Allow NULL PK11PrivKey identifiers

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11PrivKey.c
+++ b/org/mozilla/jss/pkcs11/PK11PrivKey.c
@@ -351,15 +351,12 @@ Java_org_mozilla_jss_pkcs11_PK11PrivKey_getUniqueID
     /***************************************************
      * Write the key id to a new byte array
      ***************************************************/
-    PR_ASSERT(idItem->len > 0);
-    byteArray = JSS_ToByteArray(env, idItem->data, idItem->len);
-    if (byteArray == NULL) {
-        ASSERT_OUTOFMEM(env);
-        goto finish;
+    if (idItem->len > 0) {
+        byteArray = JSS_ToByteArray(env, idItem->data, idItem->len);
     }
 
 finish:
-    if(idItem != NULL) {
+    if (idItem != NULL) {
         SECITEM_FreeItem(idItem, PR_TRUE /*freeit*/);
     }
     


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

This has impacted tests for a while. I've finally made it optional rather than fixing the ordering of test cases. 