### PR TITLE
Disable MD4, MD5 and SHA-1 algorithms in test suite

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11Signature.c
+++ b/org/mozilla/jss/pkcs11/PK11Signature.c
@@ -87,12 +87,12 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_initSigContext
     }
 
     if (ctxt == NULL) {
-        JSS_throwMsg(env, TOKEN_EXCEPTION, "Unable to create signing context");
+        JSS_throwMsgPrErr(env, TOKEN_EXCEPTION, "Unable to create signing context");
         goto finish;
     }
 
     if (SGN_Begin(ctxt) != SECSuccess) {
-        JSS_throwMsg(env, TOKEN_EXCEPTION, "Unable to begin signing context");
+        JSS_throwMsgPrErr(env, TOKEN_EXCEPTION, "Unable to begin signing context");
         goto finish;
     }
 
@@ -148,7 +148,7 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_initVfyContext
         unsigned key_bits = SECKEY_PublicKeyStrengthInBits(pubk);
         privk = SECKEY_CreateRSAPrivateKey(key_bits, &tempPubKey, NULL);
         if (privk == NULL) {
-            JSS_throwMsg(env, TOKEN_EXCEPTION,
+            JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
                          "Unable to create temporary RSA key");
             goto finish;
         }
@@ -175,13 +175,13 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_initVfyContext
     }
 
     if (ctxt == NULL) {
-        JSS_throwMsg(env, TOKEN_EXCEPTION, "Unable to create vfy context");
+        JSS_throwMsgPrErr(env, TOKEN_EXCEPTION, "Unable to create vfy context");
         goto finish;
     }
 
     if (VFY_Begin(ctxt) != SECSuccess) {
-        JSS_throwMsg(env, TOKEN_EXCEPTION,
-                     "Unable to begin verification context");
+        JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+                          "Unable to begin verification context");
         goto finish;
     }
 
@@ -251,7 +251,7 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineUpdateNative
                         (unsigned char*)bytes + offset,
                         (unsigned)length ) != SECSuccess)
         {
-            JSS_throwMsg(env, SIGNATURE_EXCEPTION, "update failed");
+            JSS_throwMsgPrErr(env, SIGNATURE_EXCEPTION, "update failed");
             goto finish;
         }
     } else {
@@ -260,7 +260,7 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineUpdateNative
                         (unsigned char*)bytes + offset,
                         (unsigned) length ) != SECSuccess)
         {
-            JSS_throwMsg(env, SIGNATURE_EXCEPTION, "update failed");
+            JSS_throwMsgPrErr(env, SIGNATURE_EXCEPTION, "update failed");
             goto finish;
         }
     }
@@ -338,13 +338,13 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineVerifyNative
 	 */
 	if( getSigContext(env, this, (void**)&ctxt, &type) != PR_SUCCESS) {
 		PR_ASSERT(PR_FALSE);
-		JSS_throwMsg(env, SIGNATURE_EXCEPTION,
+		JSS_throwMsgPrErr(env, SIGNATURE_EXCEPTION,
 			"Unable to retrieve verification context");
 		goto finish;
 	}
 	if(type != VFY_CONTEXT) {
 		PR_ASSERT(PR_FALSE);
-		JSS_throwMsg(env, SIGNATURE_EXCEPTION,
+		JSS_throwMsgPrErr(env, SIGNATURE_EXCEPTION,
 			"Verification engine has signature context");
 		goto finish;
 	}
@@ -364,7 +364,7 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineVerifyNative
 		verified = JNI_TRUE;
 	} else if( PR_GetError() != SEC_ERROR_BAD_SIGNATURE) {
 		PR_ASSERT(PR_FALSE);
-		JSS_throwMsg(env, SIGNATURE_EXCEPTION,
+		JSS_throwMsgPrErr(env, SIGNATURE_EXCEPTION,
 			"Failed to complete verification operation");
 		goto finish;
 	}
@@ -470,7 +470,7 @@ getRSAPSSParamsAndSigningAlg(JNIEnv *env, jobject this, PRArenaPool *arena,
                        SEC_OID_PKCS1_RSA_PSS_SIGNATURE, digestAlg, NULL,
                        privk);
     if (sigAlgParams == NULL) {
-        JSS_throwMsg(env, TOKEN_EXCEPTION,
+        JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
                      "Unable to create signature algorithm parameters");
         return rv;
     }
@@ -479,7 +479,7 @@ getRSAPSSParamsAndSigningAlg(JNIEnv *env, jobject this, PRArenaPool *arena,
     rv = SECOID_SetAlgorithmID(arena, *alg, SEC_OID_PKCS1_RSA_PSS_SIGNATURE,
                                sigAlgParams);
     if (rv != SECSuccess) {
-        JSS_throwMsg(env, TOKEN_EXCEPTION,
+        JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
                      "Unable to set RSA-PSS Algorithm ID");
     }
 
@@ -831,7 +831,7 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineRawSignNative
 
     /* perform the signature operation */
     if( PK11_Sign(key, sig, hash) != SECSuccess ) {
-        JSS_throwMsg(env, SIGNATURE_EXCEPTION, "Signature operation failed"
+        JSS_throwMsgPrErr(env, SIGNATURE_EXCEPTION, "Signature operation failed"
             " on token");
         goto finish;
     }
@@ -884,7 +884,7 @@ Java_org_mozilla_jss_pkcs11_PK11Signature_engineRawVerifyNative
     if( status == SECSuccess ) {
         verified = JNI_TRUE;
     } else if( PR_GetError() != SEC_ERROR_BAD_SIGNATURE ) {
-        JSS_throwMsg(env, SIGNATURE_EXCEPTION, "Verification operation"
+        JSS_throwMsgPrErr(env, SIGNATURE_EXCEPTION, "Verification operation"
             " failed on token");
         goto finish;
     }

--- a/org/mozilla/jss/tests/DigestTest.java
+++ b/org/mozilla/jss/tests/DigestTest.java
@@ -21,8 +21,7 @@ public class DigestTest {
     /**
      * List all the Digest Algorithms that JSS implements.
      */
-    static final String JSS_Digest_Algs[] = { "MD2", "MD5", "SHA-1",
-                                            "SHA-256", "SHA-384","SHA-512"};
+    static final String JSS_Digest_Algs[] = { "SHA-256", "SHA-384","SHA-512" };
 
     public static boolean messageDigestCompare(String alg, byte[] toBeDigested)
     throws Exception {

--- a/org/mozilla/jss/tests/JCASigTest.java
+++ b/org/mozilla/jss/tests/JCASigTest.java
@@ -101,9 +101,6 @@ public class JCASigTest {
             System.exit(1);
         }
 
-        sigTest("MD5/RSA", keyPair);
-        sigTest("MD2/RSA", keyPair);
-        sigTest("SHA-1/RSA", keyPair);
         sigTest("SHA-256/RSA", keyPair);
         sigTest("SHA-384/RSA", keyPair);
         sigTest("SHA-512/RSA", keyPair);
@@ -111,24 +108,6 @@ public class JCASigTest {
         sigTest("SHA384withRSA/PSS", keyPair);
         sigTest("SHA512withRSA/PSS", keyPair);
         sigTest("RSASSA-PSS",keyPair);
-
-        // Generate an DSA keypair
-        kpgen = KeyPairGenerator.getInstance("DSA");
-        kpgen.initialize(1024);
-        keyPair = kpgen.generateKeyPair();
-        provider = kpgen.getProvider();
-
-        System.out.println("The provider used to Generate the Keys was "
-                            + provider.getName() );
-        System.out.println("provider info " + provider.getInfo() );
-
-        if (provider.getName().equalsIgnoreCase("Mozilla-JSS") == false) {
-            System.out.println("Mozilla-JSS is supposed to be the " +
-                "default provider for JCASigTest");
-            System.exit(1);
-        }
-
-        sigTest("SHA-1/DSA", keyPair);
 
         kpgen = KeyPairGenerator.getInstance("EC");
         kpgen.initialize(256);
@@ -145,7 +124,6 @@ public class JCASigTest {
             System.exit(1);
         }
 
-        sigTest("SHA-1/EC", keyPair);
         sigTest("SHA-256/EC", keyPair);
         sigTest("SHA-384/EC", keyPair);
         sigTest("SHA-512/EC", keyPair);

--- a/org/mozilla/jss/tests/SigTest.java
+++ b/org/mozilla/jss/tests/SigTest.java
@@ -81,9 +81,9 @@ public class SigTest {
         kpgen.setKeyPairUsages(usages, usages_mask);
         keyPair = kpgen.genKeyPair();
 
-        // RSA MD5
+        // RSA SHA256
         signer = token.getSignatureContext(
-                SignatureAlgorithm.RSASignatureWithMD5Digest);
+                SignatureAlgorithm.RSASignatureWithSHA256Digest);
         System.out.println("Created a signing context");
         signer.initSign(
                 (org.mozilla.jss.crypto.PrivateKey) keyPair.getPrivate());


### PR DESCRIPTION
Our rawhide sandboxed CI image is currently failing with the cryptic:

    Exception in thread "main" org.mozilla.jss.crypto.TokenException: Unable to create signing context
       at org.mozilla.jss.pkcs11.PK11Signature.initSigContext(Native Method)
       at org.mozilla.jss.pkcs11.PK11Signature.engineInitSign(PK11Signature.java:114)
       at org.mozilla.jss.crypto.Signature.initSign(Signature.java:55)
       at org.mozilla.jss.tests.SigTest.main(SigTest.java:88)

Switch JSS_throwMsg to JSS_throwMsgPrErr so we can get the underlying
error code from these calls.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----


This turned out to be caused by MD4 and MD5 being disabled. I've proactively removed some usage of SHA-1 as well as that is likely next on the chopping block.

These algorithms are still exposed in JSS's Provider, but now they won't work on NSS v3.59 and later. 