### PR TITLE
Fix PKCS9 javadocs

### DIFF
--- a/cmake/JSSCommon.cmake
+++ b/cmake/JSSCommon.cmake
@@ -227,7 +227,7 @@ macro(jss_build_javadocs)
 
     add_custom_command(
         OUTPUT ${JAVADOCS_OUTPUTS}
-        COMMAND "${Java_JAVADOC_EXECUTABLE}" -overview "${PROJECT_SOURCE_DIR}/tools/javadoc/overview.html" -windowtitle "${JSS_WINDOW_TITLE}" -notimestamp -breakiterator -classpath ${JAVAC_CLASSPATH} -sourcepath ${PROJECT_SOURCE_DIR} -d ${DOCS_OUTPUT_DIR} @${JAVA_SOURCES_FILE}
+        COMMAND "${Java_JAVADOC_EXECUTABLE}" -source 1.8 -overview "${PROJECT_SOURCE_DIR}/tools/javadoc/overview.html" -windowtitle "${JSS_WINDOW_TITLE}" -notimestamp -breakiterator -classpath ${JAVAC_CLASSPATH} -sourcepath ${PROJECT_SOURCE_DIR} -d ${DOCS_OUTPUT_DIR} @${JAVA_SOURCES_FILE}
         COMMAND touch "${JAVADOCS_OUTPUTS}"
         DEPENDS ${JAVA_SOURCES}
     )

--- a/tools/Dockerfiles/debian_jdk11
+++ b/tools/Dockerfiles/debian_jdk11
@@ -32,4 +32,5 @@ CMD true \
         && cmake .. \
         && make all \
         && ctest --output-on-failure \
+        && make javadoc \
         && true

--- a/tools/Dockerfiles/fedora_rawhide
+++ b/tools/Dockerfiles/fedora_rawhide
@@ -29,4 +29,5 @@ CMD true \
         && cmake .. \
         && make all \
         && ctest --output-on-failure \
+        && make javadoc \
         && true


### PR DESCRIPTION
PKCS9 javadocs included bad HTML5 elements. Remove them, making the output look less pretty, but not requiring us to use any CSS styling.