### PR TITLE
Attempt to use SecretKeyFactory to rewrite keys prior to failing JSSMacSpi

### DIFF
--- a/org/mozilla/jss/pkcs11/PK11RSAPrivateKey.java
+++ b/org/mozilla/jss/pkcs11/PK11RSAPrivateKey.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PK11RSAPrivateKey
-    extends PK11PrivKey implements java.security.interfaces.RSAPrivateKey
+    extends PK11PrivKey implements java.security.interfaces.RSAKey
 {
     public static Logger logger = LoggerFactory.getLogger(PK11RSAPrivateKey.class);
 

--- a/org/mozilla/jss/pkcs11/PK11Store.java
+++ b/org/mozilla/jss/pkcs11/PK11Store.java
@@ -6,7 +6,7 @@ package org.mozilla.jss.pkcs11;
 
 import java.math.BigInteger;
 import java.security.PublicKey;
-import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -86,11 +86,11 @@ public final class PK11Store implements CryptoStore {
         // NSS does not provide a function to find the public key of a private key,
         // so it has to be done manually.
 
-        if (privateKey instanceof RSAPrivateKey) {
+        if (privateKey instanceof RSAKey) {
 
             logger.debug("PKCS11Store: searching for RSA public key");
 
-            RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) privateKey;
+            RSAKey rsaPrivateKey = (RSAKey) privateKey;
             BigInteger modulus = rsaPrivateKey.getModulus();
 
             // Find the RSA public key by comparing the modulus.


### PR DESCRIPTION
In `JSSCipherSpi`, if a key from another provider is passed in, we first
attempt to export it and then import it into NSS. Only when this fails
do we raise an exception. This fixes a failure in JDK8 272-b10 when
JSS is used in conjunction with SunJSSE:

    javax.net.ssl.SSLHandshakeException: Could not generate secret
            at sun.security.ssl.ECDHKeyExchange$ECDHEKAKeyDerivation.t13DeriveKey(ECDHKeyExchange.java:479)
            at sun.security.ssl.ECDHKeyExchange$ECDHEKAKeyDerivation.deriveKey(ECDHKeyExchange.java:419)
            at sun.security.ssl.ServerHello$T13ServerHelloProducer.produce(ServerHello.java:596)
            at sun.security.ssl.SSLHandshake.produce(SSLHandshake.java:421)
            at sun.security.ssl.ClientHello$T13ClientHelloConsumer.goServerHello(ClientHello.java:1152)
            at sun.security.ssl.ClientHello$T13ClientHelloConsumer.consume(ClientHello.java:1088)
            at sun.security.ssl.ClientHello$ClientHelloConsumer.onClientHello(ClientHello.java:725)
            at sun.security.ssl.ClientHello$ClientHelloConsumer.consume(ClientHello.java:693)
            at sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:377)
            at sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:444)
            at sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:968)
            at sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:955)
            at java.security.AccessController.doPrivileged(Native Method)
            at sun.security.ssl.SSLEngineImpl$DelegatedTask.run(SSLEngineImpl.java:902)
            at org.apache.tomcat.util.net.SecureNioChannel.tasks(SecureNioChannel.java:443)
            at org.apache.tomcat.util.net.SecureNioChannel.handshakeUnwrap(SecureNioChannel.java:507)
            at org.apache.tomcat.util.net.SecureNioChannel.handshake(SecureNioChannel.java:238)
            at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1575)
            at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
            at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
            at java.lang.Thread.run(Thread.java:748)
    Caused by: java.security.InvalidKeyException: Must use a key created by JSS! Try exporting the key data and importing it via SecretKeyFactory.
            at org.mozilla.jss.provider.javax.crypto.JSSMacSpi.engineInit(JSSMacSpi.java:58)
            at org.mozilla.jss.provider.javax.crypto.JSSMacSpi$HmacSHA384.engineInit(JSSMacSpi.java:116)
            at javax.crypto.Mac.init(Mac.java:413)
            at sun.security.ssl.HKDF.extract(HKDF.java:91)
            at sun.security.ssl.HKDF.extract(HKDF.java:119)
            at sun.security.ssl.ECDHKeyExchange$ECDHEKAKeyDerivation.t13DeriveKey(ECDHKeyExchange.java:469)

Because JDK recently introduced a new TLS stack for TLS-1.3 support in
JDK 8, most people will find value moving to JSS's SSLEngine instead of
continuing to use SunJSSE with JSS as the crypto provider.

----

This also pulls in the v4.6.x-only patch about `RSAPrivateKey` vs `RSAKey` usage. 