### PR TITLE
Update CI to use Fedora 31, 32

### DIFF
--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -9,13 +9,6 @@ on:
     - v4.6.x
 
 jobs:
-  fedora30:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Clone the repository
-      uses: actions/checkout@v2
-    - name: Build and Run the Docker Image
-      run: bash tools/run_container.sh "fedora_30"
   fedora31:
     runs-on: ubuntu-latest
     steps:
@@ -23,3 +16,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Build and Run the Docker Image
       run: bash tools/run_container.sh "fedora_31"
+  fedora32:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: Build and Run the Docker Image
+      run: bash tools/run_container.sh "fedora_32"

--- a/tools/Dockerfiles/fedora_32
+++ b/tools/Dockerfiles/fedora_32
@@ -1,0 +1,30 @@
+FROM registry.fedoraproject.org/fedora:32
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/master} \
+        && dnf build-dep -y jss \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Install dependencies from the spec file in case they've changed
+# since the last release on this platform.
+RUN true \
+        && dnf build-dep -y --spec /home/sandbox/jss/jss.spec \
+        && true
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && bash ./build.sh --with-timestamp --with-commit-id rpm \
+        && dnf install -y /root/build/jss/RPMS/*.rpm \
+        && true

--- a/tools/Dockerfiles/fedora_33
+++ b/tools/Dockerfiles/fedora_33
@@ -1,0 +1,30 @@
+FROM registry.fedoraproject.org/fedora:33
+
+# Install generic dependencies to build jss
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y dnf-plugins-core gcc make rpm-build \
+        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/master} \
+        && dnf build-dep -y jss \
+        && mkdir -p /home/sandbox \
+        && dnf clean -y all \
+        && rm -rf /usr/share/doc /usr/share/doc-base \
+                  /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+        && true
+
+# Link in the current version of jss from the git repository
+WORKDIR /home/sandbox
+COPY . /home/sandbox/jss
+
+# Install dependencies from the spec file in case they've changed
+# since the last release on this platform.
+RUN true \
+        && dnf build-dep -y --spec /home/sandbox/jss/jss.spec \
+        && true
+
+# Perform the actual RPM build
+WORKDIR /home/sandbox/jss
+CMD true \
+        && bash ./build.sh --with-timestamp --with-commit-id rpm \
+        && dnf install -y /root/build/jss/RPMS/*.rpm \
+        && true


### PR DESCRIPTION
This is a little newer than what we'd prefer, but F30 image isn't working any more.

**Note**: As of the time of this PR, F31 is still supported for 7 more days. F33 introduces changes to RPM Spec file building (out-of-source directories, as if we weren't already doing that...)  that break v4.6.x's spec file. I'd prefer not to backport those changes, so I went with F31/F32. 