### PR TITLE
Comply with crypto-policies outside of Tomcat

### DIFF
--- a/org/mozilla/jss/crypto/Policy.java
+++ b/org/mozilla/jss/crypto/Policy.java
@@ -12,6 +12,9 @@ import org.mozilla.jss.ssl.SSLVersionRange;
  *
  * In the event of a policy violation, applications can override policy by
  * writing to the desired variable.
+ *
+ * Refer to SSLCipher.isSupported() for whether or not a given TLS cipher
+ * suite is allowed by local policy.
  */
 public class Policy {
     /**

--- a/org/mozilla/jss/ssl/SSLVersionRange.java
+++ b/org/mozilla/jss/ssl/SSLVersionRange.java
@@ -96,4 +96,26 @@ public class SSLVersionRange {
 
         return result.toArray(new SSLVersion[result.size()]);
     }
+
+    /**
+     * Bounds this SSLVersionRange by the given range.
+     *
+     * The resulting SSLVersionRange does not has a minimum less than
+     * that of its bound and does not have a maximum greater than that
+     * of its bound.
+     */
+    public SSLVersionRange boundBy(SSLVersionRange bound) {
+        SSLVersion minimum = minVersion;
+        SSLVersion maximum = maxVersion;
+
+        if (minimum.compareTo(bound.getMinVersion()) < 0) {
+            minimum = bound.getMinVersion();
+        }
+
+        if (maximum.compareTo(bound.getMaxVersion()) > 0) {
+            maximum = bound.getMaxVersion();
+        }
+
+        return new SSLVersionRange(minimum, maximum);
+    }
 }


### PR DESCRIPTION
When constructing a new `SSLEngine`, Tomcat will take the supported
ciphers and limit the enabled cipher suites to only ones which are
supported by this `SSLEngine` implementation. Because the list of cipher
suites we returned were allowed by local crypto policy, out result was
compliant. However, other usages of `SSLEngine` aren't guaranteed to
behave the same; make sure we explicitly filter to only supported cipher
suites.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`