### PR TITLE
Move rawhide tests to known failures

### DIFF
--- a/.github/workflows/informational.yml
+++ b/.github/workflows/informational.yml
@@ -9,7 +9,6 @@ jobs:
       matrix:
         image:
           - 'pkcs11check'
-          - 'fedora_sandbox'
           - 'pki_build'
 
     steps:

--- a/.github/workflows/known_failures.yml
+++ b/.github/workflows/known_failures.yml
@@ -1,4 +1,4 @@
-name: Optional Tests
+name: Known Failing Tests
 
 on: [push, pull_request]
 
@@ -8,14 +8,12 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'debian_jdk11'
-          - 'ubuntu_jdk8'
-          - 'centos_7'
-          - 'centos_8'
+          - 'fedora_rawhide'
+          - 'fedora_sandbox'
 
     steps:
     - name: Clone the repository
       uses: actions/checkout@v2
 
     - name: Build and Run the Docker Image
-      run: bash tools/run_container.sh "${{ matrix.image }}"
+      run: bash tools/run_container.sh "${{ matrix.image }}" || echo "::warning ::Job exited with status $?"


### PR DESCRIPTION
At this point in time, Rawhide is doing a mass rebuild. This brings in
filesystem, which always fails to update. Since this is a known failure
outside of our control, move it to a separate CI section for the time
being.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`