### PR TITLE
Add PKCS11Constants test for Fedora 34

### DIFF
--- a/tools/Dockerfiles/fedora_34
+++ b/tools/Dockerfiles/fedora_34
@@ -29,4 +29,20 @@ WORKDIR /home/sandbox/jss
 CMD true \
         && bash ./build.sh --with-timestamp --with-commit-id rpm \
         && dnf install -y /root/build/jss/RPMS/*.rpm \
+        && echo "############################################################" \
+        && echo "## Generating PKCS #11 constants with Python 2" \
+        && python2 ./tools/build_pkcs11_constants.py \
+                   --pkcs11t /usr/include/nss3/pkcs11t.h \
+                   --pkcs11n /usr/include/nss3/pkcs11n.h \
+                   -o PKCS11Constants-py2.java \
+                   --verbose \
+        && echo "############################################################" \
+        && echo "## Generating PKCS #11 constants with Python 3" \
+        && python3 ./tools/build_pkcs11_constants.py -s \
+                   --pkcs11t /usr/include/nss3/pkcs11t.h \
+                   --pkcs11n /usr/include/nss3/pkcs11n.h \
+                   -o PKCS11Constants-py3.java \
+                   --verbose \
+        && diff PKCS11Constants-py2.java PKCS11Constants-py3.java \
+        && diff PKCS11Constants-py3.java src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java \
         && true

--- a/tools/build_pkcs11_constants.py
+++ b/tools/build_pkcs11_constants.py
@@ -202,7 +202,11 @@ class ConstantDefinition(object):
         # Build a minimal cc call; note that nss_args is the output from
         # pkg-config such that we can correctly link this program and
         # have the correct includes for nss.
-        cc_call = ["cc", "-o", exec_path, path] + nss_args
+        #
+        # Define NSS_PKCS11_2_0_COMPAT due to NSS changes:
+        # https://fedoraproject.org/wiki/Changes/NssGCMParams
+
+        cc_call = ["cc", "-DNSS_PKCS11_2_0_COMPAT", "-o", exec_path, path] + nss_args
         logger.debug("Command: %s", ' '.join(cc_call))
 
         proc = subprocess.Popen(cc_call, stdout=subprocess.PIPE,


### PR DESCRIPTION
This PR depends on PR #740.

Currently the PKCS #11 constants test is failing on Fedora 34 and Rawhide:
```
/tmp/tmp-jss-pkcs11constants-zbw7io_w/test.c: In function ‘main’:
/tmp/tmp-jss-pkcs11constants-zbw7io_w/test.c:6:17: error: ‘CKF_EC_FP’ undeclared (first use in this function); did you mean ‘CKF_EC_F_P’?
    6 |             if (CKF_EC_FP != 0x00100000) {
      |                 ^~~~~~~~~
      |                 CKF_EC_F_P
/tmp/tmp-jss-pkcs11constants-zbw7io_w/test.c:6:17: note: each undeclared identifier is reported only once for each function it appears in



    main()
  File "/home/sandbox/jss/./tools/build_pkcs11_constants.py", line 806, in main
    check_references(objs)
  File "/home/sandbox/jss/./tools/build_pkcs11_constants.py", line 610, in check_references
    obj.check_output(nss_args)
  File "/home/sandbox/jss/./tools/build_pkcs11_constants.py", line 229, in check_output
    raise Exception(("Unknown error with symbol '%s': cc ret: %d " +
Exception: Unknown error with symbol 'CKF_EC_FP': cc ret: 1 @ /tmp/tmp-jss-pkcs11constants-zbw7io_w; command: cc -o /tmp/tmp-jss-pkcs11constants-zbw7io_w/test.exe /tmp/tmp-jss-pkcs11constants-zbw7io_w/test.c -I/usr/include/nss3 -I/usr/include/nspr4 -lssl3 -lsmime3 -lnss3 -lnssutil3 -lplds4 -lplc4 -lnspr4 -lpthread -ldl
Container run exited with status: 1
Error: Process completed with exit code 1.
```
