### PR TITLE
Fix exception handling in Cert.mapCertFromPKCS7()

### DIFF
--- a/org/mozilla/jss/netscape/security/util/Cert.java
+++ b/org/mozilla/jss/netscape/security/util/Cert.java
@@ -147,7 +147,7 @@ public class Cert {
         try {
             p7 = new PKCS7(rawPub);
         } catch (Exception e) {
-            throw new IOException("p7 is null");
+            throw new IOException("Unable to parse PKCS #7 data: " + e.getMessage(), e);
         }
         return p7.getCertificates();
     }


### PR DESCRIPTION
The `Cert.mapCertFromPKCS7()` has been modified to chain
the original exception to help troubleshooting.