### PR TITLE
Use JSS-provided TrustManagers by default

### DIFF
--- a/org/mozilla/jss/provider/javax/net/JSSContextSpi.java
+++ b/org/mozilla/jss/provider/javax/net/JSSContextSpi.java
@@ -29,6 +29,24 @@ public class JSSContextSpi extends SSLContextSpi {
     SSLVersion protocol_version;
 
     public void engineInit(KeyManager[] kms, TrustManager[] tms, SecureRandom sr) throws KeyManagementException {
+        if (kms == null && key_manager == null) {
+            try {
+                KeyManagerFactory kmf = KeyManagerFactory.getInstance("NssX509", "Mozilla-JSS");
+                kms = kmf.getKeyManagers();
+            } catch (Exception e) {
+                throw new KeyManagementException("Unable to create default KeyManagers: " + e.getMessage(), e);
+            }
+        }
+
+        if (tms == null && (trust_managers == null || trust_managers.length == 0)) {
+            try {
+                TrustManagerFactory tmf = TrustManagerFactory.getInstance("NssX509", "Mozilla-JSS");
+                tms = tmf.getTrustManagers();
+            } catch (Exception e) {
+                throw new KeyManagementException("Unable to create default TrustManagers: " + e.getMessage(), e);
+            }
+        }
+
         logger.debug("JSSContextSpi.engineInit(" + kms + ", " + tms + ", " + sr + ")");
 
         if (kms != null) {

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -345,7 +345,8 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
         // This is most useful for the client end of the connection; this
         // specifies what to match the server's certificate against.
-        if (hostname != null) {
+        if (hostname != null && !hostname.isEmpty()) {
+            debug("JSSEngine: setting hostname for cert validation: " + hostname);
             if (SSL.SetURL(ssl_fd, hostname) == SSL.SECFailure) {
                 throw new SSLException("Unable to configure server hostname: " + errorText(PR.GetError()));
             }


### PR DESCRIPTION
When SSLContext is called with no TrustManagers, we end up defaulting to
the default internal NSS validation logic. This results in connections
which fail to verify when no hostname is provided, because NSS strictly
requires hostnames to be present and matching. Because the JDK otherwise
requires hostnames to validated (by e.g., a HostnameVerifier), we
shouldn't use the NSS handler by default.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`