### PR TITLE
Remove invalid Base64 logging

### DIFF
--- a/org/mozilla/jss/netscape/security/util/Utils.java
+++ b/org/mozilla/jss/netscape/security/util/Utils.java
@@ -37,12 +37,7 @@ import java.util.Date;
 import java.util.StringTokenizer;
 import java.util.Vector;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class Utils {
-    public static Logger logger = LoggerFactory.getLogger(Utils.class);
-
     /**
      * Checks if this is NT.
      */
@@ -417,7 +412,6 @@ public class Utils {
                 return Base64.getMimeDecoder().decode(string);
             }
         } catch (IllegalArgumentException iae) {
-            logger.warn("Invalid base64: [" + string + "]: " + iae, iae);
             return new byte[0];
         }
     }


### PR DESCRIPTION
While a nice idea in theory, this generates a ton of spurious messages
right now. We should eventually fix this and re-enable logging, but for
now we'll remove it.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`