### PR TITLE
SSLEngine - Bug fixes and performance improvements

### DIFF
--- a/org/mozilla/jss/nss/PRFDProxy.java
+++ b/org/mozilla/jss/nss/PRFDProxy.java
@@ -5,7 +5,9 @@ public class PRFDProxy extends org.mozilla.jss.util.NativeProxy {
         super(pointer);
     }
 
-    protected native void releaseNativeResources() throws Exception;
+    protected void releaseNativeResources() throws Exception {
+        PR.Close(this);
+    }
 
     protected void finalize() throws Throwable {
         super.finalize();

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -60,6 +60,10 @@ jobject JSS_NewSecurityStatusResult(JNIEnv *env, int on, char *cipher,
         keySize, secretKeySize, issuer_java, subject_java);
 
 finish:
+    PORT_Free(cipher);
+    PORT_Free(issuer);
+    PORT_Free(subject);
+
     return result;
 }
 

--- a/org/mozilla/jss/ssl/javax/JSSSession.java
+++ b/org/mozilla/jss/ssl/javax/JSSSession.java
@@ -88,7 +88,10 @@ public class JSSSession implements SSLSession {
     }
 
     public long getCreationTime() {
-        refreshData();
+        if (creationTime == 0) {
+            refreshData();
+        }
+
         return creationTime;
     }
 
@@ -115,20 +118,13 @@ public class JSSSession implements SSLSession {
         if (info != null) {
             // NSS returns the values as seconds, but we have to report them
             // in milliseconds to our callers. Multiply by a thousand here.
+            setId(info.getSessionID());
             setCreationTime(info.getCreationTime() * 1000);
             setLastAccessedTime(info.getLastAccessTime() * 1000);
             setExpirationTime(info.getExpirationTime() * 1000);
 
             setCipherSuite(info.getCipherSuite());
             setProtocol(info.getProtocolVersion());
-        }
-
-        SSLFDProxy ssl_fd = parent.getSSLFDProxy();
-        if (ssl_fd != null) {
-            try {
-                PK11Cert[] peer_chain = SSL.PeerCertificateChain(ssl_fd);
-                setPeerCertificates(peer_chain);
-            } catch (Exception e) {}
         }
     }
 
@@ -184,7 +180,6 @@ public class JSSSession implements SSLSession {
     }
 
     public Certificate[] getPeerCertificates() {
-        refreshData();
         return peerCertificates;
     }
 
@@ -222,7 +217,9 @@ public class JSSSession implements SSLSession {
     }
 
     public String getCipherSuite() {
-        refreshData();
+        if (cipherSuite == null) {
+            refreshData();
+        }
 
         if (cipherSuite == null) {
             return null;
@@ -240,7 +237,9 @@ public class JSSSession implements SSLSession {
     }
 
     public String getProtocol() {
-        refreshData();
+        if (protocolVersion == null) {
+            refreshData();
+        }
 
         if (protocolVersion == null) {
             return null;

--- a/org/mozilla/jss/ssl/javax/JSSSocket.java
+++ b/org/mozilla/jss/ssl/javax/JSSSocket.java
@@ -687,6 +687,8 @@ public class JSSSocket extends SSLSocket {
     @Override
     public void close() throws IOException {
         getInternalChannel().close();
+        engine.cleanup();
+        engine = null;
     }
 
     @Override

--- a/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -359,6 +359,7 @@ public class JSSSocketChannel extends SocketChannel {
                 // should ensure we always get a callback.
                 ByteBuffer read_one = ByteBuffer.allocate(1);
 
+                shutdownInput();
 
                 // Bypass read check.
                 inboundClosed = false;
@@ -372,6 +373,9 @@ public class JSSSocketChannel extends SocketChannel {
                 inboundClosed = true;
             }
         } finally {
+            engine.cleanup();
+            engine = null;
+
             if (parent == null) {
                 if (autoClose) {
                     parentSocket.shutdownInput();

--- a/org/mozilla/jss/tests/BadSSL.java
+++ b/org/mozilla/jss/tests/BadSSL.java
@@ -230,23 +230,23 @@ public class BadSSL {
 
     public static void testSiteOldSSLSocket(String host, int port) throws Exception {
         System.out.println("Testing connection to " + host + ":" + port);
-        org.mozilla.jss.ssl.SSLSocket sock = new org.mozilla.jss.ssl.SSLSocket(host, 443);
-        sock.forceHandshake();
-        sock.shutdownOutput();
-        sock.shutdownInput();
-        sock.close();
+        try (org.mozilla.jss.ssl.SSLSocket sock = new org.mozilla.jss.ssl.SSLSocket(host, 443)) {
+            sock.forceHandshake();
+            sock.shutdownOutput();
+            sock.shutdownInput();
+        }
     }
 
     public static void testSiteJavaxSSLSocket(String host, int port) throws Exception {
         System.out.println("Testing connection to " + host + ":" + port);
-        JSSSocket sock = (JSSSocket) jsf.createSocket(host, port);
-        sock.setUseClientMode(true);
-        sock.setWantClientAuth(false);
-        sock.setNeedClientAuth(false);
-        sock.setHostname(host);
-        sock.startHandshake();
-        sock.shutdownOutput();
-        sock.shutdownInput();
-        sock.close();
+        try (JSSSocket sock = (JSSSocket) jsf.createSocket(host, port)) {
+            sock.setUseClientMode(true);
+            sock.setWantClientAuth(false);
+            sock.setNeedClientAuth(false);
+            sock.setHostname(host);
+            sock.startHandshake();
+            sock.shutdownOutput();
+            sock.shutdownInput();
+        }
     }
 }


### PR DESCRIPTION
This is currently a work in progress to fix various issues @edewata has reported with SSLEngine in the context of ACME.

The list of fixes include:

 - Reduce the number of calls to `JSSSession.refreshData` -- this will help ensure certificates get queried less and reduce calls through the JNI layer.
 - Use try-with-resources pattern in `BadSSL` to make sure we close our sockets.
 - Make sure the `SSLEngine` explicitly gets freed when the socket is closed in `JSSSocket`, `JSSSocketChannel`
 - Fix our implementation of `BufferPRFD`, cleaning up leaks &c.
 - Free in `JSS_NewSecurityStatusResult`, though this function is unused currently because we rely on other, more advanced methods for getting Channel information.
 - Properly implement `PRFDProxy.releaseNativeResources`.

While good changes, none of these appear to fix the SSL connection issues.