### PR TITLE
Release JSS v4.8.0

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -2,7 +2,7 @@ macro(jss_config)
     # Set the current JSS release number. Arguments are:
     #   MAJOR MINOR PATCH BETA
     # When BETA is zero, it isn't a beta release.
-    jss_config_version(4 8 0 1)
+    jss_config_version(4 8 0 0)
 
     # Configure output directories
     jss_config_outputs()

--- a/jss.spec
+++ b/jss.spec
@@ -7,8 +7,8 @@ URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
 Version:        4.8.0
-Release:        0.1%{?_timestamp}%{?_commit_id}%{?dist}
-%global         _phase -a1
+Release:        1%{?_timestamp}%{?_commit_id}%{?dist}
+#global         _phase -a1
 
 # To generate the source tarball:
 # $ git clone https://github.com/dogtagpki/jss.git


### PR DESCRIPTION
This version of JSS has a few minor improvements over v4.7.x series:

 - Porting from Apache Commons Lang 2 to 3
 - A few memory fixes
 - Two contributions from Fraser Tweedale:
   - Fix missing OIDMap mappings for X.509 extensions
   - `JSSSocketChannel.read()`: deliver all data from buffer fd

Thanks to everyone who contributed to this release!

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`