### PR TITLE
Bump tomcatjss, pki-core conflicts due to lang3

### DIFF
--- a/jss.spec
+++ b/jss.spec
@@ -68,8 +68,8 @@ Requires:       apache-commons-lang3
 
 Conflicts:      ldapjdk < 4.20
 Conflicts:      idm-console-framework < 1.2
-Conflicts:      tomcatjss < 7.3.4
-Conflicts:      pki-base < 10.6.5
+Conflicts:      tomcatjss < 7.6.0
+Conflicts:      pki-base < 10.10.0
 
 %description
 Java Security Services (JSS) is a java native interface which provides a bridge


### PR DESCRIPTION
This version of JSS requires apache-commons-lang3 and shouldn't be used
with older version of pki-core as a result.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

As reported by @flo-renaud