### PR TITLE
Add init-workflow.sh

### DIFF
--- a/.github/workflows/pkcs11-tests.yml
+++ b/.github/workflows/pkcs11-tests.yml
@@ -10,18 +10,15 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
       - name: Set up test matrix
         id: set-matrix
+        env:
+          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
         run: |
-          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
-          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1 }')
-          echo "Running CI against Fedora $previous and $latest"
-          if [ "${{ secrets.MATRIX }}" == "" ]
-          then
-              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
-          else
-              echo "::set-output name=matrix::${{ secrets.MATRIX }}"
-          fi
+          tests/bin/init-workflow.sh
 
   build:
     name: Building JSS

--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -10,18 +10,15 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
       - name: Set up test matrix
         id: set-matrix
+        env:
+          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
         run: |
-          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
-          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1 }')
-          echo "Running CI against Fedora $previous and $latest"
-          if [ "${{ secrets.MATRIX }}" == "" ]
-          then
-              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
-          else
-              echo "::set-output name=matrix::${{ secrets.MATRIX }}"
-          fi
+          tests/bin/init-workflow.sh
 
   build:
     name: Building JSS

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+if [ "$BASE64_MATRIX" == "" ]
+then
+    latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+    previous=$(cat /etc/fedora-release | awk '{ print $3 - 1 }')
+    MATRIX="{\"os\":[\"$previous\", \"$latest\"]}"
+else
+    MATRIX=$(echo "$BASE64_MATRIX" | base64 -d)
+fi
+
+echo "MATRIX: $MATRIX"
+echo "::set-output name=matrix::$MATRIX"


### PR DESCRIPTION
The `init-workflow.sh` has been added to configure the test
matrix based on the `BASE64_MATRIX` variable. The test matrix
needs to be base64-encoded since otherwise GitHub will mask
the value rendering it unusable.

https://github.com/dogtagpki/jss/wiki/Configuring-Test-Matrix