### PR TITLE
Fix NPE in Utils.HexEncode

### DIFF
--- a/org/mozilla/jss/netscape/security/util/Utils.java
+++ b/org/mozilla/jss/netscape/security/util/Utils.java
@@ -215,11 +215,13 @@ public class Utils {
 
     public static String HexEncode(byte data[]) {
         StringBuffer sb = new StringBuffer();
-        for (int i = 0; i < data.length; i++) {
-            if ((data[i] & 0xff) < 16) {
-                sb.append("0");
+        if (data != null) {
+            for (int i = 0; i < data.length; i++) {
+                if ((data[i] & 0xff) < 16) {
+                    sb.append("0");
+                }
+                sb.append(Integer.toHexString((data[i] & 0xff)));
             }
-            sb.append(Integer.toHexString((data[i] & 0xff)));
         }
         return sb.toString();
     }


### PR DESCRIPTION
In 30b3cde147283d32ec2fd902128e18f54252cf4d, allowances were made for
keys without a unique identifier yet. This happens when the key is new
and code is racing to create an identifier for a key held by another
process which is also accessing the NSS DB. Mostly, this occurs in the
JSS test suite process.

As a result of the now-NULL result, `JSSKeyStoreSpi.getAliases` will call
`Utils.HexEncode` with a value of null, raising a NPE. Allow
`Utils.HexEncode` to return an empty string instead of raising an NPE in
this case.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`