### PR TITLE
Add test repository configuration

### DIFF
--- a/.github/workflows/pkcs11-tests.yml
+++ b/.github/workflows/pkcs11-tests.yml
@@ -8,15 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.init.outputs.matrix }}
+      repo: ${{ steps.init.outputs.repo }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Set up test matrix
-        id: set-matrix
+      - name: Initialize workflow
+        id: init
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
+          BASE64_REPO: ${{ secrets.BASE64_REPO }}
         run: |
           tests/bin/init-workflow.sh
 
@@ -24,8 +26,6 @@ jobs:
     name: Building JSS
     needs: init
     runs-on: ubuntu-latest
-    env:
-      COPR_REPO: "@pki/master"
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
@@ -41,7 +41,7 @@ jobs:
           context: .
           build-args: |
             OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ env.COPR_REPO }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
             BUILD_OPTS=--with-timestamp --with-commit-id
           tags: jss-runner
           target: jss-runner

--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -8,15 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.init.outputs.matrix }}
+      repo: ${{ steps.init.outputs.repo }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Set up test matrix
-        id: set-matrix
+      - name: Initialize workflow
+        id: init
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
+          BASE64_REPO: ${{ secrets.BASE64_REPO }}
         run: |
           tests/bin/init-workflow.sh
 
@@ -24,8 +26,6 @@ jobs:
     name: Building JSS
     needs: init
     runs-on: ubuntu-latest
-    env:
-      COPR_REPO: "@pki/master"
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
@@ -41,7 +41,7 @@ jobs:
           context: .
           build-args: |
             OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ env.COPR_REPO }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
             BUILD_OPTS=--with-timestamp --with-commit-id
           tags: jss-runner
           target: jss-runner
@@ -59,7 +59,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/jss
-      COPR_REPO: "@pki/master"
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
@@ -96,7 +95,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/jss
-      COPR_REPO: "@pki/master"
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -11,3 +11,13 @@ fi
 
 echo "MATRIX: $MATRIX"
 echo "::set-output name=matrix::$MATRIX"
+
+if [ "$BASE64_REPO" == "" ]
+then
+    REPO="@pki/master"
+else
+    REPO=$(echo "$BASE64_REPO" | base64 -d)
+fi
+
+echo "REPO: $REPO"
+echo "::set-output name=repo::$REPO"


### PR DESCRIPTION
The `init-workflow.sh` has been modified to load the test
repository from `BASE64_REPO` variable. The test repository
will be configured in the runner image so all tests using
the same image will automatically use the same repository.

https://github.com/dogtagpki/jss/wiki/Configuring-Test-Repository