### PR TITLE
Remove JSSContextSpi for the time being

### DIFF
--- a/org/mozilla/jss/JSSLoader.java
+++ b/org/mozilla/jss/JSSLoader.java
@@ -56,6 +56,9 @@ import org.slf4j.LoggerFactory;
  *  - nss.cooperate -- whether to cooperate with other parts of the program
  *                     already having initialized NSS (default: false)
  *
+ *  - jss.experimental.sslengine -- whether to enable experimental SSLEngine
+ *                                  support
+ *
  *  - jss.fips -- whether to switch this NSS DB into FIPS mode; allowed values
  *                are ENABLED (to force FIPS mode), DISABLED (to force
  *                non-FIPS mode), or UNCHANGED (default, to infer the value
@@ -132,6 +135,8 @@ public class JSSLoader {
 
         parseOCSPPolicy(config, cm);
         parsePasswords(config, cm);
+
+        parseExperimental(config);
     }
 
     /**
@@ -331,6 +336,16 @@ public class JSSLoader {
         if (password != null && !password.isEmpty()) {
             Password pass_cb = new Password(password.toCharArray());
             cm.setPasswordCallback(pass_cb);
+        }
+    }
+
+    /**
+     * Check for exerpimental flags.
+     */
+    private static void parseExperimental(Properties config) {
+        Boolean sslengine = parseBoolean(config, "jss.experimental.sslengine");
+        if (sslengine != null) {
+            JSSProvider.ENABLE_JSSENGINE = sslengine;
         }
     }
 

--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -9,6 +9,7 @@ import java.security.Provider;
 import java.io.InputStream;
 
 public final class JSSProvider extends java.security.Provider {
+    public static boolean ENABLE_JSSENGINE = false;
 
     private static final long serialVersionUID = 1L;
     /********************************************************************/
@@ -403,12 +404,14 @@ public final class JSSProvider extends java.security.Provider {
         /////////////////////////////////////////////////////////////
         // TLS
         /////////////////////////////////////////////////////////////
-        put("SSLContext.Default", "org.mozilla.jss.provider.javax.net.JSSContextSpi");
-        put("SSLContext.SSL", "org.mozilla.jss.provider.javax.net.JSSContextSpi");
-        put("SSLContext.TLS", "org.mozilla.jss.provider.javax.net.JSSContextSpi");
-        put("SSLContext.TLSv1.1", "org.mozilla.jss.provider.javax.net.JSSContextSpi$TLSv11");
-        put("SSLContext.TLSv1.2", "org.mozilla.jss.provider.javax.net.JSSContextSpi$TLSv12");
-        put("SSLContext.TLSv1.3", "org.mozilla.jss.provider.javax.net.JSSContextSpi$TLSv13");
+        if (ENABLE_JSSENGINE) {
+            put("SSLContext.Default", "org.mozilla.jss.provider.javax.net.JSSContextSpi");
+            put("SSLContext.SSL", "org.mozilla.jss.provider.javax.net.JSSContextSpi");
+            put("SSLContext.TLS", "org.mozilla.jss.provider.javax.net.JSSContextSpi");
+            put("SSLContext.TLSv1.1", "org.mozilla.jss.provider.javax.net.JSSContextSpi$TLSv11");
+            put("SSLContext.TLSv1.2", "org.mozilla.jss.provider.javax.net.JSSContextSpi$TLSv12");
+            put("SSLContext.TLSv1.3", "org.mozilla.jss.provider.javax.net.JSSContextSpi$TLSv13");
+        }
     }
 
     public String toString() {

--- a/org/mozilla/jss/tests/TestSSLEngine.java
+++ b/org/mozilla/jss/tests/TestSSLEngine.java
@@ -699,6 +699,10 @@ public class TestSSLEngine {
         System.out.println("Initializing CryptoManager...");
         initialize(args);
 
+        if (org.mozilla.jss.JSSProvider.ENABLE_JSSENGINE == false) {
+            return;
+        }
+
         assert(SSLVersion.TLS_1_2.matchesAlias("TLSv1.2"));
 
         System.out.println("Testing provided instance...");

--- a/tools/jss.cfg.in
+++ b/tools/jss.cfg.in
@@ -1,3 +1,4 @@
 nss.config_dir=${NSS_DB_PATH}
 nss.cooperate=true
 jss.password=${DB_PWD}
+jss.experimental.sslengine=true


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

--- 

Too many people are utilizing JSS master branch and expecting it to be stable. Remove JSSContextSpi for the time being until SSLEngine performance has been improved and SSLSocket is present. 