### PR TITLE
Fix Tomcat by handling BUFFER_UNDERFLOW events

### DIFF
--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -968,6 +968,9 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             return new SSLEngineResult(SSLEngineResult.Status.OK, handshake_state, 0, 0);
         }
 
+        boolean handshake_already_complete = ssl_fd.handshakeComplete;
+        int src_capacity = src.remaining();
+
         logUnwrap(src);
 
         // Order of operations:
@@ -1063,6 +1066,9 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         if (is_inbound_closed) {
             debug("Socket is currently closed.");
             handshake_status = SSLEngineResult.Status.CLOSED;
+        } else if (handshake_already_complete && src_capacity > 0 && app_data == 0) {
+            debug("Underflowed: produced no application data when we expected to.");
+            handshake_status = SSLEngineResult.Status.BUFFER_UNDERFLOW;
         }
 
         // Need a way to introspect the open/closed state of the TLS


### PR DESCRIPTION
We should handle `BUFFER_UNDERFLOW` events by attempting to read more data from the underlying socket.

In `JSSSocketChannel` we can handle this mostly safely by bringing the socket read into the try/catch loop. While `readBuffer` is still of a fixed size, we can now query the client for more data. This lets us claim `BUFFER_UNDERFLOW` is a supported event. However, we still would need to handle resizing the buffer in the event `readBuffer` isn't sufficiently large for this. This gets a little complicated, because we still need to maintain `src` as a view over `readBuffer` because we can't otherwise bound the size of the read on a blocking socket.

Tomcat however, already handles this case. When `unwrap` returns `BUFFER_UNDERFLOW`, it will exit the read loop it was previously stuck in and ask the peer for more data, resizing the buffer as necessary.