### PR TITLE
Add CA installation test

### DIFF
--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -1,0 +1,108 @@
+name: PKI Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Building JSS
+    runs-on: ubuntu-latest
+    env:
+      COPR_REPO: "@pki/master"
+    strategy:
+      matrix:
+        os: ['32', '33']
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build runner image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ env.COPR_REPO }}
+            BUILD_OPTS=--with-timestamp --with-commit-id
+          tags: jss-runner
+          target: jss-runner
+          outputs: type=docker,dest=/tmp/jss-runner.tar
+
+      - name: Upload runner image
+        uses: actions/upload-artifact@v2
+        with:
+          name: jss-runner-${{ matrix.os }}
+          path: /tmp/jss-runner.tar
+
+  ca-test:
+    name: Installing CA
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/jss
+      COPR_REPO: "@pki/master"
+    strategy:
+      matrix:
+        os: ['32', '33']
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download runner image
+        uses: actions/download-artifact@v2
+        with:
+          name: jss-runner-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load runner image
+        run: docker load --input /tmp/jss-runner.tar
+
+      - name: Run container
+        run: |
+          IMAGE=jss-runner \
+          NAME=pki \
+          HOSTNAME=pki.example.com \
+          tests/bin/runner-init.sh
+
+      - name: Install DS and PKI packages
+        run: docker exec pki dnf install -y 389-ds-base pki-ca
+
+      - name: Install DS
+        run: docker exec pki ${SHARED}/tests/bin/ds-create.sh
+
+      - name: Install CA
+        run: docker exec pki pkispawn -f /usr/share/pki/server/examples/installation/ca.cfg -s CA -v
+
+      - name: Run PKI healthcheck
+        run: docker exec pki pki-healthcheck --debug
+
+      - name: Verify CA admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh pki
+          tests/bin/pki-artifacts-save.sh pki
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Remove DS
+        run: docker exec pki ${SHARED}/tests/bin/ds-remove.sh
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ca-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-bin
+/bin
 *.OBJ/
 
 # CMake build directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+ARG OS_VERSION="latest"
+ARG COPR_REPO="@pki/master"
+
+################################################################################
+FROM registry.fedoraproject.org/fedora:$OS_VERSION AS jss-builder
+
+ARG COPR_REPO
+ARG BUILD_OPTS
+
+# Enable COPR repo if specified
+RUN if [ -n "$COPR_REPO" ]; then dnf install -y dnf-plugins-core; dnf copr enable -y $COPR_REPO; fi
+
+# Import JSS sources
+COPY . /tmp/jss/
+WORKDIR /tmp/jss
+
+# Build JSS packages
+RUN dnf install -y rpm-build
+RUN dnf builddep -y --spec jss.spec
+RUN ./build.sh $BUILD_OPTS --work-dir=build rpm
+
+################################################################################
+FROM registry.fedoraproject.org/fedora:$OS_VERSION AS jss-runner
+
+ARG COPR_REPO
+
+EXPOSE 389 8080 8443
+
+# Enable COPR repo if specified
+RUN if [ -n "$COPR_REPO" ]; then dnf install -y dnf-plugins-core; dnf copr enable -y $COPR_REPO; fi
+
+# Import JSS packages
+COPY --from=jss-builder /tmp/jss/build/RPMS /tmp/RPMS/
+
+# Install JSS packages
+RUN dnf localinstall -y /tmp/RPMS/*; rm -rf /tmp/RPMS
+
+# Install systemd to run the container
+RUN dnf install -y systemd
+
+CMD [ "/usr/sbin/init" ]

--- a/tests/bin/ds-artifacts-save.sh
+++ b/tests/bin/ds-artifacts-save.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+CONTAINER=$1
+INSTANCE=$2
+
+if [ "$INSTANCE" == "" ]
+then
+    INSTANCE=localhost
+fi
+
+ARTIFACTS=/tmp/artifacts/$CONTAINER
+
+mkdir -p $ARTIFACTS/etc
+mkdir -p $ARTIFACTS/var/log
+
+docker exec $CONTAINER ls -la /etc/dirsrv
+docker cp $CONTAINER:/etc/dirsrv $ARTIFACTS/etc
+
+docker exec $CONTAINER ls -la /var/log/dirsrv
+docker cp $CONTAINER:/var/log/dirsrv $ARTIFACTS/var/log
+docker exec $CONTAINER journalctl -u dirsrv@$INSTANCE.service > $ARTIFACTS/var/log/dirsrv/slapd-$INSTANCE/systemd.log

--- a/tests/bin/ds-create.sh
+++ b/tests/bin/ds-create.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+# This command needs to be executed as it pulls the machine name
+# dynamically.
+dscreate create-template ds.inf
+
+sed -i \
+    -e "s/;instance_name = .*/instance_name = localhost/g" \
+    -e "s/;root_password = .*/root_password = Secret.123/g" \
+    -e "s/;suffix = .*/suffix = dc=example,dc=com/g" \
+    -e "s/;self_sign_cert = .*/self_sign_cert = False/g" \
+    ds.inf
+
+dscreate from-file ds.inf
+
+ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 << EOF
+dn: dc=example,dc=com
+objectClass: domain
+dc: example
+
+dn: dc=pki,dc=example,dc=com
+objectClass: domain
+dc: pki
+EOF

--- a/tests/bin/ds-remove.sh
+++ b/tests/bin/ds-remove.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+dsctl slapd-localhost remove --do-it

--- a/tests/bin/pki-artifacts-save.sh
+++ b/tests/bin/pki-artifacts-save.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+CONTAINER=$1
+INSTANCE=$2
+
+if [ "$INSTANCE" == "" ]
+then
+    INSTANCE=pki-tomcat
+fi
+
+ARTIFACTS=/tmp/artifacts/$CONTAINER
+
+mkdir -p $ARTIFACTS/etc/pki
+mkdir -p $ARTIFACTS/var/log
+
+docker exec $CONTAINER ls -la /etc/pki
+docker cp $CONTAINER:/etc/pki/pki.conf $ARTIFACTS/etc/pki
+docker cp $CONTAINER:/etc/pki/$INSTANCE $ARTIFACTS/etc/pki
+
+docker exec $CONTAINER ls -la /var/log/pki
+docker cp $CONTAINER:/var/log/pki $ARTIFACTS/var/log
+docker exec $CONTAINER journalctl -u pki-tomcatd@$INSTANCE.service > $ARTIFACTS/var/log/pki/$INSTANCE/systemd.log

--- a/tests/bin/runner-init.sh
+++ b/tests/bin/runner-init.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -ex
+
+docker run \
+    --name=${NAME} \
+    --hostname=${HOSTNAME} \
+    --detach \
+    --privileged \
+    --tmpfs /tmp \
+    --tmpfs /run \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+    -v ${GITHUB_WORKSPACE}:${SHARED} \
+    -i \
+    ${IMAGE}
+
+# Pause 5 seconds to let the container start up.
+# The container uses /usr/sbin/init as its entrypoint which requires few seconds
+# to startup. This avoids the following error:
+# [Errno 2] No such file or directory: '/var/cache/dnf/metadata_lock.pid'
+sleep 5


### PR DESCRIPTION
A `Dockerfile` has been added to define the builder image and test
runner image for JSS. The builder image is used to install the
build dependencies and then build JSS. The test runner image is
used to install JSS with its runtime dependencies then run tests.

A new test has been added to install DS and CA with the newly
built JSS packages.

Some scripts have been added to initialize the test runner, to
create and remove DS, and to save the test artifacts.