### PR TITLE
Added PKCS7 constructor

### DIFF
--- a/org/mozilla/jss/netscape/security/pkcs/PKCS7.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS7.java
@@ -33,12 +33,12 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Vector;
 
-import org.mozilla.jss.netscape.security.util.Utils;
 import org.mozilla.jss.netscape.security.util.BigInt;
 import org.mozilla.jss.netscape.security.util.DerInputStream;
 import org.mozilla.jss.netscape.security.util.DerOutputStream;
 import org.mozilla.jss.netscape.security.util.DerValue;
 import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
+import org.mozilla.jss.netscape.security.util.Utils;
 import org.mozilla.jss.netscape.security.x509.AlgorithmId;
 import org.mozilla.jss.netscape.security.x509.X500Name;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
@@ -205,6 +205,15 @@ public class PKCS7 {
         this.contentInfo = contentInfo;
         this.certificates = certificates;
         this.signerInfos = signerInfos;
+    }
+
+    /**
+     * Construct PKCS7 from an array of certificates.
+     *
+     * @param certs Array of certificates.
+     */
+    public PKCS7(X509Certificate[] certs) {
+        this(new AlgorithmId[0], new ContentInfo(new byte[0]), certs, new SignerInfo[0]);
     }
 
     private void parseSignedData(DerValue val)

--- a/org/mozilla/jss/netscape/security/x509/CertificateChain.java
+++ b/org/mozilla/jss/netscape/security/x509/CertificateChain.java
@@ -26,9 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.mozilla.jss.netscape.security.pkcs.ContentInfo;
 import org.mozilla.jss.netscape.security.pkcs.PKCS7;
-import org.mozilla.jss.netscape.security.pkcs.SignerInfo;
 
 public class CertificateChain implements Serializable {
 
@@ -111,11 +109,7 @@ public class CertificateChain implements Serializable {
      */
     public void encode(OutputStream out, boolean sort) throws IOException {
         X509Certificate[] certs = getChain();
-        PKCS7 p7 = new PKCS7(
-                new AlgorithmId[0],
-                new ContentInfo(new byte[0]),
-                certs,
-                new SignerInfo[0]);
+        PKCS7 p7 = new PKCS7(certs);
         p7.encodeSignedData(out, sort);
     }
 


### PR DESCRIPTION
A new constructor has been added to create a `PKCS7` from
an array of certificates. This can be used to simplify
`CertificateChain.encode()` and some other code in PKI.