### PR TITLE
Simplify JSSServerSocketChannel.accept()

### DIFF
--- a/org/mozilla/jss/ssl/javax/JSSServerSocketChannel.java
+++ b/org/mozilla/jss/ssl/javax/JSSServerSocketChannel.java
@@ -41,12 +41,9 @@ public class JSSServerSocketChannel extends ServerSocketChannel {
 
     public JSSSocketChannel accept() throws IOException {
         if (parent == null) {
-            // Have to be in blocking mode. Call up to sslSocket to handle
-            // the accept. Note that JSSSocket always has a SocketChannel even
-            // when the underlying socket doesn't so the call to getChannel()
-            // will be non-null.
-            JSSSocket acceptedSocket = sslSocket.accept();
-            return acceptedSocket.getInternalChannel();
+            String msg = "Unable to accept() on a JSSServerSocketChannel ";
+            msg += "which wraps a blocking ServerSocket lacking a channel.";
+            throw new IOException(msg);
         }
 
         SocketChannel acceptedChannel = parent.accept();


### PR DESCRIPTION
Since we won't return the `JSSServerSocketChannel` in situations where the
wrapped socket lacks a channel, it is highly unlikely that this method
will ever be called when the parent channel is `null`. Simplify the logic
and throw an exception in this case instead of returning an accepted
socket channel. Note that, while calling `accept()` on the parent socket will
allows return a non-null socket, it isn't guaranteed to have a
`SocketChannel`.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`