### PR TITLE
Fix SSLEngine memory leaks

### DIFF
--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -162,6 +162,9 @@ Java_org_mozilla_jss_nss_SSL_ImportFD(JNIEnv *env, jclass clazz, jobject model,
     }
 
     result = SSL_ImportFD(real_model, real_fd);
+    if (result == NULL) {
+        return NULL;
+    }
 
     return JSS_PR_wrapSSLFDProxy(env, &result);
 }

--- a/org/mozilla/jss/pkcs11/PK11Cert.java
+++ b/org/mozilla/jss/pkcs11/PK11Cert.java
@@ -410,7 +410,16 @@ public class PK11Cert
         // This object also contains a token proxy; these are reference
         // counted objects and long-lived; freeing them is of little benefit
         // as they'll persist as long as CryptoManager holds a copy of all
-        // known tokens.
+        // known tokens. However, we still need to attempt to release our
+        // reference to them, otherwise the JVM will persist its reference
+        // to them.
+        if (tokenProxy != null) {
+            try {
+                tokenProxy.close();
+            } finally {
+                tokenProxy = null;
+            }
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////

--- a/org/mozilla/jss/provider/javax/crypto/JSSTokenKeyManager.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSTokenKeyManager.java
@@ -118,8 +118,10 @@ public class JSSTokenKeyManager implements JSSKeyManager {
 
         try {
             if (jks == null) {
-                org.mozilla.jss.crypto.X509Certificate cert = cm.findCertByNickname(alias);
-                return cm.findPrivKeyByCert(cert);
+                try (PK11Cert cert = (PK11Cert) cm.findCertByNickname(alias)) {
+                    PrivateKey key = cm.findPrivKeyByCert(cert);
+                    return key;
+                }
             }
 
             return (PrivateKey) jks.getKey(alias, password);

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -195,6 +195,13 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
         // Initialize ssl_fd from the model Buffer-backed PRFileDesc.
         ssl_fd = SSL.ImportFD(model, fd);
+        if (ssl_fd == null) {
+            PR.Close(fd);
+            throw new SSLException("Error creating SSL socket on top of buffer-backed PRFileDesc.");
+        }
+
+        fd.clear();
+        fd = null;
         closed_fd = false;
 
         // Turn on SSL Alert Logging for the ssl_fd object.
@@ -1422,6 +1429,12 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
         // Then clean up the NSS state.
         cleanupSSLFD();
+
+        // Clean up the session.
+        if (session != null) {
+            session.close();
+            session = null;
+        }
     }
 
     private void cleanupLoggingSocket() {

--- a/org/mozilla/jss/ssl/javax/JSSSocket.java
+++ b/org/mozilla/jss/ssl/javax/JSSSocket.java
@@ -101,6 +101,11 @@ public class JSSSocket extends SSLSocket {
     private boolean autoClose = true;
 
     /**
+     * Whether or not this socket has been closed.
+     */
+    private boolean closed;
+
+    /**
      * Start building a new JSSSocket.
      *
      * We specifically avoid creating any other constructors as we wish to
@@ -123,6 +128,11 @@ public class JSSSocket extends SSLSocket {
             throw new IOException(msg);
         }
 
+        if (closed) {
+            String msg = "Unable to perform operations on a closed socket!";
+            throw new IOException(msg);
+        }
+
         this.parent = parent;
     }
 
@@ -132,6 +142,11 @@ public class JSSSocket extends SSLSocket {
      * This is used by initSSLEngine(..) to create the underlying SSLEngine.
      */
     protected SSLContext getSSLContext() throws IOException {
+        if (closed) {
+            String msg = "Unable to perform operations on a closed socket!";
+            throw new IOException(msg);
+        }
+
         if (jssContext == null) {
             try {
                 jssContext = SSLContext.getInstance(engineProviderProtocol, engineProvider);
@@ -159,6 +174,11 @@ public class JSSSocket extends SSLSocket {
      * Initialize the underlying SocketChannel.
      */
     private void init() throws IOException {
+        if (closed) {
+            String msg = "Unable to perform operations on a closed socket!";
+            throw new IOException(msg);
+        }
+
         if (engine == null) {
             initEngine();
         }
@@ -689,6 +709,8 @@ public class JSSSocket extends SSLSocket {
         getInternalChannel().close();
         engine.cleanup();
         engine = null;
+        channel = null;
+        closed = true;
     }
 
     @Override

--- a/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -378,6 +378,9 @@ public class JSSSocketChannel extends SocketChannel {
                     shutdownOutput();
                 }
 
+                // Make sure we close the input side of the SSLEngine.
+                engine.closeInbound();
+
                 outboundClosed = true;
                 inboundClosed = true;
             }


### PR DESCRIPTION
This fixes two memory leaks in SSLEngine, and reduces memory pressure by handling certain other cases.

 1. Leaked `PRFDProxy` in `JSSEngineReferenceImpl.createBufferFD()`.
     When `SSL_ImportFD` is called, NSS merges the second argument into the return value, by way of pushing a NSPR on top of the argument. This layer is the SSL layer and the second argument is "consumed" by the SSL `PRFileDesc *`. Java doesn't know about this, so we need to manually clear (not close!!) the `PRFDProxy` instance and set it to `null` to avoid leaking it. (Otherwise, `NativeProxy` retains a reference to it, preventing the Java object from being garbage collected).
 2. Leaked `TokenProxy` in `JSSTokenKeyManager`.
    When the `CryptoManager` returns the new `PK11Cert` instance, it contains a `CertProxy` and a `TokenProxy`; the latter wasn't explicitly cleared/freed by `PK11Cert`. This meant `NativeProxy` still had a reference to it, preventing the `TokenProxy` Java object from being garbage collected. As the comment indicates, this isn't a memory leak in NSS, because Tokens (er, Slots) are long-term, reference-counted objects with the same pointer value. NSS presumably remains initialized throughout the lifetime of the program, so no leak really occurs until shutdown (if `CryptoManager.shutdown()` is actually called). 

Additionally, we:

 - Handle `null` return from `SSL_ImportFD` correctly,
 - Allow `SSLSessions` to "close", allowing us to release their resources. Note that invalidating a session is separate from closing a session. This gives us more control over when a session's certificates are freed, than leaving it to the garbage collector.
 - Ensure `JSSSocketChannel` closes the inbound side of the wrapped `JSSEngine`.
 - Ensure `JSSSocket` isn't used after being closed.