### PR TITLE
Fix build preference in tools/run_container.sh

### DIFF
--- a/tools/run_container.sh
+++ b/tools/run_container.sh
@@ -27,21 +27,7 @@ function rc_run() {
         exit 1
     fi
 
-    if rc_buildah; then
-        buildah bud --pull-always --tag "jss_$image:latest" -f "tools/Dockerfiles/$image" .
-        ret="$?"
-        if [ "x$ret" != "x0" ]; then
-            echo "Container build exited with status: $ret"
-            return $ret
-        fi
-
-        podman run "jss_$image:latest"
-        ret="$?"
-        if [ "x$ret" != "x0" ]; then
-            echo "Container run exited with status: $ret"
-            return $ret
-        fi
-    elif rc_docker; then
+    if rc_docker; then
         docker build --pull --tag "jss_$image:latest" -f "tools/Dockerfiles/$image" .
         ret="$?"
         if [ "x$ret" != "x0" ]; then
@@ -50,6 +36,20 @@ function rc_run() {
         fi
 
         docker run "jss_$image:latest"
+        ret="$?"
+        if [ "x$ret" != "x0" ]; then
+            echo "Container run exited with status: $ret"
+            return $ret
+        fi
+    elif rc_buildah; then
+        buildah bud --pull-always --tag "jss_$image:latest" -f "tools/Dockerfiles/$image" .
+        ret="$?"
+        if [ "x$ret" != "x0" ]; then
+            echo "Container build exited with status: $ret"
+            return $ret
+        fi
+
+        podman run "jss_$image:latest"
         ret="$?"
         if [ "x$ret" != "x0" ]; then
             echo "Container run exited with status: $ret"


### PR DESCRIPTION
Per @cipherboy's suggestion the `tools/run_container.sh` has
been modified to use `docker` instead of `buildah`/`podman`
if available.