### PR TITLE
[v4.7.3] Disable Fallback SCSV and add PHA to legacy SSLSocket

### DIFF
--- a/org/mozilla/jss/ssl/SSLSocket.java
+++ b/org/mozilla/jss/ssl/SSLSocket.java
@@ -1095,6 +1095,24 @@ public class SSLSocket extends java.net.Socket {
     }
 
     /**
+     * Enable or disable post-handshake auth for a single socket.
+     */
+    public void enablePostHandshakeAuth(boolean enable)
+    throws SocketException
+    {
+        base.enablePostHandshakeAuth(enable);
+    }
+
+    /**
+     * Sets the default to allow post-handshake auth globally.
+     */
+    public static void enablePostHandshakeAuthDefault(boolean enable)
+    throws SocketException
+    {
+        setSSLDefaultOption(SocketBase.SSL_ENABLE_POST_HANDSHAKE_AUTH, enable);
+    }
+
+    /**
      * @return a String listing the current SSLOptions for this SSLSocket.
      */
     public String getSSLOptions() {

--- a/org/mozilla/jss/ssl/SocketBase.java
+++ b/org/mozilla/jss/ssl/SocketBase.java
@@ -101,6 +101,7 @@ class SocketBase {
     /* ssl/sslt.h */
     static final int SSL_Variant_Stream = 33;
     static final int SSL_Variant_Datagram = 34;
+    static final int SSL_ENABLE_POST_HANDSHAKE_AUTH = 36;
 
     static final int SSL_AF_INET = 50;
     static final int SSL_AF_INET6 = 51;
@@ -173,6 +174,10 @@ class SocketBase {
 
     void enableV2CompatibleHello(boolean enable) throws SocketException {
         setSSLOption(SSL_V2_COMPATIBLE_HELLO, enable);
+    }
+
+    void enablePostHandshakeAuth(boolean enable) throws SocketException {
+        setSSLOption(SSL_ENABLE_POST_HANDSHAKE_AUTH, enable);
     }
 
     void setSSLOption(int option, boolean on)

--- a/org/mozilla/jss/ssl/common.c
+++ b/org/mozilla/jss/ssl/common.c
@@ -422,6 +422,7 @@ PRInt32 JSSL_enums[] = {
     ssl_variant_stream,           /* 33 */      /* sslt.h */
     ssl_variant_datagram,         /* 34 */      /* sslt.h */
     SSL_LIBRARY_VERSION_TLS_1_3,  /* 35 */      /* sslproto.h */
+    SSL_ENABLE_POST_HANDSHAKE_AUTH, /* 36 */      /* ssl.h */
     0
 };
 

--- a/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -945,7 +945,6 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
         // TLS < 1.3.
         result.put(SSL.ENABLE_RENEGOTIATION, SSL.RENEGOTIATE_REQUIRES_XTN);
         result.put(SSL.REQUIRE_SAFE_NEGOTIATION, 1);
-        result.put(SSL.ENABLE_FALLBACK_SCSV, 1);
         return result;
     }
 

--- a/org/mozilla/jss/ssl/jssl.h
+++ b/org/mozilla/jss/ssl/jssl.h
@@ -106,7 +106,7 @@ JSSL_DestroySocketData(JNIEnv *env, JSSL_SocketData *sd);
 
 
 extern PRInt32 JSSL_enums[];
-#define JSSL_enums_size 36
+#define JSSL_enums_size 37
 int JSSL_enums_reverse(PRInt32 value);
 
 JSSL_SocketData*


### PR DESCRIPTION
This PR fixes two additional issues:

 - We disable Fallback SCSV. While used by browsers, it isn't present in the cipher suites negotiated by SunJSSE by default. Since we're striving to be compatible with that, drop SCSV.
 - Add PHA to SSLSocket. This addresses the failure in https://github.com/dogtagpki/pki/pull/537 and https://github.com/dogtagpki/pki/pull/543, with one additional patch.

@edewata / @jmagne -- should we make PHA default in the legacy SSLSocket? We added TLSv1.3 support to it a while ago, but TLSv1.3's behavior differs from TLSV1.2's behavior, probably why we had issues with SCSV and TLSv1.2 pinned as maximum in Dogtag PKI. If we enable PHA, TLSv1.2 and TLSv1.3 will mostly be compatible.

If so, we could avoid the need for a strict dependency on a newer JSS version.