### PR TITLE
More JSSEngine Memory Leak Fixes

### DIFF
--- a/org/mozilla/jss/ssl/javax/BufferPRFD.c
+++ b/org/mozilla/jss/ssl/javax/BufferPRFD.c
@@ -94,6 +94,7 @@ static PRStatus PRBufferClose(PRFileDesc *fd)
     PR_ASSERT(fd->identity == buffer_layer_id);
     PR_ASSERT(fd->higher == NULL);
     PR_ASSERT(fd->lower == NULL);
+    fd->dtor(fd);
 
     return rv;
 }


### PR DESCRIPTION
This introduces more memory fixes for JSSEngine:

 1. Fix missing destructor call in the `PR_Close` implementation for NSPR PR/IO layers. This meant the `BufferPRFD` layer leaked.
 2. Various small leak fixes in native (C) test case for `BufferPRFDSSL`. Not an issue in production.

~Additional fixes include~

 - ~Allow duplication of `PK11Cert`, `PK11PrivKey` objects, to take ownership of new copies.~
 - ~Make SSLEngine take ownership of certs, keys, and then release memory when cleanup occurs.~

----

I've decided not to include the latter two fixes. This makes the PR smaller and we can figure out how to deal with copying certs&keys later. 