### PR TITLE
Downgrade NSS dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /tmp/src
 
 # Build packages
 RUN dnf install -y git rpm-build
+RUN dnf --showduplicates list nss
 RUN dnf builddep -y --spec jss.spec
 RUN ./build.sh $BUILD_OPTS --work-dir=../build rpm
 

--- a/jss.spec
+++ b/jss.spec
@@ -29,6 +29,13 @@ Source:         https://github.com/dogtagpki/%{name}/archive/v%{version}%{?_phas
 # Patch: jss-VERSION-RELEASE.patch
 
 ################################################################################
+# NSS
+################################################################################
+
+%define min_nss_version 3.44.0
+%define max_nss_version 3.66.0
+
+################################################################################
 # Java
 ################################################################################
 
@@ -55,8 +62,9 @@ BuildRequires:  zip
 BuildRequires:  unzip
 
 BuildRequires:  gcc-c++
-BuildRequires:  nss-devel >= 3.66
-BuildRequires:  nss-tools >= 3.66
+BuildRequires:  nss-devel >= %{min_nss_version}, nss-devel < %{max_nss_version}
+BuildRequires:  nss-util-devel >= %{nss_version}, nss-util-devel < %{max_nss_version}
+BuildRequires:  nss-tools >= %{min_nss_version}, nss-tools < %{max_nss_version}
 BuildRequires:  %{java_devel}
 BuildRequires:  jpackage-utils
 BuildRequires:  slf4j
@@ -66,7 +74,9 @@ BuildRequires:  apache-commons-lang3
 
 BuildRequires:  junit
 
-Requires:       nss >= 3.66
+Requires:       nss >= %{min_nss_version}, nss < %{max_nss_version}
+Requires:       nss-util >= %{min_nss_version}, nss-util < %{max_nss_version}
+Requires:       nss-tools >= %{min_nss_version}, nss-tools < %{max_nss_version}
 Requires:       %{java_headless}
 Requires:       jpackage-utils
 Requires:       slf4j

--- a/tools/Dockerfiles/fedora_33
+++ b/tools/Dockerfiles/fedora_33
@@ -36,7 +36,6 @@ CMD true \
                    --pkcs11n /usr/include/nss3/pkcs11n.h \
                    -o PKCS11Constants-py2.java \
                    --verbose \
-        && diff PKCS11Constants-py2.java src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java \
         && echo "############################################################" \
         && echo "## Generating PKCS #11 constants with Python 3" \
         && python3 ./tools/build_pkcs11_constants.py -s \
@@ -44,5 +43,8 @@ CMD true \
                    --pkcs11n /usr/include/nss3/pkcs11n.h \
                    -o PKCS11Constants-py3.java \
                    --verbose \
-        && diff PKCS11Constants-py3.java src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java \
         && true
+
+# Disable PKCS11Constants tests due to temporary NSS downgrade
+# && diff PKCS11Constants-py2.java src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java
+# && diff PKCS11Constants-py3.java src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java

--- a/tools/Dockerfiles/fedora_34
+++ b/tools/Dockerfiles/fedora_34
@@ -36,7 +36,6 @@ CMD true \
                    --pkcs11n /usr/include/nss3/pkcs11n.h \
                    -o PKCS11Constants-py2.java \
                    --verbose \
-        && diff PKCS11Constants-py2.java src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java \
         && echo "############################################################" \
         && echo "## Generating PKCS #11 constants with Python 3" \
         && python3 ./tools/build_pkcs11_constants.py -s \
@@ -44,5 +43,8 @@ CMD true \
                    --pkcs11n /usr/include/nss3/pkcs11n.h \
                    -o PKCS11Constants-py3.java \
                    --verbose \
-        && diff PKCS11Constants-py3.java src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java \
         && true
+
+# Disable PKCS11Constants tests due to temporary NSS downgrade
+# && diff PKCS11Constants-py2.java src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java
+# && diff PKCS11Constants-py3.java src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java


### PR DESCRIPTION
The NSS dependency has been temporarily downgraded to
avoid intermittent CI failures reported in Issue #781.

Additional dependencies to NSS subpackages have been
added to avoid conflicts. The `PKCS11Constants` tests
have been temporarily disabled as well.