### PR TITLE
Added CertificateChain.sort()

### DIFF
--- a/org/mozilla/jss/netscape/security/x509/CertificateChain.java
+++ b/org/mozilla/jss/netscape/security/x509/CertificateChain.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.mozilla.jss.netscape.security.pkcs.PKCS7;
+import org.mozilla.jss.netscape.security.util.Cert;
 
 public class CertificateChain implements Serializable {
 
@@ -97,6 +98,16 @@ public class CertificateChain implements Serializable {
      */
     public X509Certificate[] getChain() {
         return certs.toArray(new X509Certificate[certs.size()]);
+    }
+
+    /**
+     * Sorts certificate chain from root to leaf.
+     */
+    public void sort() throws Exception {
+        X509Certificate[] certs = getChain();
+        certs = Cert.sortCertificateChain(certs);
+        this.certs.clear();
+        this.certs.addAll(Arrays.asList(certs));
     }
 
     public void encode(OutputStream out)

--- a/org/mozilla/jss/tests/CertificateChainTest.java
+++ b/org/mozilla/jss/tests/CertificateChainTest.java
@@ -186,4 +186,17 @@ public class CertificateChainTest {
         Assert.assertEquals(subCA, certs[1]);
         Assert.assertEquals(admin, certs[2]);
     }
+
+    @Test
+    public void testSorting() throws Exception {
+
+        CertificateChain chain = new CertificateChain(new X509Certificate[] { admin, subCA, rootCA });
+        chain.sort();
+
+        Assert.assertEquals(3, chain.getCertificates().size());
+
+        Assert.assertEquals(rootCA, chain.getCertificate(0));
+        Assert.assertEquals(subCA, chain.getCertificate(1));
+        Assert.assertEquals(admin, chain.getCertificate(2));
+    }
 }


### PR DESCRIPTION
The CertificateChain.sort() has been added to sort the
certificates in the certificate chain.