### PR TITLE
Fix SSLSocket NULL pointer deference after close

### DIFF
--- a/org/mozilla/jss/ssl/SSLServerSocket.c
+++ b/org/mozilla/jss/ssl/SSLServerSocket.c
@@ -25,7 +25,7 @@ Java_org_mozilla_jss_ssl_SSLServerSocket_socketListen
 {
     JSSL_SocketData *sock;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     if( PR_Listen(sock->fd, backlog) != PR_SUCCESS ) {
         JSSL_throwSSLSocketException(env,
@@ -51,7 +51,7 @@ Java_org_mozilla_jss_ssl_SSLServerSocket_socketAccept
     SECStatus status;
     PRThread *me;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     ivtimeout = (timeout > 0) ? PR_MillisecondsToInterval(timeout)
                               : PR_INTERVAL_NO_TIMEOUT;
@@ -146,7 +146,7 @@ Java_org_mozilla_jss_ssl_SSLServerSocket_abortAccept(
 {
     JSSL_SocketData *sock = NULL;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     /*
      * The java layer prevents I/O once close has been 
@@ -223,7 +223,7 @@ Java_org_mozilla_jss_ssl_SSLServerSocket_setServerCert(
         goto finish;
     }
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     if( JSS_PK11_getCertPtr(env, certObj, &cert) != PR_SUCCESS ) {
         goto finish;
@@ -261,7 +261,7 @@ Java_org_mozilla_jss_ssl_SSLServerSocket_setReuseAddress(
     PRStatus status;
     PRSocketOptionData sockOptData;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     sockOptData.option = PR_SockOpt_Reuseaddr;
     sockOptData.value.reuse_addr = ((reuse == JNI_TRUE) ? PR_TRUE : PR_FALSE );
@@ -284,7 +284,7 @@ Java_org_mozilla_jss_ssl_SSLServerSocket_getReuseAddress(
     PRStatus status;
     PRSocketOptionData sockOptData;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     sockOptData.option = PR_SockOpt_Reuseaddr;
 

--- a/org/mozilla/jss/ssl/SSLSocket.c
+++ b/org/mozilla/jss/ssl/SSLSocket.c
@@ -153,7 +153,7 @@ Java_org_mozilla_jss_ssl_SocketBase_setSSLVersionRange
     }
 
     /* get my fd */
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL ) {
         goto finish;
     }
 
@@ -258,7 +258,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_forceHandshake(JNIEnv *env, jobject self)
     int rv;
 
     /* get my fd */
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) goto finish;
+    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     /* do the work */
     rv = SSL_ForceHandshake(sock->fd);
@@ -284,7 +284,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_setSoLinger(JNIEnv *env, jobject self,
     PRStatus status;
     JSSL_SocketData *sock = NULL;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL ) {
         goto finish;
     }
 
@@ -313,7 +313,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_getTcpNoDelay(JNIEnv *env, jobject self)
     JSSL_SocketData *sock = NULL;
     PRStatus status;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL ) {
         goto finish;
     }
 
@@ -338,7 +338,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_setTcpNoDelay(JNIEnv *env, jobject self,
     PRStatus status;
     JSSL_SocketData *sock = NULL;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -364,7 +364,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_getSendBufferSize(JNIEnv *env, jobject self)
     JSSL_SocketData *sock = NULL;
     PRStatus status;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -389,7 +389,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_setSendBufferSize(JNIEnv *env, jobject self,
     PRStatus status;
     JSSL_SocketData *sock = NULL;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -415,7 +415,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_getKeepAlive(JNIEnv *env, jobject self)
     JSSL_SocketData *sock = NULL;
     PRStatus status;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -440,7 +440,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_getReceiveBufferSize(
     JSSL_SocketData *sock = NULL;
     PRStatus status;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -465,7 +465,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_setReceiveBufferSize(
     PRStatus status;
     JSSL_SocketData *sock = NULL;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -492,7 +492,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_setKeepAlive(JNIEnv *env, jobject self,
     PRStatus status;
     JSSL_SocketData *sock = NULL;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -519,7 +519,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_getSoLinger(JNIEnv *env, jobject self)
     jint retval=-1;
     PRStatus status;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -588,7 +588,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_socketConnect
     jclass socketBaseClass;
     jboolean supportsIPV6 = 0;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         /* exception was thrown */
         goto finish;
     }
@@ -698,7 +698,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_getStatus
     jobject serialNumObj = NULL;
 
     /* get the fd */
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         /* exception was thrown */
         goto finish;
     }
@@ -801,7 +801,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_setCipherPreference(
     SECStatus status;
 
     /* get the fd */
-    if( JSSL_getSockData(env, sockObj, &sock) != PR_SUCCESS) {
+    if (JSSL_getSockData(env, sockObj, &sock) != PR_SUCCESS || sock == NULL) {
         /* exception was thrown */
         goto finish;
     }
@@ -828,7 +828,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_getCipherPreference(
     PRBool enabled = PR_FAILURE;
 
     /* get the fd */
-    if( JSSL_getSockData(env, sockObj, &sock) != PR_SUCCESS) {
+    if (JSSL_getSockData(env, sockObj, &sock) != PR_SUCCESS || sock == NULL) {
         /* exception was thrown */
         goto finish;
     }
@@ -912,7 +912,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_socketRead(JNIEnv *env, jobject self,
                               : PR_INTERVAL_NO_TIMEOUT;
 
     /* get the socket */
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -980,7 +980,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_socketAvailable(
     jint available=0;
     JSSL_SocketData *sock = NULL;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -1016,7 +1016,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_socketWrite(JNIEnv *env, jobject self,
                               : PR_INTERVAL_NO_TIMEOUT;
 
     /* get the socket */
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
     /* set the current thread doing the write */
@@ -1076,7 +1076,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_abortReadWrite(
 {
     JSSL_SocketData *sock = NULL;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     /*
      * The java layer prevents I/O once close has been 
@@ -1105,7 +1105,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_shutdownNative(
     JSSL_SocketData *sock = NULL;
     PRStatus status;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     status = PR_Shutdown(sock->fd, JSSL_enums[how]);
     if( status != PR_SUCCESS) {
@@ -1124,7 +1124,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_invalidateSession(JNIEnv *env, jobject self)
     JSSL_SocketData *sock = NULL;
     SECStatus status;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     status = SSL_InvalidateSession(sock->fd);
     if(status != SECSuccess) {
@@ -1144,7 +1144,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_redoHandshake(
     JSSL_SocketData *sock = NULL;
     SECStatus status;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     status = SSL_ReHandshake(sock->fd, flushCache);
     if(status != SECSuccess) {
@@ -1164,7 +1164,7 @@ Java_org_mozilla_jss_ssl_SSLSocket_resetHandshakeNative(
     JSSL_SocketData *sock = NULL;
     SECStatus status;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     status = SSL_ResetHandshake(sock->fd, !asClient);
     if(status != SECSuccess) {

--- a/org/mozilla/jss/ssl/common.c
+++ b/org/mozilla/jss/ssl/common.c
@@ -454,7 +454,7 @@ Java_org_mozilla_jss_ssl_SocketBase_socketBind
     jclass socketBaseClass;
     jboolean supportsIPV6 = 0;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         /* exception was thrown */
         goto finish;
     }
@@ -546,7 +546,7 @@ Java_org_mozilla_jss_ssl_SocketBase_requestClientAuthNoExpiryCheckNative
     JSSL_SocketData *sock = NULL;
     SECStatus status;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     /*
      * Set the option on the socket
@@ -584,7 +584,7 @@ Java_org_mozilla_jss_ssl_SocketBase_setSSLOption
     JSSL_SocketData *sock = NULL;
 
     /* get my fd */
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -608,7 +608,7 @@ Java_org_mozilla_jss_ssl_SocketBase_setSSLOptionMode
     JSSL_SocketData *sock = NULL;
 
     /* get my fd */
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -633,7 +633,7 @@ Java_org_mozilla_jss_ssl_SocketBase_getSSLOption(JNIEnv *env,
     SECStatus status = SECSuccess;
     PRBool bOption = PR_FALSE;
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -658,7 +658,7 @@ JSSL_getSockAddr
     PRStatus status=PR_FAILURE;
 
     /* get my fd */
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS ) {
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
         goto finish;
     }
 
@@ -807,7 +807,7 @@ Java_org_mozilla_jss_ssl_SocketBase_setClientCert(
         goto finish;
     }
 
-    if( JSSL_getSockData(env, self, &sock) != PR_SUCCESS) goto finish;
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) goto finish;
 
     /*
      * Store the cert and slot in the SocketData.


### PR DESCRIPTION
When `SSLSocket` is closed, the underlying pointer will be immediately
freed and `NULL`ed. This means that any future calls into the native
library could result in a `NULL` pointer dereference in NSS. This broke
IPA integration tests:

    Stack trace of thread 32848:
    # - 0  0x00007f362d7aa9e5 raise (libc.so.6 + 0x3c9e5)
    # - 1  0x00007f362d793895 abort (libc.so.6 + 0x25895)
    # - 2  0x00007f362ca8f4d1 _ZN2os5abortEb.cold (libjvm.so + 0x2114d1)
    # - 3  0x00007f362d439a32 _ZN7VMError14report_and_dieEv (libjvm.so + 0xbbba32)
    # - 4  0x00007f362d22d934 JVM_handle_linux_signal (libjvm.so + 0x9af934)
    # - 5  0x00007f362d2209ac _Z13signalHandleriP9siginfo_tPv (libjvm.so + 0x9a29ac)
    # - 6  0x00007f362d7aaa70 __restore_rt (libc.so.6 + 0x3ca70)
    # - 7  0x00007f361677a369 Java_org_mozilla_jss_ssl_SSLSocket_shutdownNative (libjss4.so + 0x2c369)
    # - 8  0x00007f36187443c7 n/a (n/a + 0x0)

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

Related: https://pagure.io/dogtagpki/issue/3198 

I'm not yet sure what changed between this and N-1 builds. 