### PR TITLE
NativeProxy: Use Weak References 

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -485,3 +485,9 @@ Java_org_mozilla_jss_nss_SECErrors_getUntrustedCert;
     local:
         *;
 };
+JSS_4.7.1 {
+    global:
+Java_org_mozilla_jss_nss_SSL_ImportFDNative;
+    local:
+        *;
+};

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -144,6 +144,15 @@ JNIEXPORT jobject JNICALL
 Java_org_mozilla_jss_nss_SSL_ImportFD(JNIEnv *env, jclass clazz, jobject model,
     jobject fd)
 {
+    PR_ASSERT(0);
+    JSS_throwMsg(env, NULL_POINTER_EXCEPTION, "JSS JAR/DLL version mismatch");
+    return NULL;
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_org_mozilla_jss_nss_SSL_ImportFDNative(JNIEnv *env, jclass clazz, jobject model,
+    jobject fd)
+{
     PRFileDesc *result = NULL;
     PRFileDesc *real_model = NULL;
     PRFileDesc *real_fd = NULL;
@@ -153,11 +162,11 @@ Java_org_mozilla_jss_nss_SSL_ImportFD(JNIEnv *env, jclass clazz, jobject model,
 
     /* Note: NSS calling semantics state that either model or fd can be
      * NULL; so when the Java Object is not-NULL, dereference it. */
-    if (model != NULL && JSS_PR_getPRFileDesc(env, model, &real_model) != PR_SUCCESS) {
+    if (model != NULL && (JSS_PR_getPRFileDesc(env, model, &real_model) != PR_SUCCESS || real_model == NULL)) {
         return NULL;
     }
 
-    if (fd != NULL && JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+    if (fd != NULL && (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS || real_fd == NULL)) {
         return NULL;
     }
 
@@ -166,7 +175,7 @@ Java_org_mozilla_jss_nss_SSL_ImportFD(JNIEnv *env, jclass clazz, jobject model,
         return NULL;
     }
 
-    return JSS_PR_wrapSSLFDProxy(env, &result);
+    return JSS_ptrToByteArray(env, result);
 }
 
 JNIEXPORT int JNICALL

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -158,7 +158,23 @@ public class SSL {
      *
      * See also: SSL_ImportFD in /usr/include/nss3/ssl.h
      */
-    public static native SSLFDProxy ImportFD(PRFDProxy model, PRFDProxy fd);
+    public static SSLFDProxy ImportFD(PRFDProxy model, PRFDProxy fd) {
+        if (fd == null) {
+            throw new NullPointerException("Expected fd != null");
+        }
+
+        byte[] ptr = ImportFDNative(model, fd);
+        if (ptr == null || ptr.length == 0) {
+            int error = PR.GetError();
+            throw new NullPointerException("SSL_ImportFD failed: " + PR.ErrorToName(error) + " (" + error + ")");
+        }
+
+        fd.clear();
+
+        return new SSLFDProxy(ptr);
+    }
+
+    public static native byte[] ImportFDNative(PRFDProxy model, PRFDProxy fd);
 
     /**
      * Set the value of a SSL option on the specified PRFileDesc.

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -200,7 +200,6 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             throw new SSLException("Error creating SSL socket on top of buffer-backed PRFileDesc.");
         }
 
-        fd.clear();
         fd = null;
         closed_fd = false;
 

--- a/org/mozilla/jss/util/NativeProxy.java
+++ b/org/mozilla/jss/util/NativeProxy.java
@@ -4,12 +4,14 @@
 
 package org.mozilla.jss.util;
 
-import java.util.HashSet;
-
 import java.lang.AutoCloseable;
 import java.lang.Thread;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mozilla.jss.CryptoManager;
@@ -59,13 +61,11 @@ public abstract class NativeProxy implements AutoCloseable
             mHashCode += Arrays.hashCode(mPointer);
         }
 
-        if (track) {
+        if (track && saveStacktraces) {
             assert(pointer != null);
             registry.add(this);
 
-            if (saveStacktraces) {
-                mTrace = Arrays.toString(Thread.currentThread().getStackTrace());
-            }
+            mTrace = Arrays.toString(Thread.currentThread().getStackTrace());
         }
     }
 
@@ -165,7 +165,7 @@ public abstract class NativeProxy implements AutoCloseable
      */
     public final void clear() {
         this.mPointer = null;
-        registry.remove(this);
+        // registry.remove(this);
     }
 
     /**
@@ -199,7 +199,7 @@ public abstract class NativeProxy implements AutoCloseable
      * NativeProxy.finalize() from their subclasses of NativeProxy, so that
      * releaseNativeResources() gets called.
      */
-    static HashSet<NativeProxy> registry = new HashSet<NativeProxy>();
+    static Set<NativeProxy> registry = Collections.newSetFromMap(new WeakHashMap<NativeProxy, Boolean>());
     static AtomicInteger registryIndex = new AtomicInteger();
 
     public String toString() {


### PR DESCRIPTION
This fixes a memory leak caused by `NativeProxy` maintaining strong references to all pointer objects. By switching them to `WeakReferences`, the registry is ignored in the GC reference count, and we can again allow items to be freed. 

Moving to `WeakReference` wasn't immediately possible due to a bug in SSLEngine: SSLEngine's server template didn't clear the underlying `PRFileDesc` pointer, meaning that -- when GC was again possible -- it would get freed, invaliding the model unintentionally. This resulted in SSLEngine tests failing. So, make `SSL.ImportFD` clear the consumed pointer.