### PR TITLE
Add missing synchronized keywords to Sockets

### DIFF
--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocket.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocket.java
@@ -511,12 +511,12 @@ public class JSSServerSocket extends SSLServerSocket {
     }
 
     @Override
-    public int getSoTimeout() throws IOException {
+    public synchronized int getSoTimeout() throws IOException {
         return parent.getSoTimeout();
     }
 
     @Override
-    public void setSoTimeout(int timeout) throws SocketException {
+    public synchronized void setSoTimeout(int timeout) throws SocketException {
         parent.setSoTimeout(timeout);
     }
 
@@ -531,12 +531,12 @@ public class JSSServerSocket extends SSLServerSocket {
     }
 
     @Override
-    public int getReceiveBufferSize() throws SocketException {
+    public synchronized int getReceiveBufferSize() throws SocketException {
         return parent.getReceiveBufferSize();
     }
 
     @Override
-    public void setReceiveBufferSize(int size) throws SocketException {
+    public synchronized void setReceiveBufferSize(int size) throws SocketException {
         parent.setReceiveBufferSize(size);
     }
 

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
@@ -703,7 +703,7 @@ public class JSSSocket extends SSLSocket {
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         getInternalChannel().close();
         engine.cleanup();
         engine = null;
@@ -772,12 +772,12 @@ public class JSSSocket extends SSLSocket {
     }
 
     @Override
-    public int getSoTimeout() throws SocketException {
+    public synchronized int getSoTimeout() throws SocketException {
         return parent.getSoTimeout();
     }
 
     @Override
-    public void setSoTimeout(int timeout) throws SocketException {
+    public synchronized void setSoTimeout(int timeout) throws SocketException {
         parent.setSoTimeout(timeout);
     }
 
@@ -797,22 +797,22 @@ public class JSSSocket extends SSLSocket {
     }
 
     @Override
-    public int getSendBufferSize() throws SocketException {
+    public synchronized int getSendBufferSize() throws SocketException {
         return parent.getSendBufferSize();
     }
 
     @Override
-    public void setSendBufferSize(int size) throws SocketException {
+    public synchronized void setSendBufferSize(int size) throws SocketException {
         parent.setSendBufferSize(size);
     }
 
     @Override
-    public int getReceiveBufferSize() throws SocketException {
+    public synchronized int getReceiveBufferSize() throws SocketException {
         return parent.getReceiveBufferSize();
     }
 
     @Override
-    public void setReceiveBufferSize(int size) throws SocketException {
+    public synchronized void setReceiveBufferSize(int size) throws SocketException {
         parent.setReceiveBufferSize(size);
     }
 


### PR DESCRIPTION
Due to the new `@Override` method, Sonar has caught missing synchronized
keywords on several `JSSSocket` and `JSSServerSocket` methods.

> Make this method "`synchronized`" to match the parent class
> implementation.
>
> When `@Overrides` of `synchronized` methods are not themselves
> `synchronized`, the result can be improper synchronization as callers
> rely on the thread-safety promised by the parent class.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`