### PR TITLE
Convert SymmetricKey.Usage into enumeration

### DIFF
--- a/org/mozilla/jss/crypto/KeyPairGeneratorSpi.java
+++ b/org/mozilla/jss/crypto/KeyPairGeneratorSpi.java
@@ -58,7 +58,7 @@ public abstract class KeyPairGeneratorSpi {
         UNWRAP         (PKCS11Constants.CKF_UNWRAP),
         DERIVE         (PKCS11Constants.CKF_DERIVE);
 
-        long value;
+        private final long value;
 
         Usage(long value) {
             this.value = value;
@@ -71,7 +71,7 @@ public abstract class KeyPairGeneratorSpi {
         public int getVal() { return ordinal(); }
 
         /**
-         * Get PKCS #11 constant.
+         * Get PKCS #11 CKF_ value.
          */
         public long value() { return value; }
     }

--- a/org/mozilla/jss/crypto/SymmetricKey.java
+++ b/org/mozilla/jss/crypto/SymmetricKey.java
@@ -7,8 +7,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Hashtable;
 
-import org.mozilla.jss.pkcs11.PKCS11Constants;
 import org.mozilla.jss.pkcs11.KeyType;
+import org.mozilla.jss.pkcs11.PKCS11Constants;
 
 public interface SymmetricKey extends javax.crypto.SecretKey {
 
@@ -144,26 +144,40 @@ public interface SymmetricKey extends javax.crypto.SecretKey {
      * <p>When you unwrap a symmetric key, you must specify which one of these
      * operations it will be used to perform.
      */
-    public final static class Usage {
-        private Usage() { }
-        private Usage(int val, long pk11_val) {
-            this.val = val;
-            this.pk11_val = pk11_val;
+    public enum Usage {
+
+        ENCRYPT        (PKCS11Constants.CKF_ENCRYPT, PKCS11Constants.CKA_ENCRYPT),
+        DECRYPT        (PKCS11Constants.CKF_DECRYPT, PKCS11Constants.CKA_DECRYPT),
+        WRAP           (PKCS11Constants.CKF_WRAP,    PKCS11Constants.CKA_WRAP),
+        UNWRAP         (PKCS11Constants.CKF_UNWRAP,  PKCS11Constants.CKA_UNWRAP),
+        SIGN           (PKCS11Constants.CKF_SIGN,    PKCS11Constants.CKA_SIGN),
+        VERIFY         (PKCS11Constants.CKF_VERIFY,  PKCS11Constants.CKA_VERIFY);
+
+        private final long value;
+        private final long cka_value;
+
+        Usage(long value, long cka_value) {
+            this.value = value;
+            this.cka_value = cka_value;
         }
 
-        private int val;
-        private long pk11_val;
+        /**
+         * @deprecated Use <code>ordinal()</code> instead.
+         */
+        @Deprecated
+        public int getVal() { return ordinal(); }
 
-        public int getVal() { return val; }
-        public long getPKCS11Constant() { return pk11_val; }
+        /**
+         * Get PKCS #11 CKF_ value.
+         */
+        public long value() { return value; }
 
-        // these enums must match the JSS_symkeyUsage list in Algorithm.c
-        // and the opFlagForUsage list in PK11KeyGenerator.java
-        public static final Usage ENCRYPT = new Usage(0, PKCS11Constants.CKA_ENCRYPT);
-        public static final Usage DECRYPT = new Usage(1, PKCS11Constants.CKA_DECRYPT);
-        public static final Usage WRAP = new Usage(2, PKCS11Constants.CKA_WRAP);
-        public static final Usage UNWRAP = new Usage(3, PKCS11Constants.CKA_UNWRAP);
-        public static final Usage SIGN = new Usage(4, PKCS11Constants.CKA_SIGN);
-        public static final Usage VERIFY = new Usage(5, PKCS11Constants.CKA_VERIFY);
+        /**
+         * Get PKCS #11 CKA_ value.
+         *
+         * @deprecated Use <code>value()</code> to get PKCS #11 CKF_ value instead.
+         */
+        @Deprecated
+        public long getPKCS11Constant() { return cka_value; }
     }
 }

--- a/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
+++ b/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
@@ -13,22 +13,22 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Arrays;
 
-import javax.crypto.spec.RC2ParameterSpec;
 import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.RC2ParameterSpec;
 
 import org.mozilla.jss.crypto.Algorithm;
 import org.mozilla.jss.crypto.EncryptionAlgorithm;
-import org.mozilla.jss.crypto.JSSOAEPParameterSpec;
 import org.mozilla.jss.crypto.HMACAlgorithm;
 import org.mozilla.jss.crypto.IVParameterSpec;
+import org.mozilla.jss.crypto.JSSOAEPParameterSpec;
 import org.mozilla.jss.crypto.KeyPairAlgorithm;
 import org.mozilla.jss.crypto.KeyWrapAlgorithm;
 import org.mozilla.jss.crypto.KeyWrapper;
 import org.mozilla.jss.crypto.PrivateKey;
 import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.TokenException;
-import org.mozilla.jss.util.NativeProxy;
 import org.mozilla.jss.util.NativeEnclosure;
+import org.mozilla.jss.util.NativeProxy;
 
 public final class PK11KeyWrapper implements KeyWrapper {
 
@@ -491,7 +491,7 @@ public final class PK11KeyWrapper implements KeyWrapper {
         throws TokenException, IllegalStateException,
             InvalidAlgorithmParameterException
     {
-        return unwrapSymmetric(wrapped, type, usage.getVal(), keyLen);
+        return unwrapSymmetric(wrapped, type, usage.ordinal(), keyLen);
     }
 
     public SymmetricKey
@@ -508,7 +508,7 @@ public final class PK11KeyWrapper implements KeyWrapper {
         throws TokenException, IllegalStateException,
             InvalidAlgorithmParameterException
     {
-        return unwrapSymmetricPerm(wrapped, type, usage.getVal(), keyLen);
+        return unwrapSymmetricPerm(wrapped, type, usage.ordinal(), keyLen);
     }
 
     public SymmetricKey


### PR DESCRIPTION
The `SymmetricKey.Usage` class has been converted into an
enumeration that defines the same elements. These elements
store the corresponding PKCS #11 `CKF_` and `CKA_` values
although the `CKA_` values are not actually used.

The `getVal()` and `getPKCS11Constant()` method have been
deprecated, but they will continue to work as before for
backward compatibility.

The `opFlags` field in `PK11KeyGenerator` has been converted
to `long` to match the PKCS #11 value. The value will be
downcasted to `int` whenever needed.

The `opFlagForUsage` array in `PK11KeyGenerator` has become
redundant since the PKCS #11 value can be obtained from
the enumeration elements, so it has been removed.