### PR TITLE
Set CMake required version to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 # This is the CMakeLists.txt for the JSS Project.
 project(jss)
 
-# Required cmake version; set a 3.0.2 since that's the version of the
-# documentation I referenced.
-cmake_minimum_required(VERSION 3.0.2)
+# Required cmake version; set a 3.14.2 since we need LINK_OPTIONS in
+# try_compile.
+cmake_minimum_required(VERSION 3.14.0)
 
 # Source our custom CMake modules; this includes NSS and NSPR modules from
 # PKI and the JSSConfig and JSSCommon modules.

--- a/jss.spec
+++ b/jss.spec
@@ -33,7 +33,7 @@ Source:         https://github.com/dogtagpki/%{name}/archive/v%{version}%{?_phas
 # autosetup
 BuildRequires:  git
 BuildRequires:  make
-BuildRequires:  cmake
+BuildRequires:  cmake >= 3.14
 BuildRequires:  zip
 BuildRequires:  unzip
 


### PR DESCRIPTION
This includes the `LINK_OPTIONS` flag to `try_compile`, allowing us to
detect features of NSS (such as OAEP).

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`