### PR TITLE
Fix return from finally in JSSSocketChannel

### DIFF
--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -388,20 +388,16 @@ public class JSSSocketChannel extends SocketChannel {
             engine.cleanup();
             engine = null;
 
-            if (parent == null) {
-                if (autoClose) {
+            if (autoClose) {
+                if (parent == null) {
                     parentSocket.shutdownInput();
                     parentSocket.shutdownOutput();
                     parentSocket.close();
+                } else {
+                    parent.shutdownInput();
+                    parent.shutdownOutput();
+                    parent.close();
                 }
-
-                return;
-            }
-
-            if (autoClose) {
-                parent.shutdownInput();
-                parent.shutdownOutput();
-                parent.close();
             }
         }
     }


### PR DESCRIPTION
Sonar reports the following on the (now removed) return statement:

> Remove this return statement from this finally block.
>
> Using `return`, `break`, `throw`, and so on from a `finally` block suppresses
> the propagation of any unhandled `Throwable` which was thrown in the
> `try` or `catch` block.

Re-do the logic to fix this bug.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

---

Note that this is likely a popular path as most sockets we construct will be `Socket` instances and not `SocketChannel`s. 