### PR TITLE
Add CertificateChain converters

### DIFF
--- a/org/mozilla/jss/netscape/security/pkcs/PKCS7.java
+++ b/org/mozilla/jss/netscape/security/pkcs/PKCS7.java
@@ -344,11 +344,9 @@ public class PKCS7 {
                 implCerts[i] = (X509CertImpl) certificates[i];
             }
         } catch (ClassCastException e) {
-            IOException ioe =
-                    new IOException("Certificates in PKCS7 " +
-                            "must be of class " +
-                            "org.mozilla.jss.netscape.security.X509CertImpl");
-            ioe.fillInStackTrace();
+            throw new IOException(
+                    "Certificates in PKCS7 must be of class " +
+                    "org.mozilla.jss.netscape.security.X509CertImpl: " + e.getMessage(), e);
         }
 
         // Add the certificate set (tagged with [0] IMPLICIT)


### PR DESCRIPTION
The `CertificateChain` class has been modified to support importing/exporting certificates from/to a series of PEM certificates or PKCS #7 data. This is needed for https://github.com/dogtagpki/pki/pull/3459.

Note: The some of the CI tests are failing due to an existing issue.