### PR TITLE
Update PKCS11Constants

### DIFF
--- a/jss.spec
+++ b/jss.spec
@@ -55,9 +55,8 @@ BuildRequires:  zip
 BuildRequires:  unzip
 
 BuildRequires:  gcc-c++
-BuildRequires:  nspr-devel >= 4.13.1
-BuildRequires:  nss-devel >= 3.44
-BuildRequires:  nss-tools >= 3.44
+BuildRequires:  nss-devel >= 3.66
+BuildRequires:  nss-tools >= 3.66
 BuildRequires:  %{java_devel}
 BuildRequires:  jpackage-utils
 BuildRequires:  slf4j
@@ -67,7 +66,7 @@ BuildRequires:  apache-commons-lang3
 
 BuildRequires:  junit
 
-Requires:       nss >= 3.44
+Requires:       nss >= 3.66
 Requires:       %{java_headless}
 Requires:       jpackage-utils
 Requires:       slf4j

--- a/src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java
+++ b/src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java
@@ -7074,6 +7074,55 @@ public interface PKCS11Constants {
      *
      * Source file: /usr/include/nss3/pkcs11n.h
      */
+    public static final long CKS_NSS_UNINITIALIZED = 0xFFFFFFFFL;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKS_NSS_FIPS_NOT_OK = 0x00000000L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKS_NSS_FIPS_OK = 0x00000001L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKT_NSS_SESSION_CHECK = 0x00000001L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKT_NSS_OBJECT_CHECK = 0x00000002L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKT_NSS_BOTH_CHECK = 0x00000003L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKT_NSS_SESSION_LAST_CHECK = 0x00000004L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
     public static final long CKR_NSS = 0xCE534350L;
 
     /**


### PR DESCRIPTION
The `PKCS11Constants` class has been updated to include
the new constants introduced in NSS 3.66. The NSPR
dependency has been dropped since it's already required
by NSS.

https://bugzilla.mozilla.org/show_bug.cgi?id=1710773

**Note:** This PR will fix the current CI failure.