### PR TITLE
Cache SSL Server Sockets

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11Cert.java
+++ b/org/mozilla/jss/pkcs11/PK11Cert.java
@@ -37,6 +37,27 @@ public class PK11Cert
         return nickname;
     }
 
+    public int hashCode() {
+        try {
+            return Arrays.hashCode(getEncoded());
+        } catch (CertificateEncodingException cee) {
+            throw new RuntimeException(cee.getMessage(), cee);
+        }
+    }
+
+    public boolean equals(Object other) {
+        if (other == null || !(other instanceof PK11Cert)) {
+            return false;
+        }
+
+        PK11Cert p_other = (PK11Cert) other;
+        try {
+            return Arrays.equals(getEncoded(), p_other.getEncoded());
+        } catch (CertificateEncodingException cee) {
+            throw new RuntimeException(cee.getMessage(), cee);
+        }
+    }
+
     /**
      * A class that implements Principal with a String.
      */


### PR DESCRIPTION
Concretely, this gives us a performance improvement from:

```
    73/77 Test #53: SSLEngine_RSA .....................................   Passed   39.81 sec
          Start 54: SSLEngine_ECDSA
    74/77 Test #54: SSLEngine_ECDSA ...................................   Passed    5.10 sec
          Start 72: SSLEngine_RSA_FIPSMODE
    75/77 Test #72: SSLEngine_RSA_FIPSMODE ............................   Passed   35.63 sec
          Start 73: SSLEngine_ECDSA_FIPSMODE
    76/77 Test #73: SSLEngine_ECDSA_FIPSMODE ..........................   Passed    4.54 sec
```

to:

```
73/77 Test #53: SSLEngine_RSA .....................................   Passed   22.16 sec
      Start 54: SSLEngine_ECDSA
74/77 Test #54: SSLEngine_ECDSA ...................................   Passed    4.05 sec
      Start 72: SSLEngine_RSA_FIPSMODE
75/77 Test #72: SSLEngine_RSA_FIPSMODE ............................   Passed   19.11 sec
      Start 73: SSLEngine_ECDSA_FIPSMODE
76/77 Test #73: SSLEngine_ECDSA_FIPSMODE ..........................   Passed    3.64 sec
```

When there's lots of tests reusing the same cert (such as `SSLEngine_RSA` and `SSLEngine_RSA_FIPSMODE`), this gives us an improvement of roughly 40%. This is the primary scenario we'd be using in Tomcat as well. 