### PR TITLE
Deprecate RevocationReasonAdapter in JSS 4

### DIFF
--- a/docs/changes/v4.9.1/API-Changes.adoc
+++ b/docs/changes/v4.9.1/API-Changes.adoc
@@ -1,0 +1,5 @@
+= API Changes =
+
+== Changes in org.mozilla.jss.netscape.security.x509.RevocationReasonAdapter ==
+
+The class has been deprecated in JSS 4 and will be dropped in JSS 5. Use the revocation reason code or label instead.

--- a/src/main/java/org/mozilla/jss/netscape/security/x509/RevocationReasonAdapter.java
+++ b/src/main/java/org/mozilla/jss/netscape/security/x509/RevocationReasonAdapter.java
@@ -24,8 +24,10 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * The RevocationReasonAdapter class provides custom marshaling for RevocationReason.
  *
+ * @deprecated Use the revocation reason code or label instead.
  * @author Endi S. Dewata
  */
+@Deprecated(since="4.9.1", forRemoval=true)
 public class RevocationReasonAdapter extends XmlAdapter<String, RevocationReason> {
 
     @Override


### PR DESCRIPTION
https://github.com/edewata/jss/blob/v4.9.x-deprecation/docs/changes/v4.9.1/API-Changes.adoc