### PR TITLE
Deprecate PK11InternalTokenCert and PK11InternalCert

### DIFF
--- a/docs/changes/v5.1.0/API-Changes.adoc
+++ b/docs/changes/v5.1.0/API-Changes.adoc
@@ -1,0 +1,11 @@
+= API Changes =
+
+== Deprecate org.mozilla.jss.pkcs11.PK11InternalTokenCert ==
+
+The `org.mozilla.jss.pkcs11.PK11InternalTokenCert` class has been deprecated and will be removed in the future.
+Use `org.mozilla.jss.pkcs11.PK11Cert` instead.
+
+== Deprecate org.mozilla.jss.pkcs11.PK11InternalCert ==
+
+The `org.mozilla.jss.pkcs11.PK11InternalCert` class has been deprecated and will be removed in the future.
+Use `org.mozilla.jss.pkcs11.PK11Cert` instead.

--- a/src/main/java/org/mozilla/jss/pkcs11/PK11InternalCert.java
+++ b/src/main/java/org/mozilla/jss/pkcs11/PK11InternalCert.java
@@ -4,97 +4,14 @@
 
 package org.mozilla.jss.pkcs11;
 
-import org.mozilla.jss.crypto.*;
-
 /**
  * A certificate that lives in the internal cert database.
+ *
+ * @deprecated Use PK11Cert instead.
  */
-public class PK11InternalCert extends PK11Cert
-        implements InternalCertificate
-{
-    ///////////////////////////////////////////////////////////////////////
-    // Trust Management.  This is all package stuff because it can only
-    // be called from PK11InternalCert.
-    ///////////////////////////////////////////////////////////////////////
-    public static final int SSL = 0;
-    public static final int EMAIL = 1;
-    public static final int OBJECT_SIGNING=2;
+@Deprecated
+public class PK11InternalCert extends PK11Cert {
 
-    /**
-     * Set the SSL trust flags for this certificate.
-     *
-     * @param trust A bitwise OR of the trust flags VALID_PEER, VALID_CA,
-     *      TRUSTED_CA, USER, and TRUSTED_CLIENT_CA.
-     */
-    @Override
-    public void setSSLTrust(int trust)
-    {
-        super.setTrust(SSL, trust);
-    }
-
-    /**
-     * Set the email (S/MIME) trust flags for this certificate.
-     *
-     * @param trust A bitwise OR of the trust flags VALID_PEER, VALID_CA,
-     *      TRUSTED_CA, USER, and TRUSTED_CLIENT_CA.
-     */
-    @Override
-    public void setEmailTrust(int trust)
-    {
-        super.setTrust(EMAIL, trust);
-    }
-
-    /**
-     * Set the object signing trust flags for this certificate.
-     *
-     * @param trust A bitwise OR of the trust flags VALID_PEER, VALID_CA,
-     *      TRUSTED_CA, USER, and TRUSTED_CLIENT_CA.
-     */
-    @Override
-    public void setObjectSigningTrust(int trust)
-    {
-        super.setTrust(OBJECT_SIGNING, trust);
-    }
-
-    /**
-     * Get the SSL trust flags for this certificate.
-     *
-     * @return A bitwise OR of the trust flags VALID_PEER, VALID_CA,
-     *      TRUSTED_CA, USER, and TRUSTED_CLIENT_CA.
-     */
-    @Override
-    public int getSSLTrust()
-    {
-        return super.getTrust(SSL);
-    }
-
-    /**
-     * Get the email (S/MIME) trust flags for this certificate.
-     *
-     * @return A bitwise OR of the trust flags VALID_PEER, VALID_CA,
-     *      TRUSTED_CA, USER, and TRUSTED_CLIENT_CA.
-     */
-    @Override
-    public int getEmailTrust()
-    {
-        return super.getTrust(EMAIL);
-    }
-
-    /**
-     * Get the object signing trust flags for this certificate.
-     *
-     * @return A bitwise OR of the trust flags VALID_PEER, VALID_CA,
-     *      TRUSTED_CA, USER, and TRUSTED_CLIENT_CA.
-     */
-    @Override
-    public int getObjectSigningTrust()
-    {
-        return super.getTrust(OBJECT_SIGNING);
-    }
-
-	/////////////////////////////////////////////////////////////
-	// Construction
-	/////////////////////////////////////////////////////////////
     PK11InternalCert(byte[] certPtr, byte[] slotPtr, String nickname) {
         super(certPtr, slotPtr, nickname);
     }

--- a/src/main/java/org/mozilla/jss/pkcs11/PK11InternalTokenCert.java
+++ b/src/main/java/org/mozilla/jss/pkcs11/PK11InternalTokenCert.java
@@ -4,24 +4,14 @@
 
 package org.mozilla.jss.pkcs11;
 
-import org.mozilla.jss.crypto.*;
-
 /**
  * A certificate that lives on the internal token.  It has database information
  * (like trust flags) but also PKCS #11 information (like unique ID).
+ *
+ * @deprecated Use PK11Cert instead.
  */
-public final class PK11InternalTokenCert extends PK11InternalCert
-    implements TokenCertificate
-{
-    @Override
-    public byte[] getUniqueID() {
-        return super.getUniqueID();
-    }
-
-    @Override
-    public CryptoToken getOwningToken() {
-        return super.getOwningToken();
-    }
+@Deprecated
+public final class PK11InternalTokenCert extends PK11InternalCert {
 
     PK11InternalTokenCert(byte[] certPtr, byte[] slotPtr, String nickname) {
         super(certPtr, slotPtr, nickname);


### PR DESCRIPTION
The constants and methods in `PK11InternalTokenCert` and `PK11InternalCert` have been moved into `PK11Cert` to make it easier to use.
    
JSS will continue to create `PK11InternalTokenCert` and `PK11InternalCert` objects for backward compatibility, but these classes have been deprecated and will be removed in the future.

https://github.com/edewata/jss/blob/cleanup/docs/changes/v5.1.0/API-Changes.adoc
