### PR TITLE
Add ALPN support in SSLSocket

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -499,3 +499,9 @@ Java_org_mozilla_jss_nss_SSLErrors_getBadCertDomain;
     local:
         *;
 };
+JSS_4.8.0 {
+    global:
+Java_org_mozilla_jss_ssl_SSLSocket_getNegotiatedProtocol;
+    local:
+        *;
+};

--- a/org/mozilla/jss/ssl/SSLSocket.c
+++ b/org/mozilla/jss/ssl/SSLSocket.c
@@ -572,6 +572,29 @@ Java_org_mozilla_jss_ssl_SSLSocket_getPort(JNIEnv *env,
     }
 }
 
+JNIEXPORT jbyteArray JNICALL
+Java_org_mozilla_jss_ssl_SSLSocket_getNegotiatedProtocol(JNIEnv *env, jobject self)
+{
+    JSSL_SocketData *sock;
+    SECStatus status;
+    SSLNextProtoState npState;
+    unsigned char buf[255];
+    unsigned int bufLen = 0;
+
+    if (JSSL_getSockData(env, self, &sock) != PR_SUCCESS || sock == NULL) {
+        /* exception was thrown */
+        EXCEPTION_CHECK(env, sock);
+        return NULL;
+    }
+
+    status = SSL_GetNextProto(sock->fd, &npState, buf, &bufLen, sizeof(buf));
+    if (status == SECSuccess && bufLen > 0 && bufLen <= sizeof(buf)) {
+        return JSS_ToByteArray(env, buf, bufLen);
+    } else {
+        return NULL;
+    }
+}
+
 JNIEXPORT void JNICALL
 Java_org_mozilla_jss_ssl_SSLSocket_socketConnect
     (JNIEnv *env, jobject self, jbyteArray addrBA, jstring hostname, jint port, jbyteArray alpn)

--- a/org/mozilla/jss/ssl/SSLSocket.java
+++ b/org/mozilla/jss/ssl/SSLSocket.java
@@ -644,6 +644,14 @@ public class SSLSocket extends java.net.Socket {
         resetHandshake();
     }
 
+    /* Get result of ALPN negotiation.
+     *
+     * Prior to the handshake this will always return null.
+     * After the handshake, returns the negotiated protocol
+     * or null (e.g. when the server does not support ALPN).
+     */
+    public native byte[] getNegotiatedProtocol() throws SocketException;
+
     /**
      * @return The remote peer's IP address or null if the SSLSocket is closed.
      */

--- a/org/mozilla/jss/ssl/SSLSocket.java
+++ b/org/mozilla/jss/ssl/SSLSocket.java
@@ -552,6 +552,36 @@ public class SSLSocket extends java.net.Socket {
             certApprovalCallback, clientCertSelectionCallback);
     }
 
+    /**
+     * Create an SSL client socket and connects to the specified
+     * address and port. Installs the given callbacks for
+     * certificate approval and client certificate selection.
+     * Supports Application Layer Protocol Negotiation (ALPN)
+     * extension.
+     *
+     * @param address The IP address to connect to.
+     * @param port The port to connect to.
+     * @param hostname Hostname to use for SNI
+     * @param alpn Array of ALPN protocol IDS.  If empty, extension is not
+     *      added.  Each protocol ID must have a length between 1 and 255
+     *      bytes.
+     * @param certApprovalCallback A callback that can be used to override
+     *      approval of the peer's certificate.
+     * @param clientCertSelectionCallback A callback to select the client
+     *      certificate to present to the peer.
+     */
+    public SSLSocket(
+        InetAddress address, int port,
+        String hostname, byte[][]alpn,
+        SSLCertificateApprovalCallback certApprovalCallback,
+        SSLClientCertificateSelectionCallback clientCertSelectionCallback)
+            throws IOException {
+        this(
+            address, hostname, port, null, 0, alpn,
+            certApprovalCallback, clientCertSelectionCallback);
+    }
+
+
     /** Write an ALPN protocol name to the OutputStream.  The protocol name
      * will be prefixed by its length (as a single byte).
      *

--- a/org/mozilla/jss/ssl/SSLSocket.java
+++ b/org/mozilla/jss/ssl/SSLSocket.java
@@ -581,7 +581,7 @@ public class SSLSocket extends java.net.Socket {
         }
 
         /* connect to the remote socket */
-        socketConnect(address.getAddress(), hostname, port);
+        socketConnect(address.getAddress(), hostname, port, null);
     }
 
     /**
@@ -789,7 +789,16 @@ public class SSLSocket extends java.net.Socket {
         }
     }
 
-    private native void socketConnect(byte[] addr, String hostname, int port)
+    /**
+     * Connect socket
+     *
+     * @param addr IPv4 or IPv6 address
+     * @param hostname server name (used for SNI)
+     * @param port port number
+     * @param alpn *formatted* ALPN extension data (see SSL_SetNextProtoNego),
+     *             or null if ALPN extension is not to be sent
+     */
+    private native void socketConnect(byte[] addr, String hostname, int port, byte[] alpn)
         throws SocketException;
 
     ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is a prerequisite for ACME tls-alpn-01 challenge verification.
See https://gist.github.com/frasertweedale/dfac386579cb2d1fe892f39d22c2975d
for usage / testbed.


```
ab29dd6c (Fraser Tweedale, 7 minutes ago)
   alpn: support via new SSLSocket constructor

   Add a new SSLSocket constructor that allows the caller to specify ALPN
   protocols.

555134db (Fraser Tweedale, 2 hours ago)
   alpn: add SSLSocket.getNegotiatedProtocol()

   Add a method to retrieve the identifier of the negotiated protocol, if
   available.

465ac1d9 (Fraser Tweedale, 4 days ago)
   alpn: format and supply ALPN data if user provides it

   Update the private SSLSocket constructor to accept a String[] of ALPN
   protocol names in preferred order.  When given, it will prepare the ALPN
   extension data in the required format and pass it along to the
   socketConnect method.

   The change to publicly expose this capability will occur in a subsequent
   commit.

6f5a0cf8 (Fraser Tweedale, 4 days ago)
   alpn: add support in native socketConnect method

   Update the private native socketConnect method to receive optional ALPN
   data to include in handshake.  The value is performatted per 
   SSL_SetNextProtoNego().

   Support for library users to supply the ALPN data will follow in subsequent
   commits.
```