### PR TITLE
Hack: provide SSLContext's SSLSocket via SunJSSE

### DIFF
--- a/org/mozilla/jss/provider/javax/net/JSSContextSpi.java
+++ b/org/mozilla/jss/provider/javax/net/JSSContextSpi.java
@@ -88,13 +88,35 @@ public class JSSContextSpi extends SSLContextSpi {
     }
 
     public SSLServerSocketFactory engineGetServerSocketFactory() {
-        logger.debug("JSSContextSpi.engineGetServerSocketFactory() - not implemented");
-        return null;
+        logger.warn("JSSContextSpi.engineGetServerSocketFactory() - not implemented - stubbing with SunJSSE");
+
+        String protocol = "TLS";
+        try {
+            if (protocol_version != null) {
+                protocol = protocol_version.jdkAlias();
+            }
+
+            SSLContext jsse = SSLContext.getInstance(protocol, "SunJSSE");
+            return jsse.getServerSocketFactory();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to get SunJSSE provider for " + protocol + ": " + e.getMessage(), e);
+        }
     }
 
     public SSLSocketFactory engineGetSocketFactory() {
-        logger.debug("JSSContextSpi.engineGetSocketFactory() - not implemented");
-        return null;
+        logger.warn("JSSContextSpi.engineGetSocketFactory() - not implemented - stubbing with SunJSSE");
+
+        String protocol = "TLS";
+        try {
+            if (protocol_version != null) {
+                protocol = protocol_version.jdkAlias();
+            }
+
+            SSLContext jsse = SSLContext.getInstance(protocol, "SunJSSE");
+            return jsse.getSocketFactory();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to get SunJSSE provider for " + protocol + ": " + e.getMessage(), e);
+        }
     }
 
     public SSLParameters engineGetSupportedSSLParameters() {


### PR DESCRIPTION
Use the default `SunJSSE` provider to implement `getSocketFactory` and
`getServerSocketFactory` rather than returning `null`. This should appease
implementations expecting a `SocketFactory` instance.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`