### PR TITLE
Add SSLEngine EventListener interface

### DIFF
--- a/src/main/java/org/mozilla/jss/ssl/SSLAlertEvent.java
+++ b/src/main/java/org/mozilla/jss/ssl/SSLAlertEvent.java
@@ -102,6 +102,10 @@ public class SSLAlertEvent extends EventObject {
         this.description = description.getID();
     }
 
+    public boolean isEngine() {
+        return engine != null;
+    }
+
     public JSSEngine getEngine() {
         return engine;
     }

--- a/src/main/java/org/mozilla/jss/ssl/SSLAlertEvent.java
+++ b/src/main/java/org/mozilla/jss/ssl/SSLAlertEvent.java
@@ -9,6 +9,7 @@ import java.util.EventObject;
 import javax.net.ssl.SSLException;
 
 import org.mozilla.jss.nss.SSLFDProxy;
+import org.mozilla.jss.ssl.javax.JSSEngine;
 
 public class SSLAlertEvent extends EventObject {
 
@@ -17,6 +18,7 @@ public class SSLAlertEvent extends EventObject {
     int level;
     int description;
 
+    transient JSSEngine engine;
     SSLAlertLevel levelEnum;
     SSLAlertDescription descriptionEnum;
 
@@ -98,6 +100,14 @@ public class SSLAlertEvent extends EventObject {
     public void setDescription(SSLAlertDescription description) {
         this.descriptionEnum = description;
         this.description = description.getID();
+    }
+
+    public JSSEngine getEngine() {
+        return engine;
+    }
+
+    public void setEngine(JSSEngine new_engine) {
+        engine = new_engine;
     }
 
     public SSLException toException() {

--- a/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
+++ b/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
@@ -58,6 +58,14 @@ public class SSLHandshakeCompletedEvent extends EventObject {
     }
 
     /**
+     * Returns true if this is a JSSEngine-based event or false if this is a
+     * SSLSocket-based event.
+     */
+    public boolean isEngine() {
+        return getSource() instanceof JSSEngine;
+    }
+
+    /**
      * Get engine on which the event occurred; null if on a SSLSocket.
      */
     public JSSEngine getEngine() {

--- a/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
+++ b/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
@@ -12,6 +12,8 @@ package org.mozilla.jss.ssl;
 import java.net.*;
 import java.util.*;
 
+import org.mozilla.jss.ssl.javax.JSSEngine;
+
 /*
  * right now, this only extends EventObject, but it will eventually
  * extend javax.net.ssl.HandshakeCompletedEvent
@@ -25,21 +27,44 @@ public class SSLHandshakeCompletedEvent extends EventObject {
     private static final long serialVersionUID = 1L;
 
     public SSLHandshakeCompletedEvent(SSLSocket socket) {
-	super(socket);
+        super(socket);
+    }
+
+    public SSLHandshakeCompletedEvent(JSSEngine engine) {
+        super(engine);
     }
     
     /**
-     * get security information about this socket, including
-     * cert data
+     * Get security information about this socket, including
+     * cert data; null if on a SSLEngine.
      */
     public SSLSecurityStatus getStatus() throws SocketException {
-	return getSocket().getStatus();
+        if (getSocket() != null) {
+            return getSocket().getStatus();
+        }
+
+        return null;
     }
     
     /**
-     * get socket on which the event occured
+     * Get socket on which the event occurred; null if on a SSLEngine.
      */
     public SSLSocket getSocket() {
-	return (SSLSocket)getSource();
+        if (getSource() instanceof SSLSocket) {
+            return (SSLSocket)getSource();
+        }
+
+        return null;
+    }
+
+    /**
+     * Get engine on which the event occurred; null if on a SSLSocket.
+     */
+    public JSSEngine getEngine() {
+        if (getSource() instanceof JSSEngine) {
+            return (JSSEngine)getSource();
+        }
+
+        return null;
     }
 }

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -1,6 +1,8 @@
 package org.mozilla.jss.ssl.javax;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EventListener;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -20,7 +22,11 @@ import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.pkcs11.PK11PrivKey;
 import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
 import org.mozilla.jss.provider.javax.crypto.JSSTrustManager;
+import org.mozilla.jss.ssl.SSLAlertEvent;
 import org.mozilla.jss.ssl.SSLCipher;
+import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
+import org.mozilla.jss.ssl.SSLHandshakeCompletedListener;
+import org.mozilla.jss.ssl.SSLSocketListener;
 import org.mozilla.jss.ssl.SSLVersion;
 import org.mozilla.jss.ssl.SSLVersionRange;
 import org.slf4j.Logger;
@@ -200,6 +206,11 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     private final static AtomicBoolean sessionCacheInitialized = new AtomicBoolean();
 
     /**
+     * Set of listeners to fire on events (SSL alerts, handshake completed).
+     */
+    private Collection<EventListener> listeners = new ArrayList<>();
+
+    /**
      * Constructor for a JSSEngine, providing no hints for an internal
      * session reuse strategy and no key.
      *
@@ -326,6 +337,7 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
 
         ret.setAlias(certAlias);
         ret.setHostname(hostname);
+        ret.setListeners(listeners);
 
         return ret;
     }
@@ -336,7 +348,8 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
      *
      * Aligning with the parent implementation, this calls:
      *  - setEnabledCipherSuites when getCipherSuites is non-null,
-     *  - setEnabledProtocols when getProtocols is non-null, and
+     *  - setEnabledProtocols when getProtocols is non-null,
+     *  - setListeners when getListeners is non-null, and
      *  - setWantClientAuth and setNeedClientAuth.
      *
      * This doesn't yet understand from the parent implementation, the
@@ -397,6 +410,11 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
         // it.
         if (parsed.getHostname() != null) {
             setHostname(parsed.getHostname());
+        }
+
+        // When we have some listeners, we should add it to our copy.
+        if (parsed.getListeners() != null) {
+            setListeners(parsed.getListeners());
         }
     }
 
@@ -933,6 +951,68 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     @Override
     public boolean getWantClientAuth() {
         return want_client_auth;
+    }
+
+    /**
+     * Sets a SSLSocketListener on this object.
+     */
+    public void setListeners(Collection<EventListener> new_listeners) {
+        listeners = new_listeners;
+    }
+
+    /**
+     * Gets the set of SSLSocketListeners on this object.
+     */
+    public Collection<EventListener> getListeners() {
+        return listeners;
+    }
+
+    /**
+     * Fires any and all SSLSocketListeners on the specified alert received event.
+     *
+     * To be used by other implementations of JSSEngine.
+     */
+    protected void fireAlertReceived(SSLAlertEvent event) {
+        if (listeners != null) {
+            for (EventListener event_listener : listeners) {
+                if (event_listener instanceof SSLSocketListener) {
+                    SSLSocketListener socket_listener = (SSLSocketListener) event_listener;
+                    socket_listener.alertReceived(event);
+                }
+            }
+        }
+    }
+
+    /**
+     * Fires any and all SSLSocketListeners on the specified alert sent event.
+     *
+     * To be used by other implementations of JSSEngine.
+     */
+    protected void fireAlertSent(SSLAlertEvent event) {
+        if (listeners != null) {
+            for (EventListener event_listener : listeners) {
+                if (event_listener instanceof SSLSocketListener) {
+                    SSLSocketListener socket_listener = (SSLSocketListener) event_listener;
+                    socket_listener.alertSent(event);
+                }
+            }
+        }
+    }
+
+    /**
+     * Fires any and all SSLHandshakeCompletedListener on the specified event.
+     *
+     * To be used by other implementations of JSSEngine.
+     */
+    protected void fireHandshakeComplete(SSLHandshakeCompletedEvent event) {
+        if (listeners != null) {
+            for (EventListener event_listener : listeners) {
+                if (event_listener instanceof SSLHandshakeCompletedListener) {
+                    SSLHandshakeCompletedListener handshake_listener = (SSLHandshakeCompletedListener) event_listener;
+                    handshake_listener.handshakeCompleted(event);
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -208,7 +208,7 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     /**
      * Set of listeners to fire on events (SSL alerts, handshake completed).
      */
-    private Collection<EventListener> listeners = new ArrayList<>();
+    private Collection<? extends EventListener> listeners = new ArrayList<>();
 
     /**
      * Constructor for a JSSEngine, providing no hints for an internal
@@ -956,7 +956,7 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     /**
      * Sets a SSLSocketListener on this object.
      */
-    public void setListeners(Collection<EventListener> new_listeners) {
+    public void setListeners(Collection<? extends EventListener> new_listeners) {
         listeners = new_listeners;
     }
 
@@ -964,7 +964,11 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
      * Gets the set of SSLSocketListeners on this object.
      */
     public Collection<EventListener> getListeners() {
-        return listeners;
+        ArrayList<EventListener> result = new ArrayList<>();
+        if (listeners != null) {
+            result.addAll(listeners);
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -939,6 +939,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         while (ssl_fd.inboundOffset < ssl_fd.inboundAlerts.size()) {
             SSLAlertEvent event = ssl_fd.inboundAlerts.get(ssl_fd.inboundOffset);
             ssl_fd.inboundOffset += 1;
+            event.setEngine(this);
 
             if (event.getLevelEnum() == SSLAlertLevel.WARNING && event.getDescriptionEnum() == SSLAlertDescription.CLOSE_NOTIFY) {
                 debug("Got inbound CLOSE_NOTIFY alert");
@@ -962,6 +963,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         while (ssl_fd.outboundOffset < ssl_fd.outboundAlerts.size()) {
             SSLAlertEvent event = ssl_fd.outboundAlerts.get(ssl_fd.outboundOffset);
             ssl_fd.outboundOffset += 1;
+            event.setEngine(this);
 
             if (event.getLevelEnum() == SSLAlertLevel.WARNING && event.getDescriptionEnum() == SSLAlertDescription.CLOSE_NOTIFY) {
                 debug("Sent outbound CLOSE_NOTIFY alert.");

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -947,6 +947,9 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
             debug("JSSEngine: Got inbound alert: " + event);
 
+            // Fire inbound alert prior to raising any exception.
+            fireAlertReceived(event);
+
             // Not every SSL Alert is fatal; toException() only returns a
             // SSLException on fatal instances. We shouldn't return NULL
             // early without checking all alerts.
@@ -966,6 +969,11 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             }
 
             debug("JSSEngine: Got outbound alert: " + event);
+
+            // Fire outbound alert prior to raising any exception. Note that
+            // this still triggers after this alert is written to the output
+            // wire buffer.
+            fireAlertSent(event);
 
             SSLException exception = event.toException();
             if (exception != null) {
@@ -1078,6 +1086,9 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
             // Also update our session information here.
             session.refreshData();
+
+            // Finally, fire any handshake completed event listeners now.
+            fireHandshakeComplete(new SSLHandshakeCompletedEvent(this));
 
             return;
         }

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSParameters.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSParameters.java
@@ -26,7 +26,7 @@ public class JSSParameters extends SSLParameters {
     private SSLVersionRange range;
     private String alias;
     private String hostname;
-    private Collection<EventListener> listeners;
+    private Collection<? extends EventListener> listeners;
 
     public JSSParameters() {
         // Choose our default set of SSLParameters here; default to null
@@ -197,10 +197,14 @@ public class JSSParameters extends SSLParameters {
     }
 
     public Collection<EventListener> getListeners() {
-        return listeners;
+        ArrayList<EventListener> result = new ArrayList<>();
+        if (listeners != null) {
+            result.addAll(listeners);
+        }
+        return result;
     }
 
-    public void setListeners(Collection<EventListener> new_listeners) {
+    public void setListeners(Collection<? extends EventListener> new_listeners) {
         listeners = new_listeners;
     }
 }

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSParameters.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSParameters.java
@@ -26,6 +26,7 @@ public class JSSParameters extends SSLParameters {
     private SSLVersionRange range;
     private String alias;
     private String hostname;
+    private Collection<EventListener> listeners;
 
     public JSSParameters() {
         // Choose our default set of SSLParameters here; default to null
@@ -193,5 +194,13 @@ public class JSSParameters extends SSLParameters {
 
     public void setHostname(String server_hostname) {
         hostname = server_hostname;
+    }
+
+    public Collection<EventListener> getListeners() {
+        return listeners;
+    }
+
+    public void setListeners(Collection<EventListener> new_listeners) {
+        listeners = new_listeners;
     }
 }

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocket.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocket.java
@@ -293,6 +293,25 @@ public class JSSServerSocket extends SSLServerSocket {
         engine.setTrustManagers(xtms);
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     /* == stubs over SSLServerSocket == */
 
     /**

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocket.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocket.java
@@ -298,7 +298,7 @@ public class JSSServerSocket extends SSLServerSocket {
      *
      * @see JSSEngine#setListeners(Collection)
      */
-    public void setListeners(Collection<EventListener> listeners) {
+    public void setListeners(Collection<? extends EventListener> listeners) {
         engine.setListeners(listeners);
     }
 

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocketChannel.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocketChannel.java
@@ -69,7 +69,7 @@ public class JSSServerSocketChannel extends ServerSocketChannel {
      *
      * @see JSSEngine#setListeners(Collection)
      */
-    public void setListeners(Collection<EventListener> listeners) {
+    public void setListeners(Collection<? extends EventListener> listeners) {
         engine.setListeners(listeners);
     }
 

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocketChannel.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocketChannel.java
@@ -64,6 +64,25 @@ public class JSSServerSocketChannel extends ServerSocketChannel {
         return this;
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     @Override
     public <T> T getOption(SocketOption<T> name) throws IOException {
         if (parent == null) {

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
@@ -433,7 +433,7 @@ public class JSSSocket extends SSLSocket {
      *
      * @see JSSEngine#setListeners(Collection)
      */
-    public void setListeners(Collection<EventListener> listeners) {
+    public void setListeners(Collection<? extends EventListener> listeners) {
         engine.setListeners(listeners);
     }
 

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
@@ -428,6 +428,25 @@ public class JSSSocket extends SSLSocket {
         engine.setTrustManagers(xtms);
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     /* == stubs over SSLSocket == */
 
     /**

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -408,6 +408,25 @@ public class JSSSocketChannel extends SocketChannel {
         }
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     /* == generic stubs for SocketChannel */
 
     @Override

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -413,7 +413,7 @@ public class JSSSocketChannel extends SocketChannel {
      *
      * @see JSSEngine#setListeners(Collection)
      */
-    public void setListeners(Collection<EventListener> listeners) {
+    public void setListeners(Collection<? extends EventListener> listeners) {
         engine.setListeners(listeners);
     }
 


### PR DESCRIPTION
Per discussion with @jmagne today, I'm proposing this interface.

This adds a generic [EventListener](https://docs.oracle.com/javase/8/docs/api/java/util/EventListener.html) interface to JSSEngine, allowing events to be propagated to the relevant logs. In particular, in discussion with Jack, we noticed the lack of server-side SSL alert event notification. Theoretically handshake status could be identified by the caller of the SSLEngine (wrap/unwrap returns FINISHED as handshake state once the handshake has successfully completed) and fatal alerts could be detected via watching exceptions. However, sometimes the SSLContext constructor has access to additional configuration and control over SSLEngine construction (such as in Tomcat) --- but _not_ over results from calls to wrap/unwrap (and exceptions thereof) --- preventing relevant information being additionally logged into the Audit log.

Note that the two event listeners implemented here are the same ones used under 10.5 to handle the required audit logging, so this should be fairly easy to go add if support is added in TomcatJSS; the relevant listener implementations should already be written. 

TODO:

 - [ ] Verify with @jmagne that this will work with TomcatJSS and exposes the desired alerts/events.
 - [x] Extend this to work with our javax.net.ssl.SSLSocket (server/client) implementations.
 - [ ] Identify any test cases we want to check this against. 

See commit messages for more information.