### PR TITLE
Remove JSSSocket wait-on-close, fix session cache creation

### DIFF
--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -356,7 +356,7 @@ public class SSL {
      *
      * See also: SSL_ConfigServerSessionIDCache in /usr/include/nss3/ssl.h
      */
-    public static native int ConfigServerSessionIDCache(int maxCacheEntries,
+    public synchronized static native int ConfigServerSessionIDCache(int maxCacheEntries,
         long timeout, long ssl3_timeout, String directory);
 
     /**

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -237,9 +237,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         // Create a small session cache.
         //
         // TODO: Make this configurable.
-        if (SSL.ConfigServerSessionIDCache(1, 100, 100, null) == SSL.SECFailure) {
-            throw new RuntimeException("Unable to configure server session cache: " + errorText(PR.GetError()));
-        }
+        initializeSessionCache(1, 100, null);
 
         configureClientAuth();
     }

--- a/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -359,30 +359,8 @@ public class JSSSocketChannel extends SocketChannel {
                 inboundClosed = false;
                 read(read_one);
 
-                outboundClosed = false;
                 if (!outboundClosed) {
                     shutdownOutput();
-                }
-
-                int times = 0;
-                while (!engine.isInboundDone()) {
-                    read_one.clear();
-                    read(read_one);
-
-                    times += 1;
-                    if (times > 50) {
-                        break;
-                    }
-
-                    try {
-                        Thread.sleep(times * 10);
-                    } catch (Exception e) {}
-                }
-
-                if (!engine.isInboundDone()) {
-                    String msg = "Premature close of SSLSocket: peer didn't ";
-                    msg += "confirm CLOSE_NOTIFY was received.";
-                    throw new IOException(msg);
                 }
 
                 outboundClosed = true;


### PR DESCRIPTION
There's two bugs found by #558: 

 - JSSSocket waiting-on-close takes a long time and doesn't work in all scenarios (e.g., wget won't send closure notifications so the socket will remain open forever). This also happens, e.g., with siege.
 - Session cache creation can race, causing the JVM to segfault in NSS code. We use an `AtomicBoolean` to avoid this potential and ensure we only initialize the session cache once.

We also add one refactoring commit:

 - Throw `SSLException`s instead of `RuntimeException`s during `JSSEngine` initialization. 

We should probably merge this ahead of #558 merging. 