### PR TITLE
JSSSocketChannel.read(): deliver all data from buffer fd

### DIFF
--- a/org/mozilla/jss/nss/PR.c
+++ b/org/mozilla/jss/nss/PR.c
@@ -176,6 +176,10 @@ Java_org_mozilla_jss_nss_PR_Read(JNIEnv *env, jclass clazz, jobject fd,
     while (read_amount < amount) {
         this_read = PR_Read(real_fd, buffer + read_amount, amount - read_amount);
         if (this_read <= 0) {
+            if (PR_GetError() == 0) {
+                /* End of data */
+                break;
+            }
             if (PR_GetError() == PR_WOULD_BLOCK_ERROR && read_amount > 0) {
                 /* If we've previously gotten data and we would block this
                  * time, then we're at the end of our data. Reset the error

--- a/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -272,10 +272,14 @@ public class JSSSocketChannel extends SocketChannel {
                 readBuffer.flip();
 
                 result = engine.unwrap(readBuffer, dsts, offset, length);
-                if (result.getStatus() != SSLEngineResult.Status.OK &&
-                    result.getStatus() != SSLEngineResult.Status.BUFFER_UNDERFLOW &&
-                    result.getStatus() != SSLEngineResult.Status.CLOSED) {
-                    throw new IOException("Unexpected status from unwrap: " + result);
+                switch (result.getStatus()) {
+                    case CLOSED:
+                        shutdownInput();
+                    case OK:
+                    case BUFFER_UNDERFLOW:
+                        break; // CLOSED, OK and BUFFER_UNDERFLOW are expected
+                    default:
+                        throw new IOException("Unexpected status from unwrap: " + result);
                 }
                 unwrapped += result.bytesConsumed();
                 decrypted += result.bytesProduced();


### PR DESCRIPTION
```
5e223293 (Fraser Tweedale, 17 minutes ago)
   JSSSocketChannel.read(): deliver all data from buffer fd

   JSSSocketChannel.read() returns 0 when the underlying socket does not yield
   any new data.  But in the case of small output buffers, earlier invocations
   of read() may result in more decrypted data sitting in the unwrapped side
   of the j_buffer, never to be delievered to the application.

   To resolve this issue, continue on to unwrap() even when the underlying
   socket does not yield new data.

   However, only do this after the handshake has been completed. Empirically,
   calling unwrap() at early stages of the handshake with empty buffers breaks
   /something/, causing no data to ever be read from the socket.  (I do not
   understand the exact cause.)

   As part of this change, also refactor how the remote read is handled.  The
   choice of which channel to read and handling of blocking channels is now
   abstracted behind the remoteRead() method, which subsumes boundRead().

   This commit also addresses a subtle bug.  If the readBuffer contains more
   data than the capacity of the j_buffer to which it is written, and if the
   dst buffer(s) get filled, then JSSSocketChannel.read() can terminate with
   leftover data in readBuffer.  Upon the next invocation of read(),
   readBuffer.clear() is called, discarding those data.  This commit modifies
   read() to ensure that leftover data in readBuffer are compacted and
   preserved.

778729ee (Fraser Tweedale, 20 minutes ago)
   JSSSocket.getChannel(): always return channel

   We can always init a channel regardless of whether the parent socket has a
   channel or not.  Indeed, init() always creates a channel, so we can always
   return a channel.
```