### PR TITLE
Fix hostname verification and improve JCA compatibility

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -491,3 +491,10 @@ Java_org_mozilla_jss_nss_SSL_ImportFDNative;
     local:
         *;
 };
+JSS_4.7.3 {
+    global:
+Java_org_mozilla_jss_nss_SSL_ConfigAsyncBadCertCallback;
+Java_org_mozilla_jss_nss_SSL_ConfigSyncBadCertCallback;
+    local:
+        *;
+};

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -495,6 +495,7 @@ JSS_4.7.3 {
     global:
 Java_org_mozilla_jss_nss_SSL_ConfigAsyncBadCertCallback;
 Java_org_mozilla_jss_nss_SSL_ConfigSyncBadCertCallback;
+Java_org_mozilla_jss_nss_SECErrors_getBadCertDomain;
     local:
         *;
 };

--- a/org/mozilla/jss/nss/BadCertHandler.java
+++ b/org/mozilla/jss/nss/BadCertHandler.java
@@ -1,0 +1,71 @@
+package org.mozilla.jss.nss;
+
+/**
+ * BadAuthHandler interface enables arbitrary certificate authentication
+ * from a NSS cert auth hook.
+ *
+ * Notably, the return code from check should be a PRErrorCode, else 0.
+ * This will be used by NSS to determine the alert to send when closing
+ * the connection (in the event of an error).
+ *
+ * The concern here is that, when this is invoked synchronously, we're
+ * called from NSS as called by Java. Certain operations may or may not
+ * succeed or work as expected (such as raising an exception, acquiring
+ * locks already held, etc.).
+ */
+public abstract class BadCertHandler implements Runnable {
+    /**
+     * When invoked via run(), the error code to pass to the
+     * check operation.
+     */
+    public int error;
+
+    /**
+     * When invoked via run(), the result of the check
+     * operation.
+     */
+    public int result;
+
+    /**
+     * Whether or not the check operation has been executed
+     * yet, when invoked via run().
+     */
+    public boolean finished;
+
+    /**
+     * SSLFDProxy instance.
+     */
+    private SSLFDProxy ssl_fd;
+
+    /**
+     * Constructor to store SSLFDProxy, error information.
+     *
+     * This is useful for implementations which expect to be used
+     * via the Runnable interface, instead of called via the
+     * synchronous certificate authentication hook in NSS.
+     */
+    public BadCertHandler(SSLFDProxy fd, int error) {
+        ssl_fd = fd;
+        this.error = error;
+    }
+
+    /**
+     * Returns the PRErrorCode the error validating certificate
+     * auth, else 0.
+     *
+     * Note that it is up to the implementer to fetch the certificates
+     * (via SSL.PeerCertificateChain(ssl_fd)) and validate them
+     * properly.
+     *
+     * Note that returning 0 here means SECis returned
+     */
+    public abstract int check(SSLFDProxy fd, int error);
+
+    public void run() {
+        try {
+            result = check(ssl_fd, error);
+        } finally {
+            finished = true;
+        }
+    }
+}

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -932,6 +932,48 @@ Java_org_mozilla_jss_nss_SSL_ConfigSyncTrustManagerCertAuthCallback(JNIEnv *env,
 }
 
 JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_ConfigAsyncBadCertCallback(JNIEnv *env, jclass clazz,
+    jobject fd)
+{
+    PRFileDesc *real_fd = NULL;
+    jobject fd_ref = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+    PR_SetError(0, 0);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    if (JSS_NSS_getGlobalRef(env, fd, &fd_ref) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    return SSL_BadCertHook(real_fd, JSSL_SSLFDAsyncBadCertCallback, fd_ref);
+}
+
+JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_ConfigSyncBadCertCallback(JNIEnv *env, jclass clazz,
+    jobject fd)
+{
+    PRFileDesc *real_fd = NULL;
+    jobject fd_ref = NULL;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+    PR_SetError(0, 0);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    if (JSS_NSS_getGlobalRef(env, fd, &fd_ref) != PR_SUCCESS) {
+        return SECFailure;
+    }
+
+    return SSL_BadCertHook(real_fd, JSSL_SSLFDSyncBadCertCallback, fd_ref);
+}
+
+JNIEXPORT jint JNICALL
 Java_org_mozilla_jss_nss_SSL_AuthCertificateComplete(JNIEnv *env, jclass clazz,
     jobject fd, jint error)
 {

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -472,8 +472,36 @@ public class SSL {
     public static native int ConfigSyncTrustManagerCertAuthCallback(SSLFDProxy fd);
 
     /**
+     * Use an asynchronous bad certificate handler which allows us to approve
+     * rejected certificates. This allows us to bypass the hostname check
+     * failure caused by the Java socket having no knowledge of the hostname
+     * we use for certificate validation; no HostnameVerifier is passed in.
+     * As a result, NSS has no value for the hostname and validation will fail.
+     *
+     * Note: This does NOT work for server-side connections.
+     *
+     * See also: SSL_BadCertHook in /usr/include/nss3/ssl.h and
+     *           JSSL_SSLFDAsyncBadCertCallback in jss/nss/SSLFDProxy.c
+     */
+    public static native int ConfigAsyncBadCertCallback(SSLFDProxy fd);
+
+    /**
+     * Use a synchronous bad certificate handler which allows us to approve
+     * rejected certificates. This allows us to bypass the hostname check
+     * failure caused by the Java socket having no knowledge of the hostname
+     * we use for certificate validation; no HostnameVerifier is passed in.
+     * As a result, NSS has no value for the hostname and validation will fail.
+     *
+     * See also: SSL_BadCertHook in /usr/include/nss3/ssl.h and
+     *           JSSL_SSLFDSyncBadCertCallback in jss/nss/SSLFDProxy.c
+     */
+    public static native int ConfigSyncBadCertCallback(SSLFDProxy fd);
+
+    /**
      * Inform NSS that the asynchronous certificate check handler has
      * completed, allowing us to continue the handshake.
+     *
+     * This is also used for the async bad certificate handler as well.
      *
      * See also: SSL_AuthCertificateComplete in /usr/include/nss3/ssl.h
      */

--- a/org/mozilla/jss/nss/SSLErrors.c
+++ b/org/mozilla/jss/nss/SSLErrors.c
@@ -1,0 +1,20 @@
+#include <nspr.h>
+#include <limits.h>
+#include <stdint.h>
+#include <jni.h>
+#include <nss.h>
+#include <ssl.h>
+#include <sslerr.h>
+
+#include "jssutil.h"
+#include "PRFDProxy.h"
+#include "BufferProxy.h"
+#include "BufferPRFD.h"
+
+#include "_jni/org_mozilla_jss_nss_SECErrors.h"
+
+JNIEXPORT int JNICALL
+Java_org_mozilla_jss_nss_SECErrors_getBadCertDomain(JNIEnv *env, jclass clazz)
+{
+    return SSL_ERROR_BAD_CERT_DOMAIN;
+}

--- a/org/mozilla/jss/nss/SSLErrors.java
+++ b/org/mozilla/jss/nss/SSLErrors.java
@@ -1,0 +1,19 @@
+package org.mozilla.jss.nss;
+
+/**
+ * This class provides access to useful NSS/SSL errors, getting their values
+ * from a JNI call. Note that it *isn't* an enum as the NSS wrappers return
+ * int. This saves us from having to wrap every NSS error in a class instance
+ * only to later unwrap it to make any useful calls.
+ */
+
+public class SSLErrors {
+    /**
+     * Certificate has a bad hostname.
+     *
+     * See also:  in /usr/include/nss3/sslcerr.h
+     */
+    public static final int BAD_CERT_DOMAIN = getBadCertDomain();
+
+    private static native int getBadCertDomain();
+}

--- a/org/mozilla/jss/nss/SSLFDProxy.h
+++ b/org/mozilla/jss/nss/SSLFDProxy.h
@@ -35,3 +35,9 @@ JSSL_SSLFDAsyncCertAuthCallback(void *arg, PRFileDesc *fd, PRBool checkSig, PRBo
 
 SECStatus
 JSSL_SSLFDSyncCertAuthCallback(void *arg, PRFileDesc *fd, PRBool checkSig, PRBool isServer);
+
+SECStatus
+JSSL_SSLFDAsyncBadCertCallback(void *arg, PRFileDesc *fd);
+
+SECStatus
+JSSL_SSLFDSyncBadCertCallback(void *arg, PRFileDesc *fd);

--- a/org/mozilla/jss/nss/SSLFDProxy.java
+++ b/org/mozilla/jss/nss/SSLFDProxy.java
@@ -19,9 +19,12 @@ public class SSLFDProxy extends PRFDProxy {
     public int outboundOffset;
 
     public boolean needCertValidation;
+    public boolean needBadCertValidation;
+    public int badCertError;
     public boolean handshakeComplete;
 
-    public CertAuthHandler handler;
+    public CertAuthHandler certAuthHandler;
+    public BadCertHandler badCertHandler;
 
     public SSLFDProxy(byte[] pointer) {
         super(pointer);
@@ -51,6 +54,10 @@ public class SSLFDProxy extends PRFDProxy {
     }
 
     public int invokeCertAuthHandler() {
-        return handler.check(this);
+        return certAuthHandler.check(this);
+    }
+
+    public int invokeBadCertHandler(int error) {
+        return badCertHandler.check(this, error);
     }
 }

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -390,7 +390,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             // from Runnable, so we can reuse it here as well. We can create
             // it ahead of time though. In this case, checkNeedCertValidation()
             // is never called.
-            ssl_fd.handler = new CertValidationTask(ssl_fd);
+            ssl_fd.certAuthHandler = new CertValidationTask(ssl_fd);
 
             if (SSL.ConfigSyncTrustManagerCertAuthCallback(ssl_fd) == SSL.SECFailure) {
                 throw new SSLException("Unable to configure TrustManager validation on this JSSengine: " + errorText(PR.GetError()));

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -228,6 +228,17 @@ public class JSSEngineReferenceImpl extends JSSEngine {
                 throw new SSLException("Unable to attach client certificate auth callback.");
             }
         }
+
+        if (hostname == null) {
+            // When we're a client with no hostname, assume we're running
+            // under standard JDK JCA semantics with no hostname available.
+            // Bypass NSS's hostname check by adding a BadCertHandler, which
+            // check ONLY for the bad hostname error and allows it.
+            ssl_fd.badCertHandler = new BypassBadHostname(ssl_fd, 0);
+            if (SSL.ConfigSyncBadCertCallback(ssl_fd) != SSL.SECSuccess) {
+                throw new SSLException("Unable to attach bad cert callback.");
+            }
+        }
     }
 
     private void initServer() throws SSLException {
@@ -1637,6 +1648,20 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             seen_exception = true;
             ssl_exception = new SSLException(msg, excpt);
             return nss_code;
+        }
+    }
+
+    private class BypassBadHostname extends BadCertHandler {
+        public BypassBadHostname(SSLFDProxy fd, int error) {
+            super(fd, error);
+        }
+
+        public int check(SSLFDProxy fd, int error) {
+            if (error == SSLErrors.BAD_CERT_DOMAIN) {
+                return 0;
+            }
+
+            return error;
         }
     }
 }


### PR DESCRIPTION
This PR improves JCA compatibility by bypassing NSS's hostname verification on client `SSLEngine` connections, to mirror the behavior of SunJSSE.

We use the approach suggested by Bob Relyea, which is to hook the bad cert handler and check for a specific error. Because hostname verification is guaranteed to be the last thing NSS does (regardless of whether or not we use NSS's default handler or libpkix verification), this should be safe. This has the added benefit of also working with our custom cert authentication callbacks. 

Eventually, we'll expose this method to all JSSEngine instances, and allow the caller a chance to override other errors if they'd like, in an asynchronous manner. 