### PR TITLE
HMAC initialization can leak ref counted symmetric key

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11MessageDigest.c
+++ b/org/mozilla/jss/pkcs11/PK11MessageDigest.c
@@ -57,6 +57,7 @@ Java_org_mozilla_jss_pkcs11_PK11MessageDigest_initHMAC
     CK_MECHANISM_TYPE mech;
     SECItem param;
     jobject contextObj=NULL;
+    bool freeNewKey = true;
 
     mech = JSS_getPK11MechFromAlg(env, algObj);
     PR_ASSERT( mech != CKM_INVALID_MECHANISM ); /* we checked already in Java */
@@ -74,6 +75,7 @@ Java_org_mozilla_jss_pkcs11_PK11MessageDigest_initHMAC
 
     if( newKey == NULL ) {
         newKey = origKey;
+        freeNewKey = false;
     }
 
     param.data = NULL;
@@ -88,7 +90,7 @@ Java_org_mozilla_jss_pkcs11_PK11MessageDigest_initHMAC
 
     contextObj = JSS_PK11_wrapCipherContextProxy(env, &context);
 finish:
-    if(newKey && (newKey != origKey)) {
+    if(freeNewKey) {
         /* SymKeys are ref counted, and the context will free it's ref
          * when it is destroyed */
         PK11_FreeSymKey(newKey);

--- a/org/mozilla/jss/pkcs11/PK11MessageDigest.java
+++ b/org/mozilla/jss/pkcs11/PK11MessageDigest.java
@@ -43,8 +43,6 @@ public final class PK11MessageDigest
             throw new DigestException("Digest is not an HMAC or CMAC digest");
         }
 
-        reset();
-
         if( ! (key instanceof PK11SymKey) ) {
             throw new InvalidKeyException("HMAC key is not a PKCS #11 key");
         }


### PR DESCRIPTION
In my company we've seen very bad memory leaks and one place we've tracked this down to is handling of the ref counted symmetric key in hmac initialization.

The problem stems from the assumption about `PK11_CopySymKeyForSigning` that if it returns a non-null pointer that it was copied. The actual implementation will return the exact same pointer if the key is already in the current slot and `CKA_SIGN` can be added to it.

```
    /* first just try to set this key up for signing */
    PK11_SETATTRS(&setTemplate, CKA_SIGN, &ckTrue, sizeof(ckTrue));
    pk11_EnterKeyMonitor(originalKey);
    crv = PK11_GETTAB(slot)->C_SetAttributeValue(originalKey->session,
                                                 originalKey->objectID, &setTemplate, 1);
    pk11_ExitKeyMonitor(originalKey);
    if (crv == CKR_OK) {
        return PK11_ReferenceSymKey(originalKey);
    }
```

The problem was reproduced by repeatedly calling `init` on an hmac with different keys that were created on the PK11 token. After applying these changes the memory usage is very flat although I suspect there's another leak because after ~92 million hmac `init` calls I'm seeing an increase in memory usage of ~100MB with no change in any java controlled memory pools (I fixed their sizes).

The change to `initHMAC` was just cleanup because it appeared unnecessary to call it when we haven't set the new key yet and the same native `initHMAC` method is called at the bottom.