### PR TITLE
Add logger for build_pkcs11_constants.py

### DIFF
--- a/tools/Dockerfiles/fedora_33
+++ b/tools/Dockerfiles/fedora_33
@@ -29,14 +29,20 @@ WORKDIR /home/sandbox/jss
 CMD true \
         && bash ./build.sh --with-timestamp --with-commit-id rpm \
         && dnf install -y /root/build/jss/RPMS/*.rpm \
+        && echo "############################################################" \
+        && echo "## Generating PKCS #11 constants with Python 2" \
         && python2 ./tools/build_pkcs11_constants.py \
                    --pkcs11t /usr/include/nss3/pkcs11t.h \
                    --pkcs11n /usr/include/nss3/pkcs11n.h \
                    -o PKCS11Constants-py2.java \
+                   --verbose \
+        && echo "############################################################" \
+        && echo "## Generating PKCS #11 constants with Python 3" \
         && python3 ./tools/build_pkcs11_constants.py -s \
                    --pkcs11t /usr/include/nss3/pkcs11t.h \
                    --pkcs11n /usr/include/nss3/pkcs11n.h \
                    -o PKCS11Constants-py3.java \
+                   --verbose \
         && diff PKCS11Constants-py2.java PKCS11Constants-py3.java \
         && diff PKCS11Constants-py3.java src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java \
         && true


### PR DESCRIPTION
The `build_pkcs11_constants.py` has been modified to send log messages to the screen instead of storing them in the output file. This way the output file will remain constant regardless how the tool was executed, and the log messages can be viewed without
having to open the output file which will make it easier to troubleshoot issues.