### PR TITLE
Add SSLSocket benchmark

### DIFF
--- a/docs/usage/benchmarksslsocket.md
+++ b/docs/usage/benchmarksslsocket.md
@@ -1,0 +1,194 @@
+# Usage
+
+This benchmark is a server-side SSLSocket benchmark for use with clients
+which measure performance. This benchmark does not, itself, make any
+performance measurements. For instance:
+
+```bash
+$ ./run_test.sh org.mozilla.jss.tests.BenchmarkSSLSocket JSS.legacy Server_RSA 8443 1024 &
+$ siege -c 100 -b -t 5m https://localhost:8443
+$ kill %1
+```
+
+There are three supported SSLSocket implementations:
+
+ 1. `org.mozilla.jss.ssl.SSLSocket`, JSS's legacy implementation
+    name: `JSS.legacy`
+ 2. `org.mozilla.jss.ssl.javax.JSSSocket`, JSS's new javax implementation
+    name: `JSS.SSLSocket`
+ 3. `sun.security`'s `SSLSocketImpl` from the current JDK.
+    name: `SunJSSE.SSLSocket`
+
+It is suggested to disable all logging (for instance, via:
+`truncate -s 0 tools/logging.properties`) in order have reproducible
+results.
+
+This class takes four arguments when invoked:
+
+ 1. The name of the implementation to benchmark, see above.
+ 2. An alias of the certificate or path to a PKCS#12 file. Only SunJSSE
+    accepts a PKCS#12 as path -- the two JSS based SSLSocket
+    implementations will utilize a nickname instead.
+ 3. The port to listen on.
+ 4. The size of the HTTP message to fake.
+
+Note that, when utilizing a JSS provider, JSS must be loaded via a
+java.security. When utilizing SunJSSE, for best results, do not load
+JSS via java.security.
+
+It is suggested to use `run_test.sh` from the `build/` directory for
+executing this utility.
+
+# Past Performance
+
+## `JSSEngineReferenceImpl`
+
+
+These are the results from siege [0] as run via:
+
+```bash
+ $ siege -c 100 -b -t 5m https://localhost:8443
+```
+
+with the benchmarker set to send a faked 1024-byte message:
+
+```bash
+ $ ./run_test.sh org.mozilla.jss.tests.BenchmarkSSLSocket JSS.legacy Server_RSA 8443 1024
+```
+
+The server certificate is 4096-bits. The selection of cipher suite and
+protocol is left at their defaults. This is on a Lenovo Thinkpad P50
+with an `Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz` processor and 32GB of RAM.
+Each request gets spun off and handled by a new thread.
+
+
+Using the legacy `org.mozilla.jss.ssl.SSLSocket` (old NSS-based socket)
+memory stays stable and under ~1-2% of total memory:
+
+```json
+{
+        "transactions":                        98588,
+        "availability":                        100.00,
+        "elapsed_time":                        299.43,
+        "data_transferred":                    96.28,
+        "response_time":                       0.30,
+        "transaction_rate":                    329.25,
+        "throughput":                          0.32,
+        "concurrency":                         99.80,
+        "successful_transactions":             98588,
+        "failed_transactions":                 0,
+        "longest_transaction":                 29.94,
+        "shortest_transaction":                0.04
+}
+```
+
+
+Using `javax.net.ssl.SSLSocket` provided by SunJSSE (but with JSS crypto
+and potentially random) and stays under 1-2% of total memory:
+
+```json
+{
+        "transactions":                        2417,
+        "availability":                        100.00,
+        "elapsed_time":                        299.36,
+        "data_transferred":                    2.36,
+        "response_time":                       12.12,
+        "transaction_rate":                    8.07,
+        "throughput":                          0.01,
+        "concurrency":                         97.82,
+        "successful_transactions":             2417,
+        "failed_transactions":                 0,
+        "longest_transaction":                 21.27,
+        "shortest_transaction":                1.63
+}
+```
+
+**Note** that the above option was removed from the benchmark utility as it
+was significantly slower.
+
+
+Using `javax.net.ssl.SSLSocket` provided by SunJSSE (without JSS crypto,
+via exporting to PKCS12 file) and stays under 8% of total memory:
+
+```json
+{
+        "transactions":                        93168,
+        "availability":                        100.00,
+        "elapsed_time":                        299.92,
+        "data_transferred":                    90.98,
+        "response_time":                       0.32,
+        "transaction_rate":                    310.64,
+        "throughput":                          0.30,
+        "concurrency":                         99.51,
+        "successful_transactions":             93168,
+        "failed_transactions":                 2,
+        "longest_transaction":                 15.81,
+        "shortest_transaction":                0.02
+}
+```
+
+
+And `javax.net.ssl.SSLSocket` provided by Mozilla-JSS, backed by our slow
+JSSEngine (proposed for 8.3) -- memory grows to ~35% of total, which suggests
+there's also at least one memory leak still...
+
+```json
+{
+        "transactions":                        87768,
+        "availability":                        100.00,
+        "elapsed_time":                        299.08,
+        "data_transferred":                    85.71,
+        "response_time":                       0.34,
+        "transaction_rate":                    293.46,
+        "throughput":                          0.29,
+        "concurrency":                         99.60,
+        "successful_transactions":             87768,
+        "failed_transactions":                 1,
+        "longest_transaction":                 16.05,
+        "shortest_transaction":                0.08
+}
+```
+
+
+Prior to jss-pr#553 (commit 1bd646a45613d16f18f28c641381f680ba1df319), the
+performance of Mozilla-JSS's `SSLSocket` was similar to
+`javax.net.ssl.SSLSoket` using `Mozilla-JSS` for primitives:
+
+```json
+{
+        "transactions":                        1551,
+        "availability":                        85.98,
+        "elapsed_time":                        299.53,
+        "data_transferred":                    1.51,
+        "response_time":                       13.02,
+        "transaction_rate":                    5.18,
+        "throughput":                          0.01,
+        "concurrency":                         67.42,
+        "successful_transactions":             1551,
+        "failed_transactions":                 253,
+        "longest_transaction":                 78.01,
+        "shortest_transaction":                0.50
+}
+```
+
+
+And for comparison, `nginx-1.18.0-1.fc32.x86_64`, using the same cert from
+above (admittedly, it uses OpenSSL and an `epoll` framework) and same `siege`
+output:
+
+```json
+{
+        "transactions":                        214725,
+        "availability":                        100.00,
+        "elapsed_time":                        299.05,
+        "data_transferred":                    209.90,
+        "response_time":                       0.14,
+        "transaction_rate":                    718.02,
+        "throughput":                          0.70,
+        "concurrency":                         99.40,
+        "successful_transactions":             214725,
+        "failed_transactions":                 0,
+        "longest_transaction":                 0.37,
+        "shortest_transaction":                0.07
+}
+```

--- a/org/mozilla/jss/tests/BenchmarkSSLSocket.java
+++ b/org/mozilla/jss/tests/BenchmarkSSLSocket.java
@@ -1,0 +1,241 @@
+package org.mozilla.jss.tests;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedKeyManager;
+
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
+import org.mozilla.jss.provider.javax.crypto.JSSNativeTrustManager;
+
+/**
+ * Utility for benchmarking the performance of SSLSocket implementations.
+ *
+ * For information about using this benchmark, see the documentation in this
+ * repo at: /docs/usage/benchmarksslsocket.md
+ */
+public class BenchmarkSSLSocket {
+    public String type;
+    public String nickname;
+    public String password;
+    public int port;
+    public int size;
+
+    public String headers = "HTTP/1.1 200 OK\r\nConnection: Closed\r\n";
+    public String message;
+
+    public BenchmarkSSLSocket(String type, String nickname, int port, int size) throws Exception {
+        this.type = type;
+        this.nickname = nickname;
+        this.port = port;
+        this.size = size;
+
+        headers = headers + "Content-Length: " + size + "\r\n";
+
+        StringBuilder sb = new StringBuilder(size);
+        for (int i = 0; i < size; i++) {
+            sb.append("a");
+        }
+
+        message = headers + "\r\n" + sb.toString();
+    }
+
+    public BenchmarkSSLSocket(String type, String nickname, String password, int port, int size) throws Exception {
+        this(type, nickname, port, size);
+        this.password = password;
+    }
+
+    public ServerSocket getServerSocket() throws Exception {
+        System.err.println("Constructing socket...");
+        switch (type) {
+            case "JSS.legacy": {
+                org.mozilla.jss.ssl.SSLServerSocket sock = new org.mozilla.jss.ssl.SSLServerSocket(port);
+                sock.setSoTimeout(0);
+                org.mozilla.jss.ssl.SSLServerSocket.configServerSessionIDCache(0, 43200, 43200, null);
+
+                sock.setReuseAddress(true);
+                sock.requestClientAuth(false);
+                sock.requireClientAuth(org.mozilla.jss.ssl.SSLSocket.SSL_REQUIRE_NEVER);
+                sock.setUseClientMode(false);
+                sock.setServerCertNickname(nickname);
+
+                return sock;
+            }
+            case "JSS.SSLSocket": {
+                KeyManagerFactory kmf = KeyManagerFactory.getInstance("NssX509");
+
+                SSLContext ctx = SSLContext.getInstance("TLS", "Mozilla-JSS");
+                ctx.init(
+                    kmf.getKeyManagers(),
+                    new TrustManager[] { new JSSNativeTrustManager() },
+                    null
+                );
+
+                SSLServerSocketFactory factory = ctx.getServerSocketFactory();
+                org.mozilla.jss.ssl.javax.JSSServerSocket sock = (org.mozilla.jss.ssl.javax.JSSServerSocket) factory.createServerSocket(port);
+
+                sock.setReuseAddress(true);
+                sock.setWantClientAuth(false);
+                sock.setNeedClientAuth(false);
+                sock.setUseClientMode(false);
+                sock.setCertFromAlias(nickname);
+
+                return sock;
+            }
+            case "SunJSSE.SSLSocket": {
+                FileInputStream fis = new FileInputStream(nickname);
+                KeyStore store = KeyStore.getInstance("PKCS12");
+                store.load(fis, "m1oZilla".toCharArray());
+
+                // Courtesy of https://stackoverflow.com/questions/537040/how-to-connect-to-a-secure-website-using-ssl-in-java-with-a-pkcs12-file
+                // Without using a JKS-type KeyStore for the TrustManager,
+                // constructing a TrustManagerFactory will consume 100% CPU
+                // and we won't reach the SSLServerSocketFactory code.
+                KeyStore jks = KeyStore.getInstance("JKS");
+                jks.load(null);
+
+                KeyStore ks = store;
+                for (java.util.Enumeration<String> t = ks.aliases(); t.hasMoreElements(); ) {
+                    String alias = t.nextElement();
+                    if (ks.isKeyEntry(alias)) {
+                        java.security.cert.Certificate[] a = ks.getCertificateChain(alias);
+                        // i = 1 skips the CA certificate
+                        for (int i = 1; i < a.length; i++) {
+                            java.security.cert.X509Certificate x509 = (java.security.cert.X509Certificate) a[i];
+                            jks.setCertificateEntry(x509.getSubjectDN().toString(), x509);
+                        }
+                    }
+                }
+
+                KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+                kmf.init(store, "m1oZilla".toCharArray());
+                TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+                tmf.init(jks);
+
+                SSLContext ctx = SSLContext.getInstance("TLS", "SunJSSE");
+                ctx.init(
+                    kmf.getKeyManagers(),
+                    tmf.getTrustManagers(),
+                    null
+                );
+
+                SSLServerSocketFactory factory = ctx.getServerSocketFactory();
+                javax.net.ssl.SSLServerSocket sock = (javax.net.ssl.SSLServerSocket) factory.createServerSocket(port);
+
+                sock.setReuseAddress(true);
+                sock.setWantClientAuth(false);
+                sock.setNeedClientAuth(false);
+                sock.setUseClientMode(false);
+
+                return sock;
+            }
+            default:
+                throw new RuntimeException("Unknown socket type: `" + type + "` -- expected one of `JSS.SSLSocket`, `JSS.legacy`, or `SunJSSE.SSLSocket`.");
+        }
+    }
+
+    class PeerTask implements Runnable {
+        Socket peer;
+        byte[] message;
+
+        public PeerTask(Socket peer, String message) {
+            this.peer = peer;
+            this.message = message.getBytes();
+        }
+
+        public void run() {
+            try {
+                try {
+                    // First, force a handshake
+                    if (peer instanceof org.mozilla.jss.ssl.SSLSocket) {
+                        org.mozilla.jss.ssl.SSLSocket sock = (org.mozilla.jss.ssl.SSLSocket) peer;
+                        sock.setUseClientMode(false);
+                        sock.forceHandshake();
+                    } else if (peer instanceof javax.net.ssl.SSLSocket) {
+                        javax.net.ssl.SSLSocket sock = (javax.net.ssl.SSLSocket) peer;
+                        sock.setUseClientMode(false);
+                        sock.startHandshake();
+                    }
+
+                    // Consume all input data.
+                    InputStream is = peer.getInputStream();
+                    byte[] in_data = new byte[is.available()];
+                    is.read(in_data);
+
+                    // Send our message back.
+                    OutputStream os = peer.getOutputStream();
+                    os.write(message);
+                } finally {
+                    peer.close();
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+        }
+    }
+
+    public void run() throws Exception {
+        try (
+            ServerSocket server_socket = getServerSocket();
+        ) {
+            System.err.println("Listening for connections...");
+            while (true) {
+                Socket peer_socket = server_socket.accept();
+                Runnable task = new PeerTask(peer_socket, message);
+                Thread thread = new Thread(task);
+                thread.start();
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 4 || args.length > 5) {
+            System.err.println("Usage: BenchmarkSSLSocket <type> [...args...]");
+            System.err.println("type: JSS.SSLSocket, JSS.legacy, or SunJSSE.SSLSocket\n");
+
+            System.err.println("When type is JSS.SSLSocket or JSS.legacy:");
+            System.err.println("Usage: BenchmarkSSLSocket <type> <alias> <port> <size>");
+            System.err.println("alias: server certificate nickname");
+            System.err.println("port: What server port to listen on");
+            System.err.println("size: bytes of body to send in reply (plus header size)\n");
+
+            System.err.println("When type is SunJSSE.SSLSocket:");
+            System.err.println("Usage: BenchmarkSSLSocket SunJSSE.SSLSocket <p12path> [<p12pass>] <port> <size>");
+            System.err.println("p12path: path to the p12 file containing the server cert");
+            System.err.println("p12pass: password to access p12 file with; default: m1oZilla");
+            System.err.println("port: What server port to listen on");
+            System.err.println("size: bytes of body to send in reply (plus header size)\n");
+            System.exit(1);
+        }
+
+        BenchmarkSSLSocket benchmark;
+        if (args.length == 4) {
+            String type = args[0];
+            String alias = args[1];
+            int port = Integer.parseInt(args[2]);
+            int size = Integer.parseInt(args[3]);
+            benchmark = new BenchmarkSSLSocket(type, alias, "m1oZilla", port, size);
+        } else {
+            String type = args[0];
+            String path = args[1];
+            String password = args[2];
+            int port = Integer.parseInt(args[3]);
+            int size = Integer.parseInt(args[4]);
+            benchmark = new BenchmarkSSLSocket(type, path, password, port, size);
+        }
+
+        benchmark.run();
+    }
+}


### PR DESCRIPTION
This benchmark supports three providers:

 1. org.mozilla.jss.ssl.SSLSocket, named JSS.legacy
 2. org.mozilla.jss.ssl.javax.JSSSocket, named JSS.SSLSocket
 3. the JDK's SunJSSE provider's SSLSocket, named SunJSSE.SSLSocket

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----


This is the results from siege [0] ran via:

```bash
 $ siege -c 100 -b -t 5m https://localhost:8443
```

with the benchmarker set to send a faked 1024-byte message:

```bash
 $ ./run_test.sh org.mozilla.jss.tests.BenchmarkSSLSocket JSS.legacy Server_RSA 8443 1024
```

The server certificate is 4096-bits. The selection of cipher suite and
protocol is left at their defaults. This is on a Lenovo Thinkpad P50
with a `Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz` and 32GB of RAM. Each
request gets spun off and handled by a new thread.

Using the legacy `org.mozilla.jss.ssl.SSLSocket` (old NSS-based socket)
memory stays stable and under ~1-2% of total memory:

```json
{        "transactions":                       98588,
        "availability":                        100.00,
        "elapsed_time":                        299.43,
        "data_transferred":                    96.28,
        "response_time":                       0.30,
        "transaction_rate":                    329.25,
        "throughput":                          0.32,
        "concurrency":                         99.80,
        "successful_transactions":             98588,
        "failed_transactions":                 0,
        "longest_transaction":                 29.94,
        "shortest_transaction":                0.04
}
```

Using `javax.net.ssl.SSLSocket` provided by SunJSSE (but with JSS crypto
and potentially random) and stays under 1-2% of total memory:

```json
{        "transactions":                       2417,
        "availability":                        100.00,
        "elapsed_time":                        299.36,
        "data_transferred":                    2.36,
        "response_time":                       12.12,
        "transaction_rate":                    8.07,
        "throughput":                          0.01,
        "concurrency":                         97.82,
        "successful_transactions":             2417,
        "failed_transactions":                 0,
        "longest_transaction":                 21.27,
        "shortest_transaction":                1.63
}
```


**Note** that the above option was removed from the benchmark as it was significantly slower



Using `javax.net.ssl.SSLSocket` provided by SunJSSE (without JSS crypto,
via exporting to PKCS12 file) and stays under 8% of total memory:

```json
{        "transactions":                       93168,
        "availability":                        100.00,
        "elapsed_time":                        299.92,
        "data_transferred":                    90.98,
        "response_time":                       0.32,
        "transaction_rate":                    310.64,
        "throughput":                          0.30,
        "concurrency":                         99.51,
        "successful_transactions":             93168,
        "failed_transactions":                 2,
        "longest_transaction":                 15.81,
        "shortest_transaction":                0.02
}
```

And `javax.net.ssl.SSLSocket` provided by Mozilla-JSS, backed by our slow
JSSEngine (proposed for 8.3) -- memory grows to ~35% of total, which suggests
there's also at least one memory leak still...

```json
{        "transactions":                       87768,
        "availability":                        100.00,
        "elapsed_time":                        299.08,
        "data_transferred":                    85.71,
        "response_time":                       0.34,
        "transaction_rate":                    293.46,
        "throughput":                          0.29,
        "concurrency":                         99.60,
        "successful_transactions":             87768,
        "failed_transactions":                 1,
        "longest_transaction":                 16.05,
        "shortest_transaction":                0.08
}
```


Prior to #553 (commit 1bd646a45613d16f18f28c641381f680ba1df319), the performance of Mozilla-JSS's `SSLSocket` was bad: 

```json
{	"transactions":			        1551,
	"availability":			       85.98,
	"elapsed_time":			      299.53,
	"data_transferred":		        1.51,
	"response_time":		       13.02,
	"transaction_rate":		        5.18,
	"throughput":			        0.01,
	"concurrency":			       67.42,
	"successful_transactions":	        1551,
	"failed_transactions":		         253,
	"longest_transaction":		       78.01,
	"shortest_transaction":		        0.50
}
```


And for comparison, `nginx-1.18.0-1.fc32.x86_64`, using the same cert from above (admittedly, it uses OpenSSL) and same `siege` output:

```json
{        "transactions":                       214725,
        "availability":                        100.00,
        "elapsed_time":                        299.05,
        "data_transferred":                    209.90,
        "response_time":                       0.14,
        "transaction_rate":                    718.02,
        "throughput":                          0.70,
        "concurrency":                         99.40,
        "successful_transactions":             214725,
        "failed_transactions":                 0,
        "longest_transaction":                 0.37,
        "shortest_transaction":                0.07
}
```