### PR TITLE
Finish JSSContext - Switch to JSS-provided SSLSocket

### DIFF
--- a/org/mozilla/jss/provider/javax/net/JSSContextSpi.java
+++ b/org/mozilla/jss/provider/javax/net/JSSContextSpi.java
@@ -16,6 +16,8 @@ import org.mozilla.jss.pkcs11.PK11PrivKey;
 import org.mozilla.jss.ssl.javax.JSSEngine;
 import org.mozilla.jss.ssl.javax.JSSEngineReferenceImpl;
 import org.mozilla.jss.ssl.javax.JSSParameters;
+import org.mozilla.jss.ssl.javax.JSSServerSocketFactory;
+import org.mozilla.jss.ssl.javax.JSSSocketFactory;
 import org.mozilla.jss.ssl.SSLVersion;
 
 public class JSSContextSpi extends SSLContextSpi {
@@ -88,35 +90,23 @@ public class JSSContextSpi extends SSLContextSpi {
     }
 
     public SSLServerSocketFactory engineGetServerSocketFactory() {
-        logger.warn("JSSContextSpi.engineGetServerSocketFactory() - not implemented - stubbing with SunJSSE");
-
         String protocol = "TLS";
-        try {
-            if (protocol_version != null) {
-                protocol = protocol_version.jdkAlias();
-            }
-
-            SSLContext jsse = SSLContext.getInstance(protocol, "SunJSSE");
-            return jsse.getServerSocketFactory();
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to get SunJSSE provider for " + protocol + ": " + e.getMessage(), e);
+        if (protocol_version != null) {
+            protocol = protocol_version.jdkAlias();
         }
+
+        logger.debug("JSSContextSpi.engineGetServerSocketFactory() @ " + protocol);
+        return new JSSServerSocketFactory(protocol, key_manager, trust_managers);
     }
 
     public SSLSocketFactory engineGetSocketFactory() {
-        logger.warn("JSSContextSpi.engineGetSocketFactory() - not implemented - stubbing with SunJSSE");
-
         String protocol = "TLS";
-        try {
-            if (protocol_version != null) {
-                protocol = protocol_version.jdkAlias();
-            }
-
-            SSLContext jsse = SSLContext.getInstance(protocol, "SunJSSE");
-            return jsse.getSocketFactory();
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to get SunJSSE provider for " + protocol + ": " + e.getMessage(), e);
+        if (protocol_version != null) {
+            protocol = protocol_version.jdkAlias();
         }
+
+        logger.debug("JSSContextSpi.engineGetSocketFactory() @ " + protocol);
+        return new JSSSocketFactory(protocol, key_manager, trust_managers);
     }
 
     public SSLParameters engineGetSupportedSSLParameters() {

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -1039,7 +1039,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
         while (index < max_index) {
             // If we don't have any remaining bytes in this buffer, skip it.
-            if (srcs[index].remaining() <= 0) {
+            if (srcs[index] == null || srcs[index].remaining() <= 0) {
                 index += 1;
                 continue;
             }

--- a/org/mozilla/jss/ssl/javax/JSSServerSocketFactory.java
+++ b/org/mozilla/jss/ssl/javax/JSSServerSocketFactory.java
@@ -1,0 +1,88 @@
+package org.mozilla.jss.ssl.javax;
+
+import java.io.*;
+import java.net.*;
+import java.security.*;
+
+import javax.net.ssl.*;
+
+import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
+import org.mozilla.jss.ssl.SSLCipher;
+
+public class JSSServerSocketFactory extends SSLServerSocketFactory {
+    private SSLContext ctx;
+    private JSSKeyManager key_manager;
+    private X509TrustManager[] trust_managers;
+
+    public JSSServerSocketFactory(String protocol, JSSKeyManager km, X509TrustManager[] tms) {
+        try {
+            ctx = SSLContext.getInstance(protocol, "Mozilla-JSS");
+            ctx.init(new JSSKeyManager[]{ km }, tms, null);
+        } catch (Exception e) {
+            throw new RuntimeException("Unexpected error recreating SSLContext instance: " + e.getMessage(), e);
+        }
+
+        key_manager = km;
+        trust_managers = tms;
+    }
+
+    public String[] getDefaultCipherSuites() {
+        SSLCipher[] ciphers = JSSEngine.queryEnabledCipherSuites();
+        String[] result = new String[ciphers.length];
+
+        for (int i = 0; i < ciphers.length; i++) {
+            result[i] = ciphers[i].toString();
+        }
+
+        return result;
+    }
+
+    public String[] getSupportedCipherSuites() {
+        JSSEngineReferenceImpl engine = new JSSEngineReferenceImpl();
+        return engine.getSupportedCipherSuites();
+    }
+
+    public JSSServerSocket createServerSocket() throws IOException {
+        JSSServerSocket ret = new JSSServerSocket();
+        ret.consumeSocket(new ServerSocket());
+        ret.setSSLContext(ctx);
+        ret.initEngine();
+        ret.setKeyManager(key_manager);
+        ret.setTrustManagers(trust_managers);
+
+        return ret;
+    }
+
+    public JSSServerSocket createServerSocket(int port) throws IOException {
+        JSSServerSocket ret = new JSSServerSocket();
+        ret.consumeSocket(new ServerSocket(port));
+        ret.setSSLContext(ctx);
+        ret.initEngine();
+        ret.setKeyManager(key_manager);
+        ret.setTrustManagers(trust_managers);
+
+        return ret;
+    }
+
+    public JSSServerSocket createServerSocket(int port, int backlog) throws IOException {
+        JSSServerSocket ret = new JSSServerSocket();
+        ret.consumeSocket(new ServerSocket(port, backlog));
+        ret.setSSLContext(ctx);
+        ret.initEngine();
+        ret.setKeyManager(key_manager);
+        ret.setTrustManagers(trust_managers);
+
+        return ret;
+    }
+
+    public JSSServerSocket createServerSocket(int port, int backlog, InetAddress ifAddress) throws IOException {
+        JSSServerSocket ret = new JSSServerSocket();
+        ret.consumeSocket(new ServerSocket(port, backlog, ifAddress));
+        ret.setSSLContext(ctx);
+        ret.initEngine();
+        ret.setKeyManager(key_manager);
+        ret.setTrustManagers(trust_managers);
+
+        return ret;
+    }
+}

--- a/org/mozilla/jss/ssl/javax/JSSSocketFactory.java
+++ b/org/mozilla/jss/ssl/javax/JSSSocketFactory.java
@@ -1,0 +1,125 @@
+package org.mozilla.jss.ssl.javax;
+
+import java.io.*;
+import java.net.*;
+import java.security.*;
+
+import javax.net.ssl.*;
+
+import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
+import org.mozilla.jss.ssl.SSLCipher;
+
+public class JSSSocketFactory extends SSLSocketFactory {
+    private SSLContext ctx;
+    private JSSKeyManager key_manager;
+    private X509TrustManager[] trust_managers;
+
+    public JSSSocketFactory(String protocol, JSSKeyManager km, X509TrustManager[] tms) {
+        try {
+            ctx = SSLContext.getInstance(protocol, "Mozilla-JSS");
+            ctx.init(new JSSKeyManager[]{ km }, tms, null);
+        } catch (Exception e) {
+            throw new RuntimeException("Unexpected error recreating SSLContext instance: " + e.getMessage(), e);
+        }
+
+        key_manager = km;
+        trust_managers = tms;
+    }
+
+    public String[] getDefaultCipherSuites() {
+        SSLCipher[] ciphers = JSSEngine.queryEnabledCipherSuites();
+        String[] result = new String[ciphers.length];
+
+        for (int i = 0; i < ciphers.length; i++) {
+            result[i] = ciphers[i].toString();
+        }
+
+        return result;
+    }
+
+    public String[] getSupportedCipherSuites() {
+        JSSEngineReferenceImpl engine = new JSSEngineReferenceImpl();
+        return engine.getSupportedCipherSuites();
+    }
+
+    public JSSSocket createSocket() throws IOException {
+        JSSSocket ret = new JSSSocket();
+        ret.consumeSocket(new Socket());
+        ret.setSSLContext(ctx);
+        ret.initEngine();
+        ret.setKeyManager(key_manager);
+        ret.setTrustManagers(trust_managers);
+
+        return ret;
+    }
+
+    public JSSSocket createSocket(InetAddress host, int port) throws IOException {
+        JSSSocket ret = new JSSSocket();
+        ret.consumeSocket(new Socket(host, port));
+        ret.setSSLContext(ctx);
+        ret.initEngine();
+        ret.setKeyManager(key_manager);
+        ret.setTrustManagers(trust_managers);
+
+        return ret;
+    }
+
+    public JSSSocket createSocket(InetAddress host, int port, InetAddress localAddress, int localPort) throws IOException {
+        JSSSocket ret = new JSSSocket();
+        ret.consumeSocket(new Socket(host, port, localAddress, localPort));
+        ret.setSSLContext(ctx);
+        ret.initEngine();
+        ret.setKeyManager(key_manager);
+        ret.setTrustManagers(trust_managers);
+
+        return ret;
+    }
+
+    public JSSSocket createSocket(String host, int port) throws IOException {
+        JSSSocket ret = new JSSSocket();
+        ret.consumeSocket(new Socket(host, port));
+        ret.setSSLContext(ctx);
+        ret.initEngine(host, port);
+        ret.setKeyManager(key_manager);
+        ret.setTrustManagers(trust_managers);
+
+        return ret;
+    }
+
+    public JSSSocket createSocket(String host, int port, InetAddress localAddress, int localPort) throws IOException {
+        JSSSocket ret = new JSSSocket();
+        ret.consumeSocket(new Socket(host, port, localAddress, localPort));
+        ret.setSSLContext(ctx);
+        ret.initEngine(host, port);
+        ret.setKeyManager(key_manager);
+        ret.setTrustManagers(trust_managers);
+
+        return ret;
+    }
+
+    public JSSSocket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        JSSSocket ret = new JSSSocket();
+        ret.consumeSocket(s);
+        ret.setSSLContext(ctx);
+        ret.initEngine(host, port);
+        ret.setAutoClose(autoClose);
+        ret.setKeyManager(key_manager);
+        ret.setTrustManagers(trust_managers);
+
+        return ret;
+    }
+
+    public JSSSocket createSocket(Socket s, InputStream consumed, boolean autoClose) throws IOException {
+        JSSSocket ret = new JSSSocket();
+        ret.consumeSocket(s);
+        ret.setConsumedData(consumed);
+        ret.setSSLContext(ctx);
+        ret.initEngine();
+        ret.setUseClientMode(false);
+        ret.setAutoClose(autoClose);
+        ret.setKeyManager(key_manager);
+        ret.setTrustManagers(trust_managers);
+
+        return ret;
+    }
+}

--- a/tools/run_test.sh.in
+++ b/tools/run_test.sh.in
@@ -6,13 +6,15 @@
 # get used.
 
 export LD_LIBRARY_PATH="${NSS_LIBRARIES}:${CMAKE_BINARY_DIR}:${NSPR_LIBRARIES}"
+export CLASSPATH="${TEST_CLASSPATH}"
+export JAVA_SECURITY_CFG="${CONFIG_OUTPUT_DIR}/java.security"
 
 if [ "$1" == "--gdb" ]; then
     shift
-    gdb --args "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="${CONFIG_OUTPUT_DIR}/java.security" -Djava.util.logging.config.file="${PROJECT_SOURCE_DIR}/tools/logging.properties" "$@"
+    gdb --args "${Java_JAVA_EXECUTABLE}" -classpath "$CLASSPATH" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="$JAVA_SECURITY_CFG" -Djava.util.logging.config.file="${PROJECT_SOURCE_DIR}/tools/logging.properties" "$@"
 elif [ "$1" == "--valgrind" ]; then
     shift
-    valgrind --leak-check=full --track-origins=yes --show-leak-kinds=all "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="${CONFIG_OUTPUT_DIR}/java.security" -Djava.util.logging.config.file="${PROJECT_SOURCE_DIR}/tools/logging.properties" "$@"
+    valgrind --leak-check=full --track-origins=yes --show-leak-kinds=all "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="$JAVA_SECURITY_CFG" -Djava.util.logging.config.file="${PROJECT_SOURCE_DIR}/tools/logging.properties" "$@"
 else
-    "${Java_JAVA_EXECUTABLE}" -classpath "${TEST_CLASSPATH}" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="${CONFIG_OUTPUT_DIR}/java.security" -Djava.util.logging.config.file="${PROJECT_SOURCE_DIR}/tools/logging.properties" "$@"
+    "${Java_JAVA_EXECUTABLE}" -classpath "$CLASSPATH" -ea -Djava.library.path="$LD_LIBRARY_PATH" -Djava.security.properties="$JAVA_SECURITY_CFG" -Djava.util.logging.config.file="${PROJECT_SOURCE_DIR}/tools/logging.properties" "$@"
 fi


### PR DESCRIPTION
This is the remaining work: add our `SSLSocketFactory` and `SSLServerSocketFactory` implementations and then switch to them in `JSSContextSpi`. Introduces a single, minor test case, which adds the new `JSSSocket` to our existing `BadSSL` tests.