### PR TITLE
Remove redundant test executions

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -36,7 +36,7 @@ jobs:
             openjdk-11-jdk libcommons-lang3-java libslf4j-java junit4
 
     - name: Build JSS binaries, Javadoc, and run tests
-      run: ./build.sh
+      run: ./build.sh --with-tests
 
   # Compare JNI symbols in the code and in the version script.
   # If there are JNI symbols in the code but not in the version script -> fail.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
     condition: or(startsWith(variables.image, 'debian_'), startsWith(variables.image, 'ubuntu_'))
     displayName: Install Debian/Ubuntu dependencies
 
-  - script: ./build.sh
+  - script: ./build.sh --with-tests
     displayName: Build JSS binaries, Javadoc, and run tests
 
 - job: SymbolTest

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ WITH_COMMIT_ID=
 DIST=
 
 WITHOUT_JAVADOC=
-WITHOUT_TEST=
+WITH_TESTS=
 
 VERBOSE=
 DEBUG=
@@ -52,7 +52,7 @@ usage() {
     echo "    --with-commit-id       Append commit ID to release number."
     echo "    --dist=<name>          Distribution name (e.g. fc28)."
     echo "    --without-javadoc      Do not build Javadoc package."
-    echo "    --without-test         Do not run unit tests."
+    echo "    --with-tests           Run unit tests."
     echo " -v,--verbose              Run in verbose mode."
     echo "    --debug                Run in debug mode."
     echo "    --help                 Show help message."
@@ -152,9 +152,9 @@ generate_rpm_spec() {
     fi
 
     # hard-code test option
-    if [ "$WITHOUT_TEST" = true ] ; then
-        # convert bcond_without into bcond_with such that unit tests do not run by default
-        commands="${commands}; s/%\(bcond_without *test\)\$/# \1\n%bcond_with test/g"
+    if [ "$WITH_TESTS" = true ] ; then
+        # convert bcond_with into bcond_without such that it runs unit tests by default
+        commands="${commands}; s/%\(bcond_with *tests\)\$/# \1\n%bcond_without tests/g"
     fi
 
     sed "$commands" "$SPEC_TEMPLATE" > "$WORK_DIR/SPECS/$RPM_SPEC"
@@ -207,8 +207,8 @@ while getopts v-: arg ; do
         without-javadoc)
             WITHOUT_JAVADOC=true
             ;;
-        without-test)
-            WITHOUT_TEST=true
+        with-tests)
+            WITH_TESTS=true
             ;;
         verbose)
             VERBOSE=true
@@ -311,7 +311,7 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
         make "${OPTIONS[@]}" javadoc
     fi
 
-    if [ "$WITHOUT_TEST" != true ] ; then
+    if [ "$WITH_TESTS" = true ] ; then
         ctest --output-on-failure
     fi
 
@@ -321,6 +321,7 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
     echo "- shared library: $WORK_DIR/libjss.so"
     echo "- documentation: $WORK_DIR/docs"
     echo
+    echo "To run the tests: $0 --with-tests"
     echo "To install the build: $0 install"
     echo "To create RPM packages: $0 rpm"
     echo

--- a/jss.spec
+++ b/jss.spec
@@ -45,10 +45,10 @@ Source:         https://github.com/dogtagpki/%{name}/archive/v%{version}%{?_phas
 
 %bcond_without javadoc
 
-# By default the build will execute unit tests unless --without test
+# By default the build will not execute unit tests unless --with tests
 # option is specified.
 
-%bcond_without test
+%bcond_with tests
 
 ################################################################################
 # Build Dependencies
@@ -128,7 +128,7 @@ modutil -dbdir /etc/pki/nssdb -chkfips true | grep -q enabled && export FIPS_ENA
     --jss-lib-dir=%{_libdir}/jss \
     --version=%{version} \
     %{!?with_javadoc:--without-javadoc} \
-    %{!?with_test:--without-test} \
+    %{?with_tests:--with-tests} \
     dist
 
 ################################################################################


### PR DESCRIPTION
To reduce redundancy the `build.sh` has been modified to no longer execute the unit tests by default. Instead, the tests will only be executed in the CI. The tests can still be executed locally by specifying a `--with-test` option.