### PR TITLE
Add configurable test repository

### DIFF
--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -68,6 +68,43 @@ jobs:
           name: jss-runner-${{ matrix.os }}
           path: /tmp/jss-runner.tar
 
+  pki-build-test:
+    name: Building PKI
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/jss
+      COPR_REPO: "@pki/master"
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download runner image
+        uses: actions/download-artifact@v2
+        with:
+          name: jss-runner-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load runner image
+        run: docker load --input /tmp/jss-runner.tar
+
+      - name: Run container
+        run: |
+          IMAGE=jss-runner \
+          NAME=pki \
+          HOSTNAME=pki.example.com \
+          tests/bin/runner-init.sh
+
+      - name: Build PKI
+        run: |
+          docker exec pki dnf install -y git rpm-build
+          docker exec pki git clone https://github.com/dogtagpki/pki
+          docker exec pki dnf build-dep -y --spec pki/pki.spec
+          docker exec pki pki/build.sh --with-timestamp --with-commit-id rpm
+          docker exec pki dnf install -y /root/build/pki/RPMS/*.rpm
+
   ca-test:
     name: Installing CA
     needs: [init, build]

--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -8,8 +8,20 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:latest
     outputs:
+      test_repo: ${{ steps.set-test-repo.outputs.test_repo }}
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Set up test repository
+        id: set-test-repo
+        run: |
+          if [ "${{ secrets.COPR_REPO }}" == "" ]
+          then
+              echo "Running CI using @pki/master repository"
+              echo "::set-output name=test_repo::@pki/master"
+          else
+              echo "::set-output name=test_repo::${{ secrets.COPR_REPO }}"
+          fi
+
       - name: Set up test matrix
         id: set-matrix
         run: |
@@ -28,7 +40,7 @@ jobs:
     needs: init
     runs-on: ubuntu-latest
     env:
-      COPR_REPO: "@pki/master"
+      COPR_REPO: ${{ needs.init.outputs.test_repo }}
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
@@ -62,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/jss
-      COPR_REPO: "@pki/master"
+      COPR_REPO: ${{ needs.init.outputs.test_repo }}
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:


### PR DESCRIPTION
The test workflow have been modified to use the test
repository specified in `COPR_REPO` secret variable.
If the secret is not defined, it will use [@pki/master](https://copr.fedorainfracloud.org/coprs/g/pki/master).

https://github.com/dogtagpki/pki/wiki/Configuring-Test-Repository