### PR TITLE
Update default test matrix

### DIFF
--- a/.github/workflows/pkcs11-tests.yml
+++ b/.github/workflows/pkcs11-tests.yml
@@ -6,7 +6,6 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
-    container: fedora:latest
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}

--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -6,7 +6,6 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
-    container: fedora:latest
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -2,9 +2,7 @@
 
 if [ "$BASE64_MATRIX" == "" ]
 then
-    latest=$(cat /etc/fedora-release | awk '{ print $3 }')
-    previous=$(cat /etc/fedora-release | awk '{ print $3 - 1 }')
-    MATRIX="{\"os\":[\"$previous\", \"$latest\"]}"
+    MATRIX="{\"os\":[\"latest\"]}"
 else
     MATRIX=$(echo "$BASE64_MATRIX" | base64 -d)
 fi


### PR DESCRIPTION
The `init-workflow.sh` has been modified to test
against the latest Fedora version by default.