### PR TITLE
Update .gitignore for JSS 4.4

### DIFF
--- a/.github/workflows/required-v4.4.x.yml
+++ b/.github/workflows/required-v4.4.x.yml
@@ -1,28 +1,8 @@
 name: Required Tests for v4.4.x branch
 
-on:
-  push:
-    branches:
-    - v4.4.x
-  pull_request:
-    branches:
-    - v4.4.x
+on: [push, pull_request]
 
 jobs:
-  fedora26:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Clone the repository
-      uses: actions/checkout@v2
-    - name: Build and Run the Docker Image
-      run: bash tools/run_container.sh "fedora_26"
-  fedora29:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Clone the repository
-      uses: actions/checkout@v2
-    - name: Build and Run the Docker Image
-      run: bash tools/run_container.sh "fedora_29"
   fedora31:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,13 @@
-bin
+# Ignore build directories and artifacts
+/bin
+*.OBJ/
+build/
+src/*.a
+src/*.o
+target/
+
+# These files are automatically generated from their .in equivalents
+org/mozilla/jss/util/jssver.h
+org/mozilla/jss/jssconfig.h
+src/main/java/org/mozilla/jss/util/jssver.h
+src/main/java/org/mozilla/jss/jssconfig.h


### PR DESCRIPTION
There is no CI for this branch.

**Edit:** Apparently there are CI tests in this branch, but they run under a specific [branch name](https://github.com/dogtagpki/jss/blob/v4.4.x/.github/workflows/required-v4.4.x.yml#L5-L9) only. Thanks to @cipherboy, I've updated the workflow to run under all branch names, and dropped the outdated tests.