### PR TITLE
Add AlgorithmId.toStringWithParams, fix toString

### DIFF
--- a/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
+++ b/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
@@ -624,9 +624,19 @@ public class AlgorithmId implements Serializable, DerEncoder {
     }
 
     /**
-     * Returns a string describing the algorithm and its parameters.
+     * Returns a string describing only the algorithm without parameters.
+     *
+     * Use toStringWithParams() for algorithm name and paramaters, or
+     * paramsToString() for just parameters.
      */
     public String toString() {
+        return algName();
+    }
+
+    /**
+     * Returns a string describing the algorithm and its parameters.
+     */
+    public String toStringWithParams() {
         if (params == null) {
             return algName();
         }


### PR DESCRIPTION
PKI's usage of `AlgorithmId.toString()` doesn't handle having the
parameters encoded in the `toString()` representation of the id.
Move `toString()` back to only having the contents of `algName`, and
move parameters to a separate method.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`