### PR TITLE
Fix missing OIDMap mappings for X.509 extensions

### DIFF
--- a/org/mozilla/jss/netscape/security/x509/OIDMap.java
+++ b/org/mozilla/jss/netscape/security/x509/OIDMap.java
@@ -77,13 +77,13 @@ public class OIDMap {
                                           NameConstraintsExtension.NAME;
     private static final String POLICY_CONSTRAINTS = ROOT + "." +
                                           PolicyConstraintsExtension.NAME;
-    private static final String CERT_POLICIES = //ROOT + "." +
+    private static final String CERT_POLICIES = ROOT + "." +
             CertificatePoliciesExtension.NAME;
-    private static final String SUBJ_DIR_ATTR = //ROOT + "." +
+    private static final String SUBJ_DIR_ATTR = ROOT + "." +
             SubjectDirAttributesExtension.NAME;
     public static final String EXT_KEY_USAGE_NAME = "ExtendedKeyUsageExtension";
     public static final String EXT_INHIBIT_ANY_POLICY_NAME = "InhibitAnyPolicyExtension";
-    private static final String EXT_KEY_USAGE = //ROOT + "." +
+    private static final String EXT_KEY_USAGE = ROOT + "." +
             EXT_KEY_USAGE_NAME;
 
     private static final String CRL_NUMBER = ROOT + "." +

--- a/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
+++ b/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
@@ -133,7 +133,22 @@ public class JSSTrustManager implements X509TrustManager {
             } else if (allowedToSkip) {
                 logger.debug("JSSTrustManager: configured to allow null extended key usages field");
             } else {
-                throw new CertificateException("Missing extended key usage: " + keyUsage);
+                String msg = "Missing EKU: " + keyUsage +
+                    ". Certificate with subject DN `" + cert.getSubjectDN() + "` had ";
+                if (extendedKeyUsages == null) {
+                    msg += "no EKU extension";
+                } else {
+                    msg += "EKUs { ";
+                    boolean first = true;
+                    for (String eku : extendedKeyUsages) {
+                        if (!first) msg += " , ";
+                        msg += eku;
+                        first = false;
+                    }
+                    msg += " }";
+                }
+                msg += ".  class = " + cert.getClass();
+                throw new CertificateException(msg);
             }
         }
     }


### PR DESCRIPTION
I was getting a very strange error in JSSTrustManager certificate
validation.  The leaf certificate was (wrongly) being rejected for
not having the id-kp-serverAuth EKU.

I traced the error to X509CertImpl.getExtensionValue(); in
particular its catch block.  Upon exception it discards the
exception and returns null.  (This is not unreasonable when e.g. the
extension data cannot be parsed).  I added some debug logging.  The
exception thrown was:

```
  java.security.cert.CertificateParsingException: Invalid root of
      attribute name, expected [x509], received [ExtendedKeyUsageExtension]
    at ...X509CertImpl.get(X509CertImpl.java:499)
    at ...X509CertImpl.getExtensionValue(X509CertImpl.java:1014)
```

From here I traced it to the OIDMap and the String names.  Whereas
most extension names in the OIDMap had a prefix of
"x509.info.extensions.", three did not, including
ExtendedKeyUsageExtension.  getExtensionValue() looks up the name in
the OIDMap by OID, then uses it to index into internal structures to
return the datum suggested by the OID.  Reinstating the prefix in
the OIDMap resolved the issue.

Apart from EKU the two other affected extensions are Subject
Directory Attributes and Certificate Policies.  Why the prefixes
were omitted for these three extensions is lost in time.  This code
was moved from Dogtag to JSS relatively recently, but the code was
like this in the first commit in Dogtag's repo, from 2008.

I believe there is a low likelihood of regression from this change.
As far as I can tell, the only classes that use the result of
OIDMap.getName() in a logical process are X509CertImpl and friends
X509CRLImpl and RevokedCertImpl.  It is also used in ExtPrettyPrint
but only for pretty-printing.