### PR TITLE
Move JDK11 test to required section

### DIFF
--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -11,7 +11,6 @@ jobs:
           - 'pkcs11check'
           - 'debian_jdk11'
           - 'ubuntu_jdk8'
-          - 'fedora_latest_jdk11'
           - 'fedora_rawhide'
           - 'fedora_sandbox'
           - 'centos_7'

--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -7,7 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['fedora_30', 'fedora_31', 'symbolcheck']
+        image:
+          - 'fedora_30'
+          - 'fedora_31'
+          - 'fedora_latest_jdk11'
+          - 'symbolcheck'
     steps:
     - name: Clone the repository
       uses: actions/checkout@v2


### PR DESCRIPTION
Fedora 33 will ship with OpenJDK 11 by default and packages will be
required to compile with it. Move this to the default section so we
can catch failures with JDK11 support.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`