### PR TITLE
Release JSS v4.6.4

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -2,7 +2,7 @@ macro(jss_config)
     # Set the current JSS release number. Arguments are:
     #   MAJOR MINOR PATCH BETA
     # When BETA is zero, it isn't a beta release.
-    jss_config_version(4 6 3 0)
+    jss_config_version(4 6 4 0)
 
     # Configure output directories
     jss_config_outputs()

--- a/jss.spec
+++ b/jss.spec
@@ -6,7 +6,7 @@ Summary:        Java Security Services (JSS)
 URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
-Version:        4.6.3
+Version:        4.6.4
 Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
 # global         _phase -a1
 


### PR DESCRIPTION
This release features improvements over [`v4.6.3`](https://github.com/dogtagpki/jss/releases/tag/v4.6.3):

 - Fixed base-64 encoding of CSRs
 - Fixed PBE handling
 - Detect broken NSS versions with partial CMAC support
 - Fix NativeProxy memory leaks present since v4.6.2

Thanks to everyone who contributed to this release!

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`