### PR TITLE
Add pom.xml and test for Maven

### DIFF
--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -1,0 +1,15 @@
+name: Maven Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Building JSS
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+
+    - name: Build JSS package
+      run: mvn package

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
+# Ignore build directories and artifacts
 /bin
 *.OBJ/
-
-# CMake build directory
 build/
+src/*.a
+src/*.o
+target/
 
 # These files are automatically generated from their .in equivalents
+org/mozilla/jss/util/jssver.h
+org/mozilla/jss/jssconfig.h
 src/main/java/org/mozilla/jss/util/jssver.h
 src/main/java/org/mozilla/jss/jssconfig.h

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.dogtagpki.jss</groupId>
+    <artifactId>jss</artifactId>
+    <version>4.9.0-SNAPSHOT</version>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.12</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.11</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.25</version>
+            <scope>runtime</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
This PR adds a basic `pom.xml` to build JSS and run the unit tests using Maven on Java 11.

A GitHub workflow is added to execute the build and the tests automatically on every check-in.

There is an existing PR (#636) by @cipherboy but it's not ready to be merged as is. Basically we're breaking it into smaller PRs and incrementally incorporate the elements from that PR. Once all elements are merged we can close it too.
