### PR TITLE
Fix -sourcepath for java test compilation

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -293,7 +293,7 @@ macro(jss_config_java)
     list(APPEND JSS_TEST_JAVAC_FLAGS "-classpath")
     list(APPEND JSS_TEST_JAVAC_FLAGS "${JAVAC_CLASSPATH}:${JUNIT4_JAR}:${CLASSES_OUTPUT_DIR}")
     list(APPEND JSS_TEST_JAVAC_FLAGS "-sourcepath")
-    list(APPEND JSS_TEST_JAVAC_FLAGS "${PROJECT_SOURCE_DIR}/src/test/java")
+    list(APPEND JSS_TEST_JAVAC_FLAGS "${PROJECT_SOURCE_DIR}/src/main/java")
 
     # Ensure we're compatible with JDK 8
     list(APPEND JSS_TEST_JAVAC_FLAGS "-target")


### PR DESCRIPTION
`man javac` has the following to say about `-sourcepath`:

> Specifies the source code path to search for class or interface
> definitions.

In particular, the way the CMake step is constructed, the test paths are
specified via file (hence `@${JAVA_TEST_SOURCES_FILE}` as an argument to
`javac`), but the compiling the tests still needs knowledge of the main
JSS source.

In this case, `sourcepath` (for test compilation) was incorrectly updated
to point back at the list of sources we already provided (or, the
directory containing the sources we already provided) instead of
pointing at the path of the main JSS code.

Prior to this change, compilation depended on order steps were executed
and could fail with the following error (if tests were attempted to be
built prior to main sources finishing building):

    ...snip...
    /home/cipherboy/GitHub/cipherboy/jss/src/test/java/org/mozilla/jss/tests/IA5StringTest.java:7: error: package org.mozilla.jss.netscape.security.util does not exist
    import org.mozilla.jss.netscape.security.util.DerValue;
                                                 ^
    ...snip...
    Note: Some input files use or override a deprecated API.
    Note: Recompile with -Xlint:deprecation for details.
    Note: Some messages have been simplified; recompile with -Xdiags:verbose to get full output
    100 errors
    11 warnings

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`

----

Note that the Mavenize JSS PR (#636) used the following:

```
list(APPEND JSS_TEST_JAVAC_FLAGS "${PROJECT_SOURCE_DIR}/jss/src/main/java:${PROJECT_SOURCE_DIR}/jss/src/test/java")
```

My belief is that the test portion of the above is overkill because all relevant test `.java` files are already present in the glob supplied in the file list. So we only need the main portion. :-) 