### PR TITLE
Replace RSAPrivateKey with RSAKey

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11RSAPrivateKey.java
+++ b/org/mozilla/jss/pkcs11/PK11RSAPrivateKey.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class PK11RSAPrivateKey
-    extends PK11PrivKey implements java.security.interfaces.RSAPrivateKey
+    extends PK11PrivKey implements java.security.interfaces.RSAKey
 {
     public static Logger logger = LoggerFactory.getLogger(PK11RSAPrivateKey.class);
 

--- a/org/mozilla/jss/pkcs11/PK11Store.java
+++ b/org/mozilla/jss/pkcs11/PK11Store.java
@@ -6,7 +6,7 @@ package org.mozilla.jss.pkcs11;
 
 import java.math.BigInteger;
 import java.security.PublicKey;
-import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -86,11 +86,11 @@ public final class PK11Store implements CryptoStore {
         // NSS does not provide a function to find the public key of a private key,
         // so it has to be done manually.
 
-        if (privateKey instanceof RSAPrivateKey) {
+        if (privateKey instanceof RSAKey) {
 
             logger.debug("PKCS11Store: searching for RSA public key");
 
-            RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) privateKey;
+            RSAKey rsaPrivateKey = (RSAKey) privateKey;
             BigInteger modulus = rsaPrivateKey.getModulus();
 
             // Find the RSA public key by comparing the modulus.


### PR DESCRIPTION
Per discussion with Andrew Hughes in #java, JCA takes `RSAPrivateKey` to mean that the private exponent is extractable. Because the JCA is careful to use Key most places, we might get away with making `PK11RSAPrivateKey` not implement `RSAPrivateKey` and instead only implement `RSAKey` -- signalling to other providers that the private exponent isn't extractable.

This patch requires careful testing with SunJSSE and Dogtag PKI to ensure we don't rely on `PK11RSAPrivateKey` implementing `RSAPrivateKey` somewhere.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

This patch targets v4.6.x branch -- I'm torn whether or not we should fix v4.7.x+ as we replace the SunJSSE TLS implementation with our own. 