### PR TITLE
Use non-interactive apt installation

### DIFF
--- a/tools/Dockerfiles/debian_jdk11
+++ b/tools/Dockerfiles/debian_jdk11
@@ -2,6 +2,7 @@ FROM debian:testing
 
 # Install generic dependencies to build jss
 RUN true \
+        && export DEBIAN_FRONTEND=noninteractive \
         && apt-get update \
         && apt-get dist-upgrade -y \
         && apt-get install -y debhelper libnss3-dev libnss3-tools libnss3 \

--- a/tools/Dockerfiles/ubuntu_jdk8
+++ b/tools/Dockerfiles/ubuntu_jdk8
@@ -2,6 +2,7 @@ FROM ubuntu:rolling
 
 # Install generic dependencies to build jss
 RUN true \
+        && export DEBIAN_FRONTEND=noninteractive \
         && apt-get update \
         && apt-get dist-upgrade -y \
         && apt-get install -y debhelper libnss3-dev libnss3-tools libnss3 \


### PR DESCRIPTION
Lately an update for `tzdata` has been breaking CI tests for Ubuntu:

    Setting up tzdata (2019c-3ubuntu1) ...
    debconf: unable to initialize frontend: Dialog
    debconf: (TERM is not set, so the dialog frontend is not usable.)
    debconf: falling back to frontend: Readline
    Configuring tzdata
    ------------------

    Please select the geographic area in which you live. Subsequent configuration
    questions will narrow this down by presenting a list of cities, representing
    the time zones in which they are located.

      1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
      2. America     5. Arctic     8. Europe    11. SystemV
      3. Antarctica  6. Asia       9. Indian    12. US

Setting `DEBIAN_FRONTEND=noninteractive` should prevent apt from querying
information from the container image.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`