### PR TITLE
Fixed CertificateChainTest.testGetterMethods()

### DIFF
--- a/org/mozilla/jss/tests/CertificateChainTest.java
+++ b/org/mozilla/jss/tests/CertificateChainTest.java
@@ -175,7 +175,7 @@ public class CertificateChainTest {
             Assert.fail("Getting cert #3 should fail");
 
         } catch (IndexOutOfBoundsException e) {
-            Assert.assertEquals("Index: 3, Size: 3", e.getMessage());
+            // failed as expected
         }
 
         X509Certificate[] certs = chain.getChain();


### PR DESCRIPTION
The `CertificateChainTest.testGetterMethods()` has been
modified to ignore the exception message since it may
change in different JDK versions.