### PR TITLE
Fix loading of CryptoManager in JSSLoader scenario

### DIFF
--- a/org/mozilla/jss/JSSLoader.java
+++ b/org/mozilla/jss/JSSLoader.java
@@ -92,7 +92,7 @@ public class JSSLoader {
     /**
      * Initialize JSS from the specified path to a configuration file.
      */
-    public static void init(String config_path) throws Exception {
+    public static CryptoManager init(String config_path) throws Exception {
         if (config_path == null) {
             String msg = "Please specify the path to the JSS configuration ";
             msg += "file in the java.security provider list.";
@@ -100,17 +100,16 @@ public class JSSLoader {
         }
 
         try (FileInputStream fistream = new FileInputStream(config_path)) {
-            init(fistream);
-            return;
+            return init(fistream);
         }
     }
 
     /**
      * Initialize JSS from an InputStream.
      */
-    public static void init(InputStream istream) throws Exception {
+    public static CryptoManager init(InputStream istream) throws Exception {
         if (loaded()) {
-            return;
+            return CryptoManager.getInstance();
         }
 
         if (istream == null) {
@@ -137,6 +136,8 @@ public class JSSLoader {
         parsePasswords(config, cm);
 
         parseExperimental(config);
+
+        return cm;
     }
 
     /**

--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -26,6 +26,8 @@ public final class JSSProvider extends java.security.Provider {
 
     private static JSSLoader loader = new JSSLoader();
 
+    private static CryptoManager cm;
+
     public JSSProvider() {
         this(loader.loaded());
     }
@@ -48,7 +50,7 @@ public final class JSSProvider extends java.security.Provider {
     public JSSProvider(InputStream config) throws Exception {
         this(false);
 
-        loader.init(config);
+        cm = loader.init(config);
         initializeProvider();
     }
 
@@ -63,7 +65,7 @@ public final class JSSProvider extends java.security.Provider {
      */
     public Provider configure(String arg) {
         try {
-            loader.init(arg);
+            cm = loader.init(arg);
         } catch (NullPointerException npe) {
             throw npe;
         } catch (Exception e) {
@@ -73,6 +75,18 @@ public final class JSSProvider extends java.security.Provider {
         initializeProvider();
 
         return this;
+    }
+
+    /**
+     * Return the CryptoManager this instance was initialized with.
+     */
+    public CryptoManager getCryptoManager() {
+        if (cm == null) {
+            try {
+                cm = CryptoManager.getInstance();
+            } catch (NotInitializedException nie) {}
+        }
+        return cm;
     }
 
     protected void initializeProvider() {

--- a/tools/jss.cfg.in
+++ b/tools/jss.cfg.in
@@ -1,4 +1,3 @@
 nss.config_dir=${NSS_DB_PATH}
-nss.cooperate=true
 jss.password=${DB_PWD}
 jss.experimental.sslengine=true


### PR DESCRIPTION
When using `JSSLoader` to initialize `JSSProvider` from the `java.security`
list, sometimes `CryptoManager.getInstance()` will fail. Usually this is
because instance is still null, even though

    Security.getProvider("Mozilla-JSS") != null

The error message will usually be something like:

    FINE: CryptoManager: loading JSS library
    FINE: CryptoManager: loaded JSS library from java.library.path
    Exception in thread "main" org.mozilla.jss.NotInitializedException
           at org.mozilla.jss.CryptoManager.getInstance(CryptoManager.java:365)
           at org.mozilla.jss.tests.SigTest.main(SigTest.java:52)

Allow `JSSLoader` to return the new CryptoManager object, let `JSSProvider`
store it, so that in this case, `CryptoManager.getInstance()` will return
an initialized instance.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`