### PR TITLE
Drop git dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY . /tmp/jss/
 WORKDIR /tmp/jss
 
 # Build JSS packages
-RUN dnf install -y rpm-build
+RUN dnf install -y git rpm-build
 RUN dnf builddep -y --spec jss.spec
 RUN ./build.sh $BUILD_OPTS --work-dir=build rpm
 

--- a/jss.spec
+++ b/jss.spec
@@ -41,8 +41,6 @@ Source:         https://github.com/dogtagpki/%{name}/archive/v%{version}%{?_phas
 # Build Dependencies
 ################################################################################
 
-# autosetup
-BuildRequires:  git
 BuildRequires:  make
 BuildRequires:  cmake >= 3.14
 BuildRequires:  zip
@@ -100,7 +98,7 @@ This package contains the API documentation for JSS.
 ################################################################################
 %prep
 
-%autosetup -n %{name}-%{version}%{?_phase} -p 1 -S git
+%autosetup -n %{name}-%{version}%{?_phase} -p 1
 
 ################################################################################
 %build


### PR DESCRIPTION
The `jss.spec` has been modified to drop `git` dependency so it's no longer required for building the official binaries, but `git` is still needed during development to call `build.sh --with-commit-id`.