### PR TITLE
Fix JSSEngine stalling

### DIFF
--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -330,6 +330,12 @@ public final class CryptoManager implements TokenSupplier
         reloadModules();
     }
 
+    public static boolean isInitialized() {
+        synchronized (CryptoManager.class) {
+            return instance != null;
+        }
+    }
+
     /**
      * Retrieve the single instance of CryptoManager.
      * This cannot be called before initialization.

--- a/org/mozilla/jss/JSSLoader.java
+++ b/org/mozilla/jss/JSSLoader.java
@@ -79,17 +79,6 @@ public class JSSLoader {
     public static Logger logger = LoggerFactory.getLogger(JSSLoader.class);
 
     /**
-     * Check if this provider has been configured.
-     */
-    public static boolean loaded() {
-        try {
-            return CryptoManager.getInstance() != null;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    /**
      * Initialize JSS from the specified path to a configuration file.
      */
     public static CryptoManager init(String config_path) throws Exception {
@@ -108,7 +97,7 @@ public class JSSLoader {
      * Initialize JSS from an InputStream.
      */
     public static CryptoManager init(InputStream istream) throws Exception {
-        if (loaded()) {
+        if (CryptoManager.isInitialized()) {
             return CryptoManager.getInstance();
         }
 

--- a/org/mozilla/jss/JSSProvider.java
+++ b/org/mozilla/jss/JSSProvider.java
@@ -29,7 +29,7 @@ public final class JSSProvider extends java.security.Provider {
     private static CryptoManager cm;
 
     public JSSProvider() {
-        this(loader.loaded());
+        this(CryptoManager.isInitialized());
     }
 
     public JSSProvider(boolean initialize) {

--- a/org/mozilla/jss/ssl/callbacks.c
+++ b/org/mozilla/jss/ssl/callbacks.c
@@ -497,8 +497,13 @@ JSSL_DefaultCertAuthCallback(void *arg, PRFileDesc *fd, PRBool checkSig,
     if (hostname && hostname[0]) {
         rv = CERT_VerifyCertName(peerCert, hostname);
         PORT_Free(hostname); 
-    } else
+    } else {
         rv = SECFailure;
+    }
+
+    if (rv == SECFailure) {
+        PR_SetError(SSL_ERROR_BAD_CERT_DOMAIN, 0);
+    }
 
     if (peerCert) CERT_DestroyCertificate(peerCert);
     return rv;

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -912,7 +912,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             return data_index;
         }
 
-        for (data_index = 0; data_index < data.length; data_index++) {
+        for (data_index = 0; data_index < data.length;) {
             // Ensure we have have a buffer with capacity.
             while ((buffers[buffer_index] == null || buffers[buffer_index].remaining() <= 0) &&
                     (buffer_index < offset + length)) {


### PR DESCRIPTION
QE (thanks @PsOverflow and @snehaveeranki1!) found a bug where `JSSEngine` stalled on certain PKI commands. This was ultimately caused by `JSSEngine` reporting that the size of `app_data` (as returned by `unwrap()`) was one byte larger than was actually written into the `ByteBuffer`. This meant that certain libraries (like Apache HTTP components) added an extra `NULL` byte into the data stream between HTTP requests, breaking the parsing code and stalling the connection.

We do a few things in this PR:

 -  Forward port a fix from v4.7.x around `BAD_CERT_DOMAIN` handling in our JSS cert checking handler. This matches NSS behavior. Not a candidate for backport.
 - Add additional inline documentation to the `JSSEngine`. Made while looking for the bug, not a candidate for backport.
 - Add `CryptoManager.isInitialized()` to fix another stack trace found while trying to reproduce the bug. The `JSSProvider` security provider attempted to load itself again, causing recursion that the Security Provider interface prevented, printing a stack trace when debugging was enabled. This is harmless as `JSSProvider` still loads, but we should still avoid it when possible. Candidate for backport.
 - Add SNI to client requests whithout `setHostname`. During constructor, we're given a hostname used for the underlying socket connection usually. This isn't guaranteed to be the actual service hostname, but usually is. Pass it through to `setHostname` because `SSL_SetURL` is the only way for a client SSL socket to indicate SNI information. This is useful for testing against hosts such as `google.com`, which require SNI to even connect. Candidate for backport.
 - Finally, the named bug: fix extra increment in `unwrap()`'s `putData()` call. Off by one error that was eventually returned to the caller. Candidate for backport. 