### PR TITLE
Bump ubuntu_jdk8 -> 11 in github CI workflows

### DIFF
--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -13,7 +13,7 @@ jobs:
           - 'fedora_latest_jdk11'
           - 'symbolcheck'
           - 'debian_jdk11'
-          - 'ubuntu_jdk8'
+          - 'ubuntu_jdk11'
           # Disable tests due to missing dependencies
           # - 'centos_7'
           # - 'centos_8'

--- a/tools/Dockerfiles/ubuntu_jdk11
+++ b/tools/Dockerfiles/ubuntu_jdk11
@@ -6,7 +6,7 @@ RUN true \
         && apt-get update \
         && apt-get dist-upgrade -y \
         && apt-get install -y debhelper libnss3-dev libnss3-tools libnss3 \
-                              openjdk-8-jdk pkg-config quilt g++ mercurial \
+                              openjdk-11-jdk pkg-config quilt g++ mercurial \
                               zlib1g-dev libslf4j-java liblog4j2-java \
                               libcommons-lang3-java libjaxb-api-java cmake \
                               zip unzip junit4 \


### PR DESCRIPTION
I used some Java 11 syntax and this test failed (correctly, of course).

We should update this workflow to use OpenJDK11 so we can make use of new language features