### PR TITLE
Log exceptions when libjss4.so failed to load

### DIFF
--- a/org/mozilla/jss/CryptoManager.java
+++ b/org/mozilla/jss/CryptoManager.java
@@ -68,8 +68,14 @@ public final class CryptoManager implements TokenSupplier
                 logger.debug("CryptoManager: loaded JSS library from /usr/lib64/jss/libjss4.so");
 
             } catch (UnsatisfiedLinkError e1) {
-                System.load("/usr/lib/jss/libjss4.so");
-                logger.debug("CryptoManager: loaded JSS library from /usr/lib/jss/libjss4.so");
+                try {
+                    System.load("/usr/lib/jss/libjss4.so");
+                    logger.debug("CryptoManager: loaded JSS library from /usr/lib/jss/libjss4.so");
+                } catch (UnsatisfiedLinkError e2) {
+                    logger.warn("Unable to load jss4 via loadLibrary: " + e.toString());
+                    logger.warn("Unable to load /usr/lib64/jss/libjss4.so: " + e1.toString());
+                    throw e2;
+                }
             }
         }
     }


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

This was helpful in debugging @jmagne's issue, so I think we should include it. In particular, when `libjss4.so` is linked incorrectly, all three loads will fail, but only the second one will contain useful information.