### PR TITLE
Remove more legacy algos

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -170,11 +170,6 @@ macro(jss_tests)
         COMMAND "org.mozilla.jss.tests.GenerateTestCert" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}" "30" "localhost" "SHA-256/EC" "CA_ECDSA" "Server_ECDSA" "Client_ECDSA"
         DEPENDS "Generate_known_RSA_cert_pair"
     )
-    jss_test_java(
-        NAME "Generate_known_DSS_cert_pair"
-        COMMAND "org.mozilla.jss.tests.GenerateTestCert" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}" "40" "localhost" "SHA-1/DSA" "CA_DSS" "Server_DSS" "Client_DSS"
-        DEPENDS "Generate_known_ECDSA_cert_pair"
-    )
     jss_test_exec(
         NAME "Create_PKCS11_cert_to_PKCS12_rsa.pfx"
         COMMAND "pk12util" "-o" "${RESULTS_NSSDB_OUTPUT_DIR}/rsa.pfx" "-n" "CA_RSA" "-d" "${RESULTS_NSSDB_OUTPUT_DIR}" "-K" "${DB_PWD}" "-W" "${DB_PWD}"
@@ -185,15 +180,10 @@ macro(jss_tests)
         COMMAND "pk12util" "-o" "${RESULTS_NSSDB_OUTPUT_DIR}/ecdsa.pfx" "-n" "CA_ECDSA" "-d" "${RESULTS_NSSDB_OUTPUT_DIR}" "-K" "${DB_PWD}" "-W" "${DB_PWD}"
         DEPENDS "Generate_known_ECDSA_cert_pair"
     )
-    jss_test_exec(
-        NAME "Create_PKCS11_cert_to_PKCS12_dss.pfx"
-        COMMAND "pk12util" "-o" "${RESULTS_NSSDB_OUTPUT_DIR}/dss.pfx" "-n" "CA_DSS" "-d" "${RESULTS_NSSDB_OUTPUT_DIR}" "-K" "${DB_PWD}" "-W" "${DB_PWD}"
-        DEPENDS "Generate_known_DSS_cert_pair"
-    )
     jss_test_java(
         NAME "List_CA_certs"
         COMMAND "org.mozilla.jss.tests.ListCACerts" "${RESULTS_NSSDB_OUTPUT_DIR}" "Verbose"
-        DEPENDS "Generate_known_DSS_cert_pair"
+        DEPENDS "Generate_known_ECDSA_cert_pair"
     )
     jss_test_java(
         NAME "SSLClientAuth"

--- a/org/mozilla/jss/tests/SSLClientAuth.java
+++ b/org/mozilla/jss/tests/SSLClientAuth.java
@@ -28,7 +28,7 @@ public class SSLClientAuth implements Runnable {
     
     private CryptoManager cm;
     public static final SignatureAlgorithm sigAlg =
-            SignatureAlgorithm.RSASignatureWithSHA1Digest;
+            SignatureAlgorithm.RSASignatureWithSHA256Digest;
     
     /**
      * Method that generates a certificate for given credential


### PR DESCRIPTION
- Removes SHA-1 in accordance with [crypto-policies changes](https://gitlab.com/redhat-crypto/fedora-crypto-policies/-/commit/b298a9e107b7e9699b36879eca031d1900ded1c4)
- Removes DSS because it is old, unused, and only supports SHA-1 signatures too. 

This should fix Fedora Rawhide builds.