### PR TITLE
Drop SHA-1 references from JSSProvider

### DIFF
--- a/src/main/java/org/mozilla/jss/CryptoManager.java
+++ b/src/main/java/org/mozilla/jss/CryptoManager.java
@@ -793,13 +793,10 @@ public final class CryptoManager implements TokenSupplier
         importCertToPerm(X509Certificate cert, String nickname)
         throws TokenException, InvalidNicknameException
     {
-        if (nickname==null) {
+        if (nickname == null) {
             throw new InvalidNicknameException("Nickname must be non-null");
         }
-
-        else {
-            return importCertToPermNative(cert,nickname);
-        }
+        return importCertToPermNative(cert,nickname);
     }
 
     /**
@@ -1054,15 +1051,15 @@ public final class CryptoManager implements TokenSupplier
     /********************************************************************/
 
 
-    private static native int getJSSMajorVersion();
-    private static native int getJSSMinorVersion();
-    private static native int getJSSPatchVersion();
+    public static native int getJSSMajorVersion();
+    public static native int getJSSMinorVersion();
+    public static native int getJSSPatchVersion();
 
     public static final String getJSSVersion() {
         return String.format("%d.%d.%d", getJSSMajorVersion(), getJSSMinorVersion(), getJSSPatchVersion());
     }
 
-    private static native boolean getJSSDebug();
+    public static native boolean getJSSDebug();
 
     public static final boolean JSS_DEBUG = getJSSDebug();
 
@@ -1169,21 +1166,12 @@ public final class CryptoManager implements TokenSupplier
         }
         // 0 certificate usage will get current usage
         // should call isCertValid() call above that returns certificate usage
-        if ((certificateUsage == null) ||
-                (certificateUsage == CertificateUsage.CheckAllUsages)){
-            int currCertificateUsage = 0x0000;
-            currCertificateUsage = verifyCertificateNowCUNative(nickname,
-                checkSig);
-
-            if (currCertificateUsage == CertificateUsage.basicCertificateUsages){
-                // cert is good for nothing
-                return false;
-            } else
-                return true;
-        } else {
-            return verifyCertificateNowNative(nickname, checkSig,
-              certificateUsage.getUsage());
+        if (certificateUsage == null || certificateUsage == CertificateUsage.CheckAllUsages) {
+            int currCertificateUsage = verifyCertificateNowCUNative(nickname, checkSig);
+            return currCertificateUsage != CertificateUsage.basicCertificateUsages;
         }
+        return verifyCertificateNowNative(nickname, checkSig,
+          certificateUsage.getUsage());
     }
 
     /**

--- a/src/main/java/org/mozilla/jss/CryptoManager.java
+++ b/src/main/java/org/mozilla/jss/CryptoManager.java
@@ -1054,15 +1054,15 @@ public final class CryptoManager implements TokenSupplier
     /********************************************************************/
 
 
-    public native static int getJSSMajorVersion();
-    public native static int getJSSMinorVersion();
-    public native static int getJSSPatchVersion();
-    private native static boolean getJSSDebug();
+    private static native int getJSSMajorVersion();
+    private static native int getJSSMinorVersion();
+    private static native int getJSSPatchVersion();
 
-    public static final String
-    JAR_JSS_VERSION     = "JSS_VERSION = JSS_" + getJSSMajorVersion() +
-                          "_" + getJSSMinorVersion() +
-                          "_" + getJSSPatchVersion();
+    public static final String getJSSVersion() {
+        return String.format("%d.%d.%d", getJSSMajorVersion(), getJSSMinorVersion(), getJSSPatchVersion());
+    }
+
+    private static native boolean getJSSDebug();
 
     public static final boolean JSS_DEBUG = getJSSDebug();
 

--- a/src/main/java/org/mozilla/jss/JSSProvider.java
+++ b/src/main/java/org/mozilla/jss/JSSProvider.java
@@ -15,12 +15,7 @@ public final class JSSProvider extends java.security.Provider {
     /* of JSS is generated. Note that this is done by changing          */
     /* cmake/JSSConfig.cmake.                                           */
     /********************************************************************/
-    private static int JSS_MAJOR_VERSION  = CryptoManager.getJSSMajorVersion();
-    private static int JSS_MINOR_VERSION  = CryptoManager.getJSSMinorVersion();
-    private static int JSS_PATCH_VERSION  = CryptoManager.getJSSPatchVersion();
-    private static double JSS_VERSION     = JSS_MAJOR_VERSION +
-                                           (JSS_MINOR_VERSION * 100 +
-                                            JSS_PATCH_VERSION)/10000.0;
+    private static final String JSS_VERSION = CryptoManager.getJSSVersion();
 
     private static JSSLoader loader = new JSSLoader();
 
@@ -31,8 +26,7 @@ public final class JSSProvider extends java.security.Provider {
     }
 
     public JSSProvider(boolean initialize) {
-        super("Mozilla-JSS", String.valueOf(JSS_VERSION),
-                "Provides Signature, Message Digesting, and RNG");
+        super("Mozilla-JSS", JSS_VERSION, "Provides Signature, Message Digesting, and RNG");
 
         if (initialize) {
             initializeProvider();
@@ -398,13 +392,6 @@ public final class JSSProvider extends java.security.Provider {
 
     @Override
     public String toString() {
-        String mozillaProviderVersion = JSS_MAJOR_VERSION + "." +
-                                        JSS_MINOR_VERSION;
-        if ( JSS_PATCH_VERSION != 0 ) {
-            mozillaProviderVersion = mozillaProviderVersion + "." +
-                                     JSS_PATCH_VERSION;
-        }
-
-        return "Mozilla-JSS version " + mozillaProviderVersion;
+        return "Mozilla-JSS version: " + JSS_VERSION;
     }
 }

--- a/src/main/java/org/mozilla/jss/JSSProvider.java
+++ b/src/main/java/org/mozilla/jss/JSSProvider.java
@@ -31,7 +31,7 @@ public final class JSSProvider extends java.security.Provider {
     }
 
     public JSSProvider(boolean initialize) {
-        super("Mozilla-JSS", JSS_VERSION,
+        super("Mozilla-JSS", String.valueOf(JSS_VERSION),
                 "Provides Signature, Message Digesting, and RNG");
 
         if (initialize) {
@@ -92,16 +92,6 @@ public final class JSSProvider extends java.security.Provider {
         /////////////////////////////////////////////////////////////
         // Signature
         /////////////////////////////////////////////////////////////
-        put("Signature.SHA1withDSA",
-            "org.mozilla.jss.provider.java.security.JSSSignatureSpi$DSA");
-
-        put("Alg.Alias.Signature.DSA", "SHA1withDSA");
-        put("Alg.Alias.Signature.DSS", "SHA1withDSA");
-        put("Alg.Alias.Signature.SHA/DSA", "SHA1withDSA");
-        put("Alg.Alias.Signature.SHA-1/DSA", "SHA1withDSA");
-        put("Alg.Alias.Signature.SHA1/DSA", "SHA1withDSA");
-        put("Alg.Alias.Signature.DSAWithSHA1", "SHA1withDSA");
-        put("Alg.Alias.Signature.SHAwithDSA", "SHA1withDSA");
 
         put("Signature.MD5/RSA",
             "org.mozilla.jss.provider.java.security.JSSSignatureSpi$MD5RSA");
@@ -109,11 +99,6 @@ public final class JSSProvider extends java.security.Provider {
 
         put("Signature.MD2/RSA",
             "org.mozilla.jss.provider.java.security.JSSSignatureSpi$MD2RSA");
-
-        put("Signature.SHA-1/RSA",
-            "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA1RSA");
-        put("Alg.Alias.Signature.SHA1/RSA", "SHA-1/RSA");
-        put("Alg.Alias.Signature.SHA1withRSA", "SHA-1/RSA");
 
         put("Signature.SHA-256/RSA",
             "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA256RSA");
@@ -152,17 +137,6 @@ public final class JSSProvider extends java.security.Provider {
         put("Alg.Alias.Signature.SHA512/RSA", "SHA-512/RSA");
         put("Alg.Alias.Signature.SHA512withRSA", "SHA-512/RSA");
 // ECC
-        put("Signature.SHA1withEC",
-            "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA1EC");
-        put("Alg.Alias.Signature.EC", "SHA1withEC");
-        put("Alg.Alias.Signature.ECC", "SHA1withEC");
-        put("Alg.Alias.Signature.ECDSA", "SHA1withEC");
-        put("Alg.Alias.Signature.SHA/EC", "SHA1withEC");
-        put("Alg.Alias.Signature.SHA1/EC", "SHA1withEC");
-        put("Alg.Alias.Signature.SHA-1/EC", "SHA1withEC");
-        put("Alg.Alias.Signature.SHA/ECDSA", "SHA1withEC");
-        put("Alg.Alias.Signature.SHA1/ECDSA", "SHA1withEC");
-        put("Alg.Alias.Signature.SHA1withECDSA", "SHA1withEC"); //JCE Standard Name
 
         put("Signature.SHA256withEC",
             "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA256EC");
@@ -186,8 +160,6 @@ public final class JSSProvider extends java.security.Provider {
         // Message Digesting
         /////////////////////////////////////////////////////////////
 
-        put("MessageDigest.SHA-1",
-                "org.mozilla.jss.provider.java.security.JSSMessageDigestSpi$SHA1");
         put("MessageDigest.MD2",
                 "org.mozilla.jss.provider.java.security.JSSMessageDigestSpi$MD2");
         put("MessageDigest.MD5",
@@ -199,8 +171,6 @@ public final class JSSProvider extends java.security.Provider {
         put("MessageDigest.SHA-512",
                 "org.mozilla.jss.provider.java.security.JSSMessageDigestSpi$SHA512");
 
-        put("Alg.Alias.MessageDigest.SHA1", "SHA-1");
-        put("Alg.Alias.MessageDigest.SHA", "SHA-1");
         put("Alg.Alias.MessageDigest.SHA256", "SHA-256");
         put("Alg.Alias.MessageDigest.SHA384", "SHA-384");
         put("Alg.Alias.MessageDigest.SHA512", "SHA-512");
@@ -381,7 +351,6 @@ public final class JSSProvider extends java.security.Provider {
             "org.mozilla.jss.provider.javax.crypto.JSSMacSpi$HmacSHA512");
         put("Mac.CmacAES", "org.mozilla.jss.provider.javax.crypto.JSSMacSpi$CmacAES");
         put("Alg.Alias.Mac.Hmac-SHA512", "HmacSHA512");
-        put("Alg.Alias.Mac.SHA-1-HMAC", "HmacSHA1");
         put("Alg.Alias.Mac.SHA-256-HMAC", "HmacSHA256");
         put("Alg.Alias.Mac.SHA-384-HMAC", "HmacSHA384");
         put("Alg.Alias.Mac.SHA-512-HMAC", "HmacSHA512");

--- a/src/test/java/org/mozilla/jss/tests/JSSPackageTest.java
+++ b/src/test/java/org/mozilla/jss/tests/JSSPackageTest.java
@@ -26,7 +26,7 @@ public class JSSPackageTest {
             }
             System.out.println("\n\tFetching version information " +
                                "from CryptoManager");
-            System.out.println("\n\t" + org.mozilla.jss.CryptoManager.JAR_JSS_VERSION);
+            System.out.println("\n\t" + org.mozilla.jss.CryptoManager.getJSSVersion());
 
             System.out.println("\n\tTo check the JNI version in libjss.so:");
             System.out.println("\n\ttry: strings libjss.so | grep -i header");


### PR DESCRIPTION
* Also modify constructor to use non-deprecated superclass constructor.