### PR TITLE
Add build.sh dist and install targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Alternatively, to build a RPM distribution of JSS:
 
     git clone https://github.com/dogtagpki/jss
     cd jss
-    ./build.sh
+    ./build.sh rpm
 
 To view more detailed instructions for building JSS, please refer to
 the build documentation: [`docs/building.md`](docs/building.md).

--- a/docs/building.md
+++ b/docs/building.md
@@ -92,7 +92,7 @@ To build a RPM release, please ensure all dependencies are installed:
 
 Then, issue a build using the `build.sh` interface:
 
-    ./build.sh
+    ./build.sh rpm
 
 This will build RPMS and place them in `$HOME/build/jss` by default. For more
 information about this build script, refer to its help text:

--- a/jss.spec
+++ b/jss.spec
@@ -129,14 +129,10 @@ modutil -dbdir /etc/pki/nssdb -chkfips true | grep -q enabled && export FIPS_ENA
 ################################################################################
 %install
 
-cd %{_vpath_builddir}
-
-%{__make} \
-    VERBOSE=%{?_verbose} \
-    CMAKE_NO_VERBOSE=1 \
-    DESTDIR=%{buildroot} \
-    INSTALL="install -p" \
-    --no-print-directory \
+./build.sh \
+    %{?_verbose:-v} \
+    --work-dir=%{_vpath_builddir} \
+    --install-dir=%{buildroot} \
     install
 
 ################################################################################

--- a/jss.spec
+++ b/jss.spec
@@ -105,6 +105,8 @@ This package contains the API documentation for JSS.
 
 %set_build_flags
 
+export JAVA_HOME=%{java_home}
+
 # Enable compiler optimizations
 export BUILD_OPT=1
 
@@ -115,31 +117,14 @@ export CFLAGS
 # Check if we're in FIPS mode
 modutil -dbdir /etc/pki/nssdb -chkfips true | grep -q enabled && export FIPS_ENABLED=1
 
-# The Makefile is not thread-safe
-%cmake \
-    -DVERSION=%{version} \
-    -DJAVA_HOME=%{java_home} \
-    -DJAVA_LIB_INSTALL_DIR=%{_jnidir} \
-    -DJSS_LIB_INSTALL_DIR=%{_libdir}/jss \
-    -B %{_vpath_builddir}
-
-cd %{_vpath_builddir}
-
-%{__make} \
-    VERBOSE=%{?_verbose} \
-    CMAKE_NO_VERBOSE=1 \
-    --no-print-directory \
-    all
-
-%{__make} \
-    VERBOSE=%{?_verbose} \
-    CMAKE_NO_VERBOSE=1 \
-    --no-print-directory \
-    javadoc
-
-%if %{with test}
-ctest --output-on-failure
-%endif
+./build.sh \
+    %{?_verbose:-v} \
+    --work-dir=%{_vpath_builddir} \
+    --java-lib-dir=%{_jnidir} \
+    --jss-lib-dir=%{_libdir}/jss \
+    --version=%{version} \
+    %{!?with_test:--without-test} \
+    dist
 
 ################################################################################
 %install


### PR DESCRIPTION
The `build.sh` script has been modified to provide a `dist` and `install` targets to build and install JSS binaries without creating RPM packages. The `jss.spec` has been modified to call `build.sh` instead of calling CMake directly.