### PR TITLE
Only check PKCS11Constants on beta builds -- v4.7.x backport

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -112,7 +112,7 @@ macro(jss_tests)
         COMMAND "org.mozilla.jss.tests.TestGlobalReference"
         MODE "NONE"
     )
-    if ((${Java_VERSION_MAJOR} EQUAL 1) AND (${Java_VERSION_MINOR} LESS 9))
+    if ((${Java_VERSION_MAJOR} EQUAL 1) AND (${Java_VERSION_MINOR} LESS 9) AND (${JSS_VERSION_BETA} EQUAL 1))
         jss_test_java(
             NAME "Test_PKCS11Constants.java_for_Sun_compatibility"
             COMMAND "org.mozilla.jss.tests.TestPKCS11Constants"


### PR DESCRIPTION
Recent errors with PKCS11Constants have shown that we shouldn't be
running these tests on release builds for backports: only for
pre-release content. Only run them when the beta bit is set.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`