### PR TITLE
Convert RPM install script into CMake script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,3 +78,41 @@ include(JSSTests)
 jss_config()
 jss_build()
 jss_tests()
+
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/jss4.jar
+    DESTINATION
+        ${JAVA_LIB_INSTALL_DIR}
+)
+
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/libjss4.so
+    DESTINATION
+        ${JSS_LIB_INSTALL_DIR}
+    PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+)
+
+install(
+    CODE "execute_process(
+        COMMAND ln -sf ${JAVA_LIB_INSTALL_DIR}/jss4.jar \$ENV{DESTDIR}${JSS_LIB_INSTALL_DIR}/jss4.jar
+    )"
+)
+
+install(
+    DIRECTORY
+        ${CMAKE_CURRENT_BINARY_DIR}/docs/
+    DESTINATION
+        ${CMAKE_INSTALL_PREFIX}/share/javadoc/jss-${VERSION}
+)
+
+install(
+    FILES
+        jss.html MPL-1.1.txt gpl.txt lgpl.txt
+    DESTINATION
+        ${CMAKE_INSTALL_PREFIX}/share/javadoc/jss-${VERSION}
+)

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -68,6 +68,14 @@ macro(jss_config_outputs)
     set(INCLUDE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/include/jss")
     set(JNI_OUTPUT_DIR "${CMAKE_BINARY_DIR}/include/jss/_jni")
 
+    if (NOT DEFINED JAVA_LIB_INSTALL_DIR)
+        set(JAVA_LIB_INSTALL_DIR "/usr/lib/java")
+    endif(NOT DEFINED JAVA_LIB_INSTALL_DIR)
+
+    if (NOT DEFINED JSS_LIB_INSTALL_DIR)
+        set(JSS_LIB_INSTALL_DIR "/usr/lib/jss")
+    endif(NOT DEFINED JSS_LIB_INSTALL_DIR)
+
     # This folder is for pseudo-locations for CMake targets
     set(TARGETS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/.targets")
     set(JAVA_SOURCES_FILE "${TARGETS_OUTPUT_DIR}/java.sources")

--- a/jss.spec
+++ b/jss.spec
@@ -125,13 +125,25 @@ modutil -dbdir /etc/pki/nssdb -chkfips true | grep -q enabled && export FIPS_ENA
 
 # The Makefile is not thread-safe
 %cmake \
+    -DVERSION=%{version} \
     -DJAVA_HOME=%{java_home} \
     -DJAVA_LIB_INSTALL_DIR=%{_jnidir} \
+    -DJSS_LIB_INSTALL_DIR=%{_libdir}/jss \
     -B %{_vpath_builddir}
 
 cd %{_vpath_builddir}
-%{__make} all
-%{__make} javadoc
+
+%{__make} \
+    VERBOSE=%{?_verbose} \
+    CMAKE_NO_VERBOSE=1 \
+    --no-print-directory \
+    all
+
+%{__make} \
+    VERBOSE=%{?_verbose} \
+    CMAKE_NO_VERBOSE=1 \
+    --no-print-directory \
+    javadoc
 
 %if %{with_test}
 ctest --output-on-failure
@@ -140,27 +152,16 @@ ctest --output-on-failure
 ################################################################################
 %install
 
-# There is no install target so we'll do it by hand
+cd %{_vpath_builddir}
 
-# jars
-install -d -m 0755 $RPM_BUILD_ROOT%{_jnidir}
-install -m 644 %{_vpath_builddir}/jss4.jar ${RPM_BUILD_ROOT}%{_jnidir}/jss4.jar
+%{__make} \
+    VERBOSE=%{?_verbose} \
+    CMAKE_NO_VERBOSE=1 \
+    DESTDIR=%{buildroot} \
+    INSTALL="install -p" \
+    --no-print-directory \
+    install
 
-# We have to use the name libjss4.so because this is dynamically
-# loaded by the jar file.
-install -d -m 0755 $RPM_BUILD_ROOT%{_libdir}/jss
-install -m 0755 %{_vpath_builddir}/libjss4.so ${RPM_BUILD_ROOT}%{_libdir}/jss/
-pushd  ${RPM_BUILD_ROOT}%{_libdir}/jss
-    ln -fs %{_jnidir}/jss4.jar jss4.jar
-popd
-
-# javadoc
-install -d -m 0755 $RPM_BUILD_ROOT%{_javadocdir}/%{name}-%{version}
-cp -rp %{_vpath_builddir}/docs/* $RPM_BUILD_ROOT%{_javadocdir}/%{name}-%{version}
-cp -p jss.html $RPM_BUILD_ROOT%{_javadocdir}/%{name}-%{version}
-cp -p *.txt $RPM_BUILD_ROOT%{_javadocdir}/%{name}-%{version}
-
-# No ldconfig is required since this library is loaded by Java itself.
 ################################################################################
 %files
 


### PR DESCRIPTION
The installation script in `jss.spec` has been converted into CMake script.
The `make` invocations have been modified to make it easier to read the output.