### PR TITLE
JSSEngine - Initial ALPN support

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -503,6 +503,7 @@ JSS_4.8.0 {
     global:
 Java_org_mozilla_jss_crypto_JSSOAEPParameterSpec_acquireNativeResources;
 Java_org_mozilla_jss_crypto_JSSOAEPParameterSpec_releaseNativeResources;
+Java_org_mozilla_jss_nss_SSL_SetNextProtoNeg;
     local:
         *;
 };

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -504,6 +504,7 @@ JSS_4.8.0 {
 Java_org_mozilla_jss_crypto_JSSOAEPParameterSpec_acquireNativeResources;
 Java_org_mozilla_jss_crypto_JSSOAEPParameterSpec_releaseNativeResources;
 Java_org_mozilla_jss_nss_SSL_SetNextProtoNeg;
+Java_org_mozilla_jss_nss_SSL_GetNextProto;
     local:
         *;
 };

--- a/org/mozilla/jss/nss/NextProtoResult.java
+++ b/org/mozilla/jss/nss/NextProtoResult.java
@@ -24,7 +24,7 @@ public class NextProtoResult {
     }
 
     public String getProtocol() {
-        if (protocol == null || protocol.length == 0) {
+        if (protocol == null) {
             return null;
         }
 

--- a/org/mozilla/jss/nss/NextProtoResult.java
+++ b/org/mozilla/jss/nss/NextProtoResult.java
@@ -1,0 +1,41 @@
+package org.mozilla.jss.nss;
+
+import java.lang.StringBuilder;
+import java.util.Arrays;
+
+import org.mozilla.jss.ssl.SSLNextProtoState;
+
+/**
+ * The fields in the NextProtoResult indicate whether a given SSL-enabled
+ * PRFileDesc has negotiated a next protocol (via ALPN) and if so, what it
+ * is.
+ *
+ * These object is returned by org.mozilla.jss.nss.SSL.GetNextProto(fd).
+ * This is a native method; note that updating the constructor will require
+ * modifying util/java_ids.h and nss/SSL.c
+ */
+public class NextProtoResult {
+    public SSLNextProtoState state;
+    public byte[] protocol;
+
+    public NextProtoResult(int state_value, byte[] protocol) {
+        state = SSLNextProtoState.valueOf(state_value);
+        this.protocol = protocol;
+    }
+
+    public String getProtocol() {
+        if (protocol == null || protocol.length == 0) {
+            return null;
+        }
+
+        return new String(protocol);
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("State: " + state + "\n");
+        sb.append("Protocol: " + getProtocol() + " ");
+        sb.append(Arrays.toString(protocol) + "\n");
+        return sb.toString();
+    }
+}

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -817,6 +817,32 @@ Java_org_mozilla_jss_nss_SSL_KeyUpdate(JNIEnv *env, jclass clazz,
 }
 
 JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_SetNextProtoNeg(JNIEnv *env, jclass clazz,
+    jobject fd, jbyteArray wire_data)
+{
+    PRFileDesc *real_fd = NULL;
+    uint8_t *data = NULL;
+    size_t data_length = 0;
+    SECStatus ret = SECFailure;
+
+    PR_ASSERT(env != NULL && fd != NULL && wire_data != NULL);
+    PR_SetError(0, 0);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return ret;
+    }
+
+    if (!JSS_FromByteArray(env, wire_data, &data, &data_length)) {
+        return ret;
+    }
+
+    ret = SSL_SetNextProtoNego(real_fd, data, data_length);
+    free(data);
+
+    return ret;
+}
+
+JNIEXPORT jint JNICALL
 Java_org_mozilla_jss_nss_SSL_AttachClientCertCallback(JNIEnv *env, jclass clazz,
     jobject fd)
 {

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -418,6 +418,13 @@ public class SSL {
     public static native int SetNextProtoNeg(SSLFDProxy fd, byte[] wire_data);
 
     /**
+     * Gets the next negotiated protocol.
+     *
+     * See also: SSL_GetNextProto in /usr/include/nss3/ssl.h.
+     */
+    public static native NextProtoResult GetNextProto(SSLFDProxy fd);
+
+    /**
      * Use client authentication; set client certificate from SSLFDProxy.
      *
      * See also: SSL_GetClientAuthDataHook in /usr/include/nss3/ssl.h,

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -411,6 +411,13 @@ public class SSL {
     public static native int KeyUpdate(SSLFDProxy fd, boolean requestUpdate);
 
     /**
+     * Sets the next protocol negotiation (ALPN) in wire format.
+     *
+     * See also: SSL_SetNextProtoNego in /usr/include/nss3/ssl.h.
+     */
+    public static native int SetNextProtoNeg(SSLFDProxy fd, byte[] wire_data);
+
+    /**
      * Use client authentication; set client certificate from SSLFDProxy.
      *
      * See also: SSL_GetClientAuthDataHook in /usr/include/nss3/ssl.h,

--- a/org/mozilla/jss/ssl/SSLNextProtoState.java
+++ b/org/mozilla/jss/ssl/SSLNextProtoState.java
@@ -1,0 +1,29 @@
+package org.mozilla.jss.ssl;
+
+public enum SSLNextProtoState {
+    SSL_NEXT_PROTO_NO_SUPPORT (0),
+    SSL_NEXT_PROTO_NEGOTIATED (1),
+    SSL_NEXT_PROTO_NO_OVERLAP (2),
+    SSL_NEXT_PROTO_SELECTED (3),
+    SSL_NEXT_PROTO_EARLY_VALUE (4);
+
+    private int value;
+
+    private SSLNextProtoState(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static SSLNextProtoState valueOf(int value) {
+        for (SSLNextProtoState type : SSLNextProtoState.values()) {
+            if (type.value == value) {
+                return type;
+            }
+        }
+
+        return null;
+    }
+}

--- a/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -1,5 +1,6 @@
 package org.mozilla.jss.ssl.javax;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.net.ssl.*;
@@ -951,14 +952,14 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     public byte[] getALPNWireData() {
         int length = 0;
         for (String protocol : alpn_protocols) {
-            length += 1 + protocol.getBytes().length;
+            length += 1 + protocol.getBytes(StandardCharsets.UTF_8).length;
         }
 
         byte[] result = new byte[length];
         int offset = 0;
 
         for (String protocol : alpn_protocols) {
-            byte[] p_bytes = protocol.getBytes();
+            byte[] p_bytes = protocol.getBytes(StandardCharsets.UTF_8);
             result[offset] = (byte) p_bytes.length;
             offset += 1;
             System.arraycopy(p_bytes, 0, result, offset, p_bytes.length);

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -1108,22 +1108,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             handshake_state = SSLEngineResult.HandshakeStatus.FINISHED;
             unknown_state_count = 0;
 
-            // Only update peer certificate chain when we've finished
-            // handshaking.
-            try {
-                PK11Cert[] peer_chain = SSL.PeerCertificateChain(ssl_fd);
-                session.setPeerCertificates(peer_chain);
-            } catch (Exception e) {
-                String msg = "Unable to get peer's certificate chain: ";
-                msg += e.getMessage();
-
-                seen_exception = true;
-                ssl_exception = new SSLException(msg, e);
-            }
-
-            // Also update our session information here.
-            session.refreshData();
-
+            updateSession();
             return;
         }
 

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -349,10 +349,13 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
         if (alpn_protocols != null) {
             byte[] wire_data = getALPNWireData();
+            if (wire_data == null) {
+                throw new RuntimeException("JSSEngine.init(): ALPN wire data is NULL but alpn_protocols is non-NULL.");
+            }
 
             ret = SSL.SetNextProtoNeg(ssl_fd, wire_data);
-            if (ret == SSL.SECFailure) {
-                throw new RuntimeException("JSSEngine.init(): Unable to set ALPN protocol list.");
+            if (ret != SSL.SECSuccess) {
+                throw new RuntimeException("JSSEngine.init(): Unable to set ALPN protocol list: " + errorText(PR.GetError()) + " " + ret);
             }
         }
     }

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -970,6 +970,8 @@ public class JSSEngineReferenceImpl extends JSSEngine {
                     ret.state != SSLNextProtoState.SSL_NEXT_PROTO_NO_OVERLAP)
                 {
                     session.setNextProtocol(ret.getProtocol());
+                } else {
+                    session.setNextProtocol("");
                 }
             }
         } catch (Exception e) {

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -347,8 +347,14 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             throw new SSLException("Unable to enable SSL Handshake Callback on this SSLFDProxy instance.");
         }
 
-        // Pass this ssl_fd to the session object so that we can use
-        // SSL methods to invalidate the session.
+        if (alpn_protocols != null) {
+            byte[] wire_data = getALPNWireData();
+
+            ret = SSL.SetNextProtoNeg(ssl_fd, wire_data);
+            if (ret == SSL.SECFailure) {
+                throw new RuntimeException("JSSEngine.init(): Unable to set ALPN protocol list.");
+            }
+        }
     }
 
     private void initClient() throws SSLException {
@@ -935,6 +941,37 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         }
 
         return data_index;
+    }
+
+    private void updateSession() {
+        if (ssl_fd == null) {
+            return;
+        }
+
+        try {
+            PK11Cert[] peer_chain = SSL.PeerCertificateChain(ssl_fd);
+            session.setPeerCertificates(peer_chain);
+
+            SSLChannelInfo info = SSL.GetChannelInfo(ssl_fd);
+            if (info == null) {
+                return;
+            }
+
+            session.setId(info.getSessionID());
+            session.refreshData();
+        
+            NextProtoResult ret = SSL.GetNextProto(ssl_fd);
+            if (ret != null) {
+                // Only advertise the resulting protocol if we have one.
+                if (ret.state != SSLNextProtoState.SSL_NEXT_PROTO_NO_SUPPORT &&
+                    ret.state != SSLNextProtoState.SSL_NEXT_PROTO_NO_OVERLAP)
+                {
+                    session.setNextProtocol(ret.getProtocol());
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
     }
 
     private SSLException checkSSLAlerts() {

--- a/org/mozilla/jss/ssl/javax/JSSParameters.java
+++ b/org/mozilla/jss/ssl/javax/JSSParameters.java
@@ -3,6 +3,7 @@ package org.mozilla.jss.ssl.javax;
 import javax.net.ssl.*;
 import java.util.*;
 
+import org.mozilla.jss.util.JDKCompat;
 import org.mozilla.jss.ssl.*;
 
 /**
@@ -56,7 +57,7 @@ public class JSSParameters extends SSLParameters {
             setNeedClientAuth(downcast.getNeedClientAuth());
         }
 
-        String[] alpn = downcast.getApplicationProtocols(downcast);
+        String[] alpn = JDKCompat.SSLParametersHelper.getApplicationProtocols(downcast);
         if (alpn != null) {
             setApplicationProtocols(alpn);
         }

--- a/org/mozilla/jss/ssl/javax/JSSParameters.java
+++ b/org/mozilla/jss/ssl/javax/JSSParameters.java
@@ -1,7 +1,8 @@
 package org.mozilla.jss.ssl.javax;
 
-import javax.net.ssl.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
+import javax.net.ssl.*;
 
 import org.mozilla.jss.util.JDKCompat;
 import org.mozilla.jss.ssl.*;
@@ -206,7 +207,7 @@ public class JSSParameters extends SSLParameters {
 
         int index = 0;
         for (String protocol : protocols) {
-            if (protocol.length() > 255 || protocol.getBytes().length > 255) {
+            if (protocol != "" && protocol.getBytes(StandardCharsets.UTF_8).length > 255) {
                 String msg = "Invalid application protocol " + protocol;
                 msg += ": standard allows up to 255 characters but was ";
                 msg += protocol.length();

--- a/org/mozilla/jss/ssl/javax/JSSParameters.java
+++ b/org/mozilla/jss/ssl/javax/JSSParameters.java
@@ -26,6 +26,7 @@ public class JSSParameters extends SSLParameters {
     private SSLVersionRange range;
     private String alias;
     private String hostname;
+    private String[] appProtocols;
 
     public JSSParameters() {
         // Choose our default set of SSLParameters here; default to null
@@ -53,6 +54,11 @@ public class JSSParameters extends SSLParameters {
         }
         if (downcast.getNeedClientAuth()) {
             setNeedClientAuth(downcast.getNeedClientAuth());
+        }
+
+        String[] alpn = downcast.getApplicationProtocols(downcast);
+        if (alpn != null) {
+            setApplicationProtocols(alpn);
         }
     }
 
@@ -189,5 +195,28 @@ public class JSSParameters extends SSLParameters {
 
     public void setHostname(String server_hostname) {
         hostname = server_hostname;
+    }
+
+    public void setApplicationProtocols(String[] protocols) throws IllegalArgumentException {
+        if (protocols == null) {
+            appProtocols = null;
+            return;
+        }
+
+        int index = 0;
+        for (String protocol : protocols) {
+            if (protocol.length() > 255 || protocol.getBytes().length > 255) {
+                String msg = "Invalid application protocol " + protocol;
+                msg += ": standard allows up to 255 characters but was ";
+                msg += protocol.length();
+                throw new IllegalArgumentException(msg);
+            }
+        }
+
+        appProtocols = protocols;
+    }
+
+    public String[] getApplicationProtocols() {
+        return appProtocols;
     }
 }

--- a/org/mozilla/jss/ssl/javax/JSSSession.java
+++ b/org/mozilla/jss/ssl/javax/JSSSession.java
@@ -40,6 +40,8 @@ public class JSSSession implements SSLSession, AutoCloseable {
 
     private boolean closed;
 
+    private String nextProtocol;
+
     protected JSSSession(JSSEngine engine, int buffer_size) {
         this.parent = engine;
 
@@ -291,5 +293,13 @@ public class JSSSession implements SSLSession, AutoCloseable {
 
     public void setPeerPort(int port) {
         peerPort = port;
+    }
+
+    public void setNextProtocol(String protocol) {
+        nextProtocol = protocol;
+    }
+
+    public String getNextProtocol() {
+        return nextProtocol;
     }
 }

--- a/org/mozilla/jss/ssl/javax/JSSSocket.java
+++ b/org/mozilla/jss/ssl/javax/JSSSocket.java
@@ -665,6 +665,27 @@ public class JSSSocket extends SSLSocket {
     }
 
     /**
+     * Set a specific list of protocols to negotiate next for ALPN support.
+     */
+    public void setApplicationProtocols(String[] protocols) {
+        engine.setApplicationProtocols(protocols);
+    }
+
+    /**
+     * Get the most recently negotiated application protocol.
+     */
+    public String getApplicationProtocol() {
+        return engine.getApplicationProtocol();
+    }
+
+    /**
+     * Get the application protocol negotiated during the initial handshake.
+     */
+    public String getHandshakeApplicationProtocol() {
+        return engine.getHandshakeApplicationProtocol();
+    }
+
+    /**
      * Get the configuration of this SSLSocket as a JSSParameters object.
      *
      * @see JSSEngine#getSSLParameters()

--- a/org/mozilla/jss/tests/TestSSLEngine.java
+++ b/org/mozilla/jss/tests/TestSSLEngine.java
@@ -1003,6 +1003,20 @@ public class TestSSLEngine {
         testJSSEToJSSHandshakes(ctx, server_alias);
     }
 
+    public static void testALPNEncoding() throws Exception {
+        JSSEngine eng = new JSSEngineReferenceImpl();
+
+        eng.setApplicationProtocols(new String[] { "http/1.1" });
+        byte[] expectedHTTPOnly = new byte[] { 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31 };
+        assert Arrays.equals(eng.getALPNWireData(), expectedHTTPOnly);
+
+        eng = new JSSEngineReferenceImpl();
+
+        eng.setApplicationProtocols(new String[] { "http/1.1", "spdy/2" });
+        byte[] expectedHTTPSpdy = new byte[] { 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31, 0x06, 0x73, 0x70, 0x64, 0x79, 0x2f, 0x32 };
+        assert Arrays.equals(eng.getALPNWireData(), expectedHTTPSpdy);
+    }
+
     public static void main(String[] args) throws Exception {
         // Args:
         //  - nssdb
@@ -1027,5 +1041,8 @@ public class TestSSLEngine {
 
         System.out.println("Testing basic handshake with native TM...");
         testNativeClientServer(args);
+
+        System.out.println("Testing ALPN encoding...");
+        testALPNEncoding();
     }
 }

--- a/org/mozilla/jss/tests/TestSSLEngine.java
+++ b/org/mozilla/jss/tests/TestSSLEngine.java
@@ -11,6 +11,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
@@ -1050,6 +1051,22 @@ public class TestSSLEngine {
         eng.setApplicationProtocols(new String[] { "http/1.1", "spdy/2" });
         byte[] expectedHTTPSpdy = new byte[] { 0x06, 0x73, 0x70, 0x64, 0x79, 0x2f, 0x32, 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31 };
         assert Arrays.equals(eng.getALPNWireData(), expectedHTTPSpdy);
+
+        // Handles default value
+        SSLParameters s_params = new SSLParameters();
+        JSSParameters j_params = new JSSParameters(s_params);
+        assert j_params.getApplicationProtocols() == null;
+
+        // Handles empty list
+        j_params = new JSSParameters();
+        j_params.setApplicationProtocols(new String[0]);
+        assert j_params.getApplicationProtocols() == null;
+
+        // Handles null list
+        j_params = new JSSParameters();
+        String[] protos = null;
+        j_params.setApplicationProtocols(protos);
+        assert j_params.getApplicationProtocols() == null;
     }
 
     public static void main(String[] args) throws Exception {

--- a/org/mozilla/jss/tests/TestSSLEngine.java
+++ b/org/mozilla/jss/tests/TestSSLEngine.java
@@ -1001,8 +1001,10 @@ public class TestSSLEngine {
         }
 
         try {
-            testBasicHandshake(client_eng, server_eng, false);
-            assert(server_eng.getApplicationProtocol().equals("h2"));
+            testInitialHandshake(client_eng, server_eng);
+            assert client_eng.getApplicationProtocol().equals("h2");
+            assert server_eng.getApplicationProtocol().equals("h2");
+            testClose(client_eng, server_eng);
         } catch (Exception e) {
             client_eng.cleanup();
             server_eng.cleanup();
@@ -1046,7 +1048,7 @@ public class TestSSLEngine {
         eng = new JSSEngineReferenceImpl();
 
         eng.setApplicationProtocols(new String[] { "http/1.1", "spdy/2" });
-        byte[] expectedHTTPSpdy = new byte[] { 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31, 0x06, 0x73, 0x70, 0x64, 0x79, 0x2f, 0x32 };
+        byte[] expectedHTTPSpdy = new byte[] { 0x06, 0x73, 0x70, 0x64, 0x79, 0x2f, 0x32, 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31 };
         assert Arrays.equals(eng.getALPNWireData(), expectedHTTPSpdy);
     }
 

--- a/org/mozilla/jss/util/JDKCompat.java
+++ b/org/mozilla/jss/util/JDKCompat.java
@@ -1,0 +1,22 @@
+
+package org.mozilla.jss.util;
+
+import java.lang.reflect.Method;
+
+import javax.net.ssl.SSLParameters;
+
+public class JDKCompat {
+    public static class SSLParametersHelper {
+        public static String[] getApplicationProtocols(SSLParameters inst) {
+            try {
+                Method getter = inst.getClass().getMethod("getApplicationProtocols");
+                Object result = getter.invoke(inst);
+                return (String[]) result;
+            } catch (NoSuchMethodException nsme) {
+                return null;
+            } catch (Throwable t) {
+                throw new RuntimeException(t.getMessage(), t);
+            }
+        }
+    }
+}

--- a/org/mozilla/jss/util/java_ids.h
+++ b/org/mozilla/jss/util/java_ids.h
@@ -444,6 +444,12 @@ PR_BEGIN_EXTERN_C
 #define SSL_PRELIMINARY_CHANNEL_INFO_CLASS_NAME "org/mozilla/jss/nss/SSLPreliminaryChannelInfo"
 #define SSL_PRELIMINARY_CHANNEL_INFO_CONSTRUCTOR_SIG "(JIIZJZIZZII)V"
 
+/*
+ * NextProtoResult classes
+ */
+#define NEXT_PROTO_CLASS_NAME "org/mozilla/jss/nss/NextProtoResult"
+#define NEXT_PROTO_CONSTRUCTOR_SIG "(I[B)V"
+
 PR_END_EXTERN_C
 
 #endif


### PR DESCRIPTION
This pull requests introduces support for ALPN negotiation via a fixed list of next protocol identifiers.

Technically this support was introduced in the native SSLEngine in JDK 9, but support in Tomcat exists for older versions when advertised.

ALPN is a method of negotiating the next protocol after TLS. Most of the time this will be `http/1.1`, but could be `h2` or `spdy/2` depending on browser and server support. Without this, Tomcat is limited to `http/1.1` and cannot speak e.g., `http/2`.

--

Also, having a ALPN-capable implementation means we can go implement [TLS-ALPN-01 / RFC 8737](https://tools.ietf.org/html/rfc8737) if we wanted to.

