### PR TITLE
Update PKI CA test

### DIFF
--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -123,25 +123,55 @@ jobs:
           tests/bin/runner-init.sh
 
       - name: Install DS and PKI packages
-        run: docker exec pki dnf install -y 389-ds-base pki-ca
+        run: docker exec pki dnf install -y 389-ds-base pki-ca pki-tests
 
       - name: Install DS
         run: docker exec pki ${SHARED}/tests/bin/ds-create.sh
 
       - name: Install CA
-        run: docker exec pki pkispawn -f /usr/share/pki/server/examples/installation/ca.cfg -s CA -v
+        run: |
+          docker exec pki pkispawn -f /usr/share/pki/server/examples/installation/ca.cfg -s CA -v
+          # set buffer size to 0 so that revocation takes effect immediately
+          docker exec pki pki-server ca-config-set auths.revocationChecking.bufferSize 0
+          # enable signed audit log
+          docker exec pki pki-server ca-config-set log.instance.SignedAudit.logSigning true
+          # restart PKI server
+          docker exec pki pki-server restart --wait
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --debug
 
-      - name: Verify CA admin
+      - name: Initialize PKI client
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki info
+
+      - name: Test CA certs
+        run: |
+          docker exec pki /usr/share/pki/tests/ca/bin/test-ca-signing-cert.sh
+          docker exec pki /usr/share/pki/tests/ca/bin/test-subsystem-cert.sh
+          docker exec pki /usr/share/pki/tests/ca/bin/test-ca-certs.sh
+
+      - name: Test CA admin
+        run: |
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
           docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Test CA agent
+        run: |
+          docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-create.sh
+          docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-cert-create.sh
+          docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-cert-revoke.sh
+          docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-cert-unrevoke.sh
+
+      - name: Test CA auditor
+        run: |
+          docker exec pki /usr/share/pki/tests/ca/bin/test-ca-auditor-create.sh
+          docker exec pki /usr/share/pki/tests/ca/bin/test-ca-auditor-cert.sh
+          docker exec pki /usr/share/pki/tests/ca/bin/test-ca-auditor-logs.sh
 
       - name: Gather artifacts
         if: always()


### PR DESCRIPTION
The CA test has been update to match the CA test in PKI:
https://github.com/dogtagpki/pki/blob/master/.github/workflows/ca-tests.yml#L60-L160

This can be used to reproduce issue #781 and test the fix when it becomes available.
