### PR TITLE
Update version number to 5.0.0-alpha1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,14 +81,14 @@ jss_tests()
 
 install(
     FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/jss4.jar
+        ${CMAKE_CURRENT_BINARY_DIR}/jss.jar
     DESTINATION
         ${JAVA_LIB_INSTALL_DIR}
 )
 
 install(
     FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/libjss4.so
+        ${CMAKE_CURRENT_BINARY_DIR}/libjss.so
     DESTINATION
         ${JSS_LIB_INSTALL_DIR}
     PERMISSIONS
@@ -99,10 +99,7 @@ install(
 
 install(
     CODE "execute_process(
-        COMMAND ln -sf ${JAVA_LIB_INSTALL_DIR}/jss4.jar \$ENV{DESTDIR}${JSS_LIB_INSTALL_DIR}/jss4.jar
-        COMMAND ln -sf jss4.jar \$ENV{DESTDIR}${JAVA_LIB_INSTALL_DIR}/jss.jar
-        COMMAND ln -sf jss4.jar \$ENV{DESTDIR}${JSS_LIB_INSTALL_DIR}/jss.jar
-        COMMAND ln -sf libjss4.so \$ENV{DESTDIR}${JSS_LIB_INSTALL_DIR}/libjss.so
+        COMMAND ln -sf ${JAVA_LIB_INSTALL_DIR}/jss.jar \$ENV{DESTDIR}${JSS_LIB_INSTALL_DIR}/jss.jar
     )"
 )
 

--- a/cmake/JSSCommon.cmake
+++ b/cmake/JSSCommon.cmake
@@ -54,7 +54,7 @@ macro(jss_build_globs)
     # We exclude any C files in the tests directory because they shouldn't
     # contribute to our library. They should instead be built as part of the
     # test suite and probably be built as stand alone binaries which link
-    # against libjss4.so (at most).
+    # against libjss.so (at most).
     file(GLOB_RECURSE C_SOURCES src/main/java/*.c)
     file(GLOB_RECURSE C_TEST_SOURCES src/test/java/*.c)
 endmacro()

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -3,7 +3,7 @@ macro(jss_config)
     #   MAJOR MINOR PATCH BETA
     # When BETA is 1, it is a pre-release (it enables some tests).
     # When BETA is 0, it is a final release.
-    jss_config_version(4 9 0 1)
+    jss_config_version(5 0 0 1)
 
     # Configure output directories
     jss_config_outputs()
@@ -91,8 +91,8 @@ macro(jss_config_outputs)
     set(REPRODUCIBLE_TEMP_DIR "${CMAKE_BINARY_DIR}/reproducible")
 
     set(JSS_BUILD_JAR "staging.jar")
-    set(JSS_JAR "jss${JSS_VERSION_MAJOR}.jar")
-    set(JSS_SO "libjss${JSS_VERSION_MAJOR}.so")
+    set(JSS_JAR "jss.jar")
+    set(JSS_SO "libjss.so")
     set(JSS_BUILD_JAR_PATH "${CMAKE_BINARY_DIR}/${JSS_BUILD_JAR}")
     set(JSS_JAR_PATH "${CMAKE_BINARY_DIR}/${JSS_JAR}")
     set(JSS_SO_PATH "${CMAKE_BINARY_DIR}/${JSS_SO}")
@@ -104,7 +104,7 @@ macro(jss_config_outputs)
     set(TESTS_CLASSES_OUTPUT_DIR "${CMAKE_BINARY_DIR}/classes/tests")
     set(TESTS_INCLUDE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/include/tests")
     set(TESTS_JNI_OUTPUT_DIR "${CMAKE_BINARY_DIR}/include/jss/_jni")
-    set(JSS_TESTS_JAR "tests-jss${JSS_VERSION_MAJOR}.jar")
+    set(JSS_TESTS_JAR "tests-jss.jar")
     set(JSS_TESTS_SO "${JSS_SO}")
     set(JSS_TESTS_JAR_PATH "${CMAKE_BINARY_DIR}/${JSS_TESTS_JAR}")
     set(JSS_TESTS_SO_PATH "${LIB_OUTPUT_DIR}/${JSS_TESTS_SO}")

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -470,7 +470,7 @@ macro(jss_tests_compile_c C_FILE C_OUTPUT C_TARGET)
 
     add_custom_command(
         OUTPUT "${C_OUTPUT}"
-        COMMAND ${CMAKE_C_COMPILER} ${JSS_C_FLAGS} -o ${C_OUTPUT} ${C_FILE} -L${LIB_OUTPUT_DIR} -ljss4 ${JSS_LD_FLAGS}
+        COMMAND ${CMAKE_C_COMPILER} ${JSS_C_FLAGS} -o ${C_OUTPUT} ${C_FILE} -L${LIB_OUTPUT_DIR} -ljss ${JSS_LD_FLAGS}
         WORKING_DIRECTORY ${C_DIR}
         DEPENDS "${C_FILE}"
         DEPENDS "${JSS_TESTS_SO_PATH}"

--- a/docs/build_system.md
+++ b/docs/build_system.md
@@ -14,7 +14,7 @@ built in five stages:
    done in a single pass of the `javac` compiler. All Java source files under
    `org/` are currently compiled to the `build/classes/` folder.
 2. Any C header files are moved to the `build/includes/` folder.
-3. C source files are compiled to objects and linked to form `libjss4.so`,
+3. C source files are compiled to objects and linked to form `libjss.so`,
    excluding any C source files in `org/mozilla/jss/tests`. If any exist,
    they'll be compiled at a later stage for `ctest`. This step is dependent
    on steps 1 and 2.
@@ -99,7 +99,7 @@ in output and when running particular tests), a `COMMAND` to execute, and an
 optional set of dependencies (`DEPENDS ...`) on other tests. We use this
 because `add_test` doesn't itself handle dependencies or set environment
 variables (we need to inject `LD_LIBRARY_PATH` to handle testing our built
-`libjss4.so`).
+`libjss.so`).
 
 `jss_test_java` is a wrapper over `jss_test_exec` which handles setting up
 the JVM and passing required arguments to it (`-classpath`, `-enableasserts`,

--- a/docs/building.md
+++ b/docs/building.md
@@ -64,20 +64,20 @@ information, read `man ctest`.
 
 ### Installation
 
-To install JSS, place `jss4.jar` and `libjss4.so` in places where the system
+To install JSS, place `jss.jar` and `libjss.so` in places where the system
 can find them. We recommend the following locations on a 64-bit system:
 
     cd jss/build
-    sudo cp jss4.jar /usr/lib/java/jss4.jar
-    sudo chown root:root /usr/lib/java/jss4.jar
-    sudo chmod 644 /usr/lib/java/jss4.jar
+    sudo cp jss.jar /usr/lib/java/jss.jar
+    sudo chown root:root /usr/lib/java/jss.jar
+    sudo chmod 644 /usr/lib/java/jss.jar
 
-    sudo cp libjss4.so /usr/lib64/jss/libjss4.so
-    sudo chown root:root /usr/lib64/jss/libjss4.so
-    sudo chmod 755 /usr/lib64/jss/libjss4.so
+    sudo cp libjss.so /usr/lib64/jss/libjss.so
+    sudo chown root:root /usr/lib64/jss/libjss.so
+    sudo chmod 755 /usr/lib64/jss/libjss.so
 
-To uninstall, simply remove the created files (`/usr/lib/java/jss4.jar` and
-`/usr/lib64/jss/libjss4.so`).
+To uninstall, simply remove the created files (`/usr/lib/java/jss.jar` and
+`/usr/lib64/jss/libjss.so`).
 
 Note that the preferred way to install JSS is from your distribution or via
 an RPM built with `build.sh`.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -53,7 +53,7 @@ To install these dependencies on Debian, execute the following:
 At run time, the following JARs are required to be specified on the
 `CLASSPATH` of anyone wishing to use JSS:
 
- - `jss4.jar`
+ - `jss.jar`
  - `slf4j-api.jar`
  - `apache-commons-lang.jar`
  - `jaxb-api.jar`

--- a/docs/legacy_building.md
+++ b/docs/legacy_building.md
@@ -129,31 +129,31 @@ If JSS already exists on the system, run something similar to the
 following command(s):
 
 ```
-# sudo mv /usr/lib/java/jss4.jar /usr/lib/java/jss4.jar.orig
+# sudo mv /usr/lib/java/jss.jar /usr/lib/java/jss.jar.orig
 ```
 
 If the platform is 32-bit Linux:
 
 ```
-# sudo mv /usr/lib/jss/libjss4.so /usr/lib/jss/libjss4.so.orig
+# sudo mv /usr/lib/jss/libjss.so /usr/lib/jss/libjss.so.orig
 ```
 
 else if the platform is 64-bit Linux:
 
 ```
-# sudo mv /usr/lib64/jss/libjss4.so /usr/lib64/jss/libjss4.so.orig
+# sudo mv /usr/lib64/jss/libjss.so /usr/lib64/jss/libjss.so.orig
 ```
 
 Then install the new JSS binaries:
 
 ```
-# sudo cp sandbox/dist/xpclass.jar /usr/lib/java/jss4.jar
-# sudo chown root:root /usr/lib/java/jss4.jar
-# sudo chmod 644 /usr/lib/java/jss4.jar
+# sudo cp sandbox/dist/xpclass.jar /usr/lib/java/jss.jar
+# sudo chown root:root /usr/lib/java/jss.jar
+# sudo chmod 644 /usr/lib/java/jss.jar
 
-# sudo cp sandbox/jss/lib/Linux*.OBJ/libjss4.so /usr/lib64/jss/libjss4.so
-# sudo chown root:root /usr/lib64/jss/libjss4.so
-# sudo chmod 755 /usr/lib64/jss/libjss4.so
+# sudo cp sandbox/jss/lib/Linux*.OBJ/libjss.so /usr/lib64/jss/libjss.so
+# sudo chown root:root /usr/lib64/jss/libjss.so
+# sudo chmod 755 /usr/lib64/jss/libjss.so
 ```
 
 ### 5. Run JSS Tests (Optional, but only if build method (1)(a) was utilized)
@@ -185,19 +185,19 @@ other than test, the user may wish to restore the original system JSS
 by running the following commands:
 
 ```
-# sudo mv /usr/lib/java/jss4.jar.orig /usr/lib/java/jss4.jar
+# sudo mv /usr/lib/java/jss.jar.orig /usr/lib/java/jss.jar
 ```
 
 If the platform is 32-bit Linux:
 
 ```
-# sudo mv /usr/lib/jss/libjss4.so.orig /usr/lib/jss/libjss4.so
+# sudo mv /usr/lib/jss/libjss.so.orig /usr/lib/jss/libjss.so
 ```
 
 else if the platform is 64-bit Linux:
 
 ```
-# sudo mv /usr/lib64/jss/libjss4.so.orig /usr/lib64/jss/libjss4.so
+# sudo mv /usr/lib64/jss/libjss.so.orig /usr/lib64/jss/libjss.so
 ```
 
 NOTE:  For this procedure, no ownership or permission changes should

--- a/docs/usage/capabilities_list.md
+++ b/docs/usage/capabilities_list.md
@@ -20,7 +20,7 @@ Usage
 ========================================
 First build jss according to the instructions
 here [README](../../README.md)
-You should see in the build directory tests_jss4.jar which is what
+You should see in the build directory tests_jss.jar which is what
 contains the application along with the regular tests.
 From the `jss/build` directory execute
 

--- a/docs/using_jss.md
+++ b/docs/using_jss.md
@@ -1,10 +1,10 @@
 # Using JSS
 
-Please make sure `libjss4.so` is included in your library path or set it via
+Please make sure `libjss.so` is included in your library path or set it via
 the `LD_LIBRARY_PATH` environment variable. See `man 8 ld.so` for more
 information. Alternatively, this can be done by setting `-Djava.library.path`
-to the directory with `libjss4.so` on the command line of all Java programs
-using JSS. Note that without `libjss4.so`, using JSS in nearly any capacity
+to the directory with `libjss.so` on the command line of all Java programs
+using JSS. Note that without `libjss.so`, using JSS in nearly any capacity
 will fail.
 
 ## Classpath Dependencies
@@ -12,8 +12,8 @@ will fail.
 To use JSS in your project after installation, you'll need to ensure the
 following dependencies are available in your `CLASSPATH`:
 
- - `jss4.jar` -- provided by the `jss` package and installed to
-   `/usr/lib/java/jss4.jar`.
+ - `jss.jar` -- provided by the `jss` package and installed to
+   `/usr/lib/java/jss.jar`.
  - `slf4j-api.jar` -- provided by the `slf4j` package and installed to
    `/usr/share/java/slf4j/slf4j-api.jar`.
  - `apache-commons-lang.jar` -- provided by the `apache-commons-lang` package

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,13 +6,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dogtagpki</groupId>
     <artifactId>jss-example</artifactId>
-    <version>4.9.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>org.dogtagpki</groupId>
             <artifactId>jss</artifactId>
-            <version>4.9.0-SNAPSHOT</version>
+            <version>5.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/jss.spec
+++ b/jss.spec
@@ -8,9 +8,9 @@ License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
 # For development (i.e. unsupported) releases, use x.y.z-0.n.<phase>.
 # For official (i.e. supported) releases, use x.y.z-r where r >=1.
-Version:        4.9.0
-Release:        0.2.alpha2%{?_timestamp}%{?_commit_id}%{?dist}
-%global         _phase -alpha2
+Version:        5.0.0
+Release:        0.1.alpha1%{?_timestamp}%{?_commit_id}%{?dist}
+%global         _phase -alpha1
 
 # To generate the source tarball:
 # $ git clone https://github.com/dogtagpki/jss.git

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dogtagpki</groupId>
     <artifactId>jss</artifactId>
-    <version>4.9.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
 

--- a/src/main/java/org/mozilla/jss/CryptoManager.java
+++ b/src/main/java/org/mozilla/jss/CryptoManager.java
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.jss;
 
-import java.security.Security;
 import java.security.GeneralSecurityException;
+import java.security.Security;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
@@ -57,22 +57,22 @@ public final class CryptoManager implements TokenSupplier
         logger.debug("CryptoManager: loading JSS library");
 
         try {
-            System.loadLibrary("jss4");
+            System.loadLibrary("jss");
             logger.debug("CryptoManager: loaded JSS library from java.library.path");
 
         } catch (UnsatisfiedLinkError e) {
 
             try {
-                System.load("/usr/lib64/jss/libjss4.so");
-                logger.debug("CryptoManager: loaded JSS library from /usr/lib64/jss/libjss4.so");
+                System.load("/usr/lib64/jss/libjss.so");
+                logger.debug("CryptoManager: loaded JSS library from /usr/lib64/jss/libjss.so");
 
             } catch (UnsatisfiedLinkError e1) {
                 try {
-                    System.load("/usr/lib/jss/libjss4.so");
-                    logger.debug("CryptoManager: loaded JSS library from /usr/lib/jss/libjss4.so");
+                    System.load("/usr/lib/jss/libjss.so");
+                    logger.debug("CryptoManager: loaded JSS library from /usr/lib/jss/libjss.so");
                 } catch (UnsatisfiedLinkError e2) {
-                    logger.warn("Unable to load jss4 via loadLibrary: " + e.toString());
-                    logger.warn("Unable to load /usr/lib64/jss/libjss4.so: " + e1.toString());
+                    logger.warn("Unable to load jss via loadLibrary: " + e.toString());
+                    logger.warn("Unable to load /usr/lib64/jss/libjss.so: " + e1.toString());
                     throw e2;
                 }
             }
@@ -1352,7 +1352,7 @@ public final class CryptoManager implements TokenSupplier
      * @param policy - Either cert and chain or normal default processing.
      *
      */
- 
+
     public static synchronized void setOCSPPolicy(OCSPPolicy policy) {
         ocspPolicy = policy;
     }
@@ -1378,8 +1378,8 @@ public final class CryptoManager implements TokenSupplier
     {
         /* set the ocsp policy */
 
-        if(ocspCheckingEnabled && 
-            ocspResponderURL == null && 
+        if(ocspCheckingEnabled &&
+            ocspResponderURL == null &&
             ocspResponderCertNickname == null) {
             setOCSPPolicy(OCSPPolicy.LEAF_AND_CHAIN);
         } else {

--- a/src/test/java/org/mozilla/jss/tests/JSSPackageTest.java
+++ b/src/test/java/org/mozilla/jss/tests/JSSPackageTest.java
@@ -28,9 +28,9 @@ public class JSSPackageTest {
                                "from CryptoManager");
             System.out.println("\n\t" + org.mozilla.jss.CryptoManager.JAR_JSS_VERSION);
 
-            System.out.println("\n\tTo check the JNI version in libjss4.so:");
-            System.out.println("\n\ttry: strings libjss4.so | grep -i header");
-            System.out.println("\n\tor : ident libjss4.so");
+            System.out.println("\n\tTo check the JNI version in libjss.so:");
+            System.out.println("\n\ttry: strings libjss.so | grep -i header");
+            System.out.println("\n\tor : ident libjss.so");
             System.exit(0);
 
         } catch (Exception e) {

--- a/src/test/java/org/mozilla/jss/tests/JSS_SelfServClient.java
+++ b/src/test/java/org/mozilla/jss/tests/JSS_SelfServClient.java
@@ -38,19 +38,19 @@ import org.slf4j.LoggerFactory;
  * For debugging purposes you should modify Constant.java debug_level to 4.
  *
  * First create db's and certificates
- * java -cp jss4.jar org.mozilla.jss.tests.SetupDBs . ./passwords
- * java -cp jss4.jar org.mozilla.jss.tests.GenerateTestCert . /passwords
+ * java -cp jss.jar org.mozilla.jss.tests.SetupDBs . ./passwords
+ * java -cp jss.jar org.mozilla.jss.tests.GenerateTestCert . /passwords
  *                             localhost SHA-256/RSA CA_RSA Client_RSA Server_RSA
  *
  * Start the server:
  *
- *  java -cp ./jss4.jar org.mozilla.jss.tests.JSS_SelfServServer . passwords
+ *  java -cp ./jss.jar org.mozilla.jss.tests.JSS_SelfServServer . passwords
  *             localhost false 2921 verboseoff
  *
  * Start the client with 4 threads using ciphersuite 0x33.
  * Look at the file Constant.java for the ciphersuites values.
  *
- * java -cp jss4.jar org.mozilla.jss.tests.JSS_SelfServClient 2 0x33
+ * java -cp jss.jar org.mozilla.jss.tests.JSS_SelfServClient 2 0x33
  * . localhost 2921 verboseoff JSS Client_RSA
  *
  * If you envoke the client with a ciphersuite value -1
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * will closed all client SSLSockets and then tell the server to
  * shutdown. This case is for the nightly automated tests.
  *
- * java -cp jss4.jar org.mozilla.jss.tests.JSS_SelfServClient 4 -1
+ * java -cp jss.jar org.mozilla.jss.tests.JSS_SelfServClient 4 -1
  * . passwords localhost 2921 verboseoff JSS
  */
 

--- a/src/test/java/org/mozilla/jss/tests/JSS_SelfServServer.java
+++ b/src/test/java/org/mozilla/jss/tests/JSS_SelfServServer.java
@@ -33,19 +33,19 @@ import org.slf4j.LoggerFactory;
  * For debugging purposes you should modify Constant.java debug_level to 4.
  *
  * First create db's and certificates
- * java -cp jss4.jar org.mozilla.jss.tests.SetupDBs . ./passwords
- * java -cp jss4.jar org.mozilla.jss.tests.GenerateTestCert . /passwords
+ * java -cp jss.jar org.mozilla.jss.tests.SetupDBs . ./passwords
+ * java -cp jss.jar org.mozilla.jss.tests.GenerateTestCert . /passwords
  *                             localhost SHA-256/RSA CA_RSA Client_RSA Server_RSA
  *
  * Start the server:
  *
- *  java -cp ./jss4.jar org.mozilla.jss.tests.JSS_SelfServServer . passwords localhost
+ *  java -cp ./jss.jar org.mozilla.jss.tests.JSS_SelfServServer . passwords localhost
  *             false 2921 verboseoff
  *
  * Start the client with 4 threads using ciphersuite 0x33.
  * Look at the file Constant.java for the ciphersuites values.
  *
- * java -cp jss4.jar org.mozilla.jss.tests.JSS_SelfServClient 2 0x33
+ * java -cp jss.jar org.mozilla.jss.tests.JSS_SelfServClient 2 0x33
  * . localhost 2921 verboseoff JSS Client_RSA
  *
  * If you envoke the client with a ciphersuite value -1
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * will closed all client SSLSockets and then tell the server to
  * shutdown. This case is for the nightly automated tests.
  *
- * java -cp jss4.jar org.mozilla.jss.tests.JSS_SelfServClient 4 -1
+ * java -cp jss.jar org.mozilla.jss.tests.JSS_SelfServClient 4 -1
  * . passwords localhost 2921 verboseoff JSS
  */
 

--- a/src/test/java/org/mozilla/jss/tests/TestBuffer.java
+++ b/src/test/java/org/mozilla/jss/tests/TestBuffer.java
@@ -72,7 +72,7 @@ public class TestBuffer {
     }
 
     public static void main(String[] args) {
-        System.loadLibrary("jss4");
+        System.loadLibrary("jss");
 
         System.out.println("Calling TestCreateFree()...");
         TestCreateFree();

--- a/src/test/java/org/mozilla/jss/tests/TestBufferPRFD.java
+++ b/src/test/java/org/mozilla/jss/tests/TestBufferPRFD.java
@@ -1,10 +1,20 @@
 package org.mozilla.jss.tests;
 
-import org.mozilla.jss.*;
-import org.mozilla.jss.pkcs11.*;
-import org.mozilla.jss.nss.*;
-import org.mozilla.jss.ssl.*;
-import org.mozilla.jss.util.*;
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.nss.Buffer;
+import org.mozilla.jss.nss.BufferProxy;
+import org.mozilla.jss.nss.PR;
+import org.mozilla.jss.nss.PRErrors;
+import org.mozilla.jss.nss.PRFDProxy;
+import org.mozilla.jss.nss.SSL;
+import org.mozilla.jss.nss.SSLFDProxy;
+import org.mozilla.jss.nss.SecurityStatusResult;
+import org.mozilla.jss.pkcs11.PK11Cert;
+import org.mozilla.jss.pkcs11.PK11PrivKey;
+import org.mozilla.jss.ssl.SSLAlertEvent;
+import org.mozilla.jss.ssl.SSLVersion;
+import org.mozilla.jss.ssl.SSLVersionRange;
+import org.mozilla.jss.util.Password;
 
 public class TestBufferPRFD {
     public static void TestCreateClose() {
@@ -259,7 +269,7 @@ public class TestBufferPRFD {
     }
 
     public static void main(String[] args) throws Exception {
-        System.loadLibrary("jss4");
+        System.loadLibrary("jss");
 
         System.out.println("Calling TestCreateClose()...");
         TestCreateClose();

--- a/src/test/java/org/mozilla/jss/tests/TestPRFD.java
+++ b/src/test/java/org/mozilla/jss/tests/TestPRFD.java
@@ -81,7 +81,7 @@ public class TestPRFD {
     }
 
     public static void main(String[] args) {
-        System.loadLibrary("jss4");
+        System.loadLibrary("jss");
 
         System.out.println("Calling TestPROpenNoCreate()...");
         TestPROpenNoCreate();

--- a/src/test/java/org/mozilla/jss/tests/TestRawSSL.java
+++ b/src/test/java/org/mozilla/jss/tests/TestRawSSL.java
@@ -2,12 +2,11 @@ package org.mozilla.jss.tests;
 
 import org.mozilla.jss.nss.PR;
 import org.mozilla.jss.nss.PRFDProxy;
-import org.mozilla.jss.nss.SSLFDProxy;
 import org.mozilla.jss.nss.SSL;
-import org.mozilla.jss.nss.SecurityStatusResult;
 import org.mozilla.jss.nss.SSLChannelInfo;
+import org.mozilla.jss.nss.SSLFDProxy;
 import org.mozilla.jss.nss.SSLPreliminaryChannelInfo;
-
+import org.mozilla.jss.nss.SecurityStatusResult;
 import org.mozilla.jss.ssl.SSLCipher;
 
 public class TestRawSSL {
@@ -155,7 +154,7 @@ public class TestRawSSL {
     }
 
     public static void main(String[] args) throws Exception {
-        System.loadLibrary("jss4");
+        System.loadLibrary("jss");
 
         if (args.length != 1) {
             System.out.println("Usage: TestRawSSL /path/to/nssdb");


### PR DESCRIPTION
Recently JSS 4.9 was modified to require Java 11. However, older platforms that use JSS 4.8 might have other libraries that will not work with Java 11, so it will not be able to be upgraded to JSS 4.9.

To address the problem, the current JSS 4.9 has been renamed into JSS 5.0 which will only work on newer platforms, and a new JSS 4.9 branch will be created from JSS 4.8 to provide updates for older platforms.

The binaries have also been renamed to `jss.jar` and `libjss.so` to simplify future upgrades.