### PR TITLE
Fix Bug 2001169 - Audit event 'ACCESS_SESSION_ESTABLISH' is not gener…

### DIFF
--- a/src/main/java/org/mozilla/jss/ssl/SSLAlertEvent.java
+++ b/src/main/java/org/mozilla/jss/ssl/SSLAlertEvent.java
@@ -9,6 +9,7 @@ import java.util.EventObject;
 import javax.net.ssl.SSLException;
 
 import org.mozilla.jss.nss.SSLFDProxy;
+import org.mozilla.jss.ssl.javax.JSSEngine;
 
 public class SSLAlertEvent extends EventObject {
 
@@ -17,6 +18,7 @@ public class SSLAlertEvent extends EventObject {
     int level;
     int description;
 
+    transient JSSEngine engine;
     SSLAlertLevel levelEnum;
     SSLAlertDescription descriptionEnum;
 
@@ -57,11 +59,19 @@ public class SSLAlertEvent extends EventObject {
     }
 
     public SSLSocket getSocket() {
-        return (SSLSocket) getSource();
+        Object obj = getSource();
+	if( obj != null && obj instanceof SSLSocket) {
+            return (SSLSocket) obj;
+	}
+	return null;
     }
 
     public SSLFDProxy getFileDesc() {
-        return (SSLFDProxy) getSource();
+        Object obj = getSource();
+	if( obj != null && obj instanceof SSLFDProxy) { 
+            return (SSLFDProxy) getSource();
+        }
+        return null;
     }
 
     public int getLevel() {
@@ -98,6 +108,13 @@ public class SSLAlertEvent extends EventObject {
     public void setDescription(SSLAlertDescription description) {
         this.descriptionEnum = description;
         this.description = description.getID();
+    }
+
+    public JSSEngine getEngine() {
+        return engine;
+    }
+    public void setEngine(JSSEngine new_engine) {
+        engine = new_engine;
     }
 
     public SSLException toException() {

--- a/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
+++ b/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
@@ -12,6 +12,8 @@ package org.mozilla.jss.ssl;
 import java.net.*;
 import java.util.*;
 
+import org.mozilla.jss.ssl.javax.JSSEngine;
+
 /*
  * right now, this only extends EventObject, but it will eventually
  * extend javax.net.ssl.HandshakeCompletedEvent
@@ -25,21 +27,46 @@ public class SSLHandshakeCompletedEvent extends EventObject {
     private static final long serialVersionUID = 1L;
 
     public SSLHandshakeCompletedEvent(SSLSocket socket) {
-	super(socket);
+        super(socket);
+    }
+
+    public SSLHandshakeCompletedEvent(JSSEngine engine) {
+        super(engine);
     }
     
     /**
-     * get security information about this socket, including
-     * cert data
+     * Get security information about this socket, including
+     * cert data; null if on a SSLEngine.
      */
     public SSLSecurityStatus getStatus() throws SocketException {
-	return getSocket().getStatus();
+        if (getSocket() != null) {
+            return getSocket().getStatus();
+        }
+
+        return null;
     }
     
     /**
-     * get socket on which the event occured
+     * Get socket on which the event occurred; null if on a SSLEngine.
      */
     public SSLSocket getSocket() {
-	return (SSLSocket)getSource();
+        Object obj = getSource();
+        if (obj != null && obj instanceof SSLSocket) {
+            return (SSLSocket)getSource();
+        }
+
+        return null;
+    }
+
+    /**
+     * Get engine on which the event occurred; null if on a SSLSocket.
+     */
+    public JSSEngine getEngine() {
+        Object obj = getSource();
+        if (obj != null  && obj instanceof JSSEngine) {
+            return (JSSEngine)getSource();
+        }
+
+        return null;
     }
 }

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -939,6 +939,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         while (ssl_fd.inboundOffset < ssl_fd.inboundAlerts.size()) {
             SSLAlertEvent event = ssl_fd.inboundAlerts.get(ssl_fd.inboundOffset);
             ssl_fd.inboundOffset += 1;
+	    event.setEngine(this);
 
             if (event.getLevelEnum() == SSLAlertLevel.WARNING && event.getDescriptionEnum() == SSLAlertDescription.CLOSE_NOTIFY) {
                 debug("Got inbound CLOSE_NOTIFY alert");
@@ -946,6 +947,9 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             }
 
             debug("JSSEngine: Got inbound alert: " + event);
+
+            // Fire inbound alert prior to raising any exception.
+            fireAlertReceived(event);
 
             // Not every SSL Alert is fatal; toException() only returns a
             // SSLException on fatal instances. We shouldn't return NULL
@@ -959,6 +963,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         while (ssl_fd.outboundOffset < ssl_fd.outboundAlerts.size()) {
             SSLAlertEvent event = ssl_fd.outboundAlerts.get(ssl_fd.outboundOffset);
             ssl_fd.outboundOffset += 1;
+            event.setEngine(this);
 
             if (event.getLevelEnum() == SSLAlertLevel.WARNING && event.getDescriptionEnum() == SSLAlertDescription.CLOSE_NOTIFY) {
                 debug("Sent outbound CLOSE_NOTIFY alert.");
@@ -966,6 +971,11 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             }
 
             debug("JSSEngine: Got outbound alert: " + event);
+
+            // Fire outbound alert prior to raising any exception. Note that
+            // this still triggers after this alert is written to the output
+            // wire buffer.
+            fireAlertSent(event);
 
             SSLException exception = event.toException();
             if (exception != null) {
@@ -1078,6 +1088,9 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
             // Also update our session information here.
             session.refreshData();
+
+            // Finally, fire any handshake completed event listeners now.
+            fireHandshakeComplete(new SSLHandshakeCompletedEvent(this));
 
             return;
         }

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSParameters.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSParameters.java
@@ -26,6 +26,7 @@ public class JSSParameters extends SSLParameters {
     private SSLVersionRange range;
     private String alias;
     private String hostname;
+    private Collection<? extends EventListener> listeners;
 
     public JSSParameters() {
         // Choose our default set of SSLParameters here; default to null
@@ -193,5 +194,13 @@ public class JSSParameters extends SSLParameters {
 
     public void setHostname(String server_hostname) {
         hostname = server_hostname;
+    }
+
+    public Collection<? extends EventListener> getListeners() {
+        return listeners;
+    }
+
+    public void setListeners(Collection<? extends EventListener> new_listeners) {
+        listeners = new_listeners;
     }
 }

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocket.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocket.java
@@ -293,6 +293,25 @@ public class JSSServerSocket extends SSLServerSocket {
         engine.setTrustManagers(xtms);
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<? extends EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<? extends EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     /* == stubs over SSLServerSocket == */
 
     /**

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocketChannel.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocketChannel.java
@@ -64,6 +64,25 @@ public class JSSServerSocketChannel extends ServerSocketChannel {
         return this;
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<? extends EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<? extends EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     @Override
     public <T> T getOption(SocketOption<T> name) throws IOException {
         if (parent == null) {

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
@@ -428,6 +428,25 @@ public class JSSSocket extends SSLSocket {
         engine.setTrustManagers(xtms);
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<? extends EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<? extends EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     /* == stubs over SSLSocket == */
 
     /**

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -408,6 +408,25 @@ public class JSSSocketChannel extends SocketChannel {
         }
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<? extends EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<? extends EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     /* == generic stubs for SocketChannel */
 
     @Override


### PR DESCRIPTION
…ating for PKI instances acting as Server [10.2.1]

    This fix allows us to actually see ssl connection events in the audit log from the pki /server perspective.
    This fill will also require support bug fixes for both pki and tomcatjss.

Based on original code contributed by Alex Ascheel, (cipherboy).