### PR TITLE
Prevent usage of ssl_fd after closing

### DIFF
--- a/.github/workflows/informational.yml
+++ b/.github/workflows/informational.yml
@@ -8,11 +8,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'debian_jdk11'
-          - 'ubuntu_jdk8'
-          - 'fedora_rawhide'
-          - 'centos_7'
-          - 'centos_8'
+          - 'pkcs11check'
+          - 'fedora_sandbox'
+          - 'pki_build'
 
     steps:
     - name: Clone the repository

--- a/org/mozilla/jss/nss/SSLFDProxy.c
+++ b/org/mozilla/jss/nss/SSLFDProxy.c
@@ -237,7 +237,7 @@ JSSL_SSLFDCertSelectionCallback(void *arg,
         return SECFailure;
     }
 
-    *pRetCert = cert;
+    *pRetCert = CERT_DupCertificate(cert);
     *pRetKey = privkey;
     return SECSuccess;
 }

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -543,14 +543,20 @@ public class JSSEngineReferenceImpl extends JSSEngine {
     public void closeInbound() {
         debug("JSSEngine: closeInbound()");
 
-        PR.Shutdown(ssl_fd, PR.SHUTDOWN_RCV);
+        if (!is_inbound_closed && ssl_fd != null && !closed_fd) {
+            PR.Shutdown(ssl_fd, PR.SHUTDOWN_RCV);
+        }
+
         is_inbound_closed = true;
     }
 
     public void closeOutbound() {
         debug("JSSEngine: closeOutbound()");
 
-        PR.Shutdown(ssl_fd, PR.SHUTDOWN_SEND);
+        if (!is_outbound_closed && ssl_fd != null && !closed_fd) {
+            PR.Shutdown(ssl_fd, PR.SHUTDOWN_SEND);
+        }
+
         is_outbound_closed = true;
     }
 
@@ -561,7 +567,9 @@ public class JSSEngineReferenceImpl extends JSSEngine {
     public Runnable getDelegatedTask() {
         debug("JSSEngine: getDelegatedTask()");
 
-        checkNeedCertValidation();
+        if (ssl_fd != null) {
+            checkNeedCertValidation();
+        }
 
         return task;
     }

--- a/org/mozilla/jss/tests/TestBufferPRFDSSL.c
+++ b/org/mozilla/jss/tests/TestBufferPRFDSSL.c
@@ -25,6 +25,7 @@
 #include <certt.h>
 #include <secmod.h>
 #include <sslproto.h>
+#include <keyhi.h>
 
 /* Standard includes */
 #include <errno.h>


### PR DESCRIPTION
In the previous commit, 76396ae47adf740aac0db38f143d959e5d6c39ec, by
calling the destructor on BufferPRFD layer, we finally clean it up
properly. However, this resulted in multiple calls to `closeInbound` or
`closeOutbound` resulting in a use-after-free.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`