### PR TITLE
Update Fedora container and COPR repository

### DIFF
--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -6,19 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
-    container: fedora:latest
+    container: fedora:34
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
-          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export current=$(cat /etc/fedora-release | awk '{ print $3 }')
           export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1 }')
-          echo "Running CI against Fedora $previous and $latest"
+          echo "Running CI against Fedora $previous and $current"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$current\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi
@@ -28,7 +28,7 @@ jobs:
     needs: init
     runs-on: ubuntu-latest
     env:
-      COPR_REPO: "@pki/10.11"
+      COPR_REPO: "@pki/10.12"
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/jss
-      COPR_REPO: "@pki/10.11"
+      COPR_REPO: "@pki/10.12"
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:

--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -10,7 +10,7 @@ jobs:
         image:
           - 'fedora_33'
           - 'fedora_34'
-          - 'fedora_latest_jdk11'
+          - 'fedora_34_jdk11'
           - 'symbolcheck'
           - 'debian_jdk11'
           - 'ubuntu_jdk11'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-ARG OS_VERSION="latest"
-ARG COPR_REPO="@pki/10.11"
+ARG OS_VERSION="34"
+ARG COPR_REPO="@pki/10.12"
 
 ################################################################################
 FROM registry.fedoraproject.org/fedora:$OS_VERSION AS jss-builder

--- a/tools/Dockerfiles/fedora_33
+++ b/tools/Dockerfiles/fedora_33
@@ -5,7 +5,7 @@ RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core git gcc make rpm-build \
                           java-devel python2 python3 diffutils \
-        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/10.11} \
+        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/10.12} \
         && dnf build-dep -y jss \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \

--- a/tools/Dockerfiles/fedora_34
+++ b/tools/Dockerfiles/fedora_34
@@ -5,7 +5,7 @@ RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core git gcc make rpm-build \
                           java-devel python2 python3 diffutils \
-        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/10.11} \
+        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/10.12} \
         && dnf build-dep -y jss \
         && mkdir -p /home/sandbox \
         && dnf clean -y all \

--- a/tools/Dockerfiles/fedora_34_jdk11
+++ b/tools/Dockerfiles/fedora_34_jdk11
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:34
 
 # Install generic dependencies to build jss
 RUN true \

--- a/tools/Dockerfiles/pki_build
+++ b/tools/Dockerfiles/pki_build
@@ -1,10 +1,10 @@
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:34
 
 # Install generic dependencies to build jss and pki
 RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core gcc make rpm-build \
-        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/10.11} \
+        && dnf copr -y enable ${JSS_4_6_REPO:-@pki/10.12} \
         && dnf build-dep -y jss pki-core \
         && mkdir -p /home/sandbox \
         && git clone -b v10.11 https://github.com/dogtagpki/pki /home/sandbox/pki \

--- a/tools/Dockerfiles/stylecheck
+++ b/tools/Dockerfiles/stylecheck
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:34
 
 # Install generic dependencies to check style
 RUN true \

--- a/tools/Dockerfiles/symbolcheck
+++ b/tools/Dockerfiles/symbolcheck
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:34
 
 # Install generic dependencies to check symbols
 RUN true \


### PR DESCRIPTION
JSS 4.9 is only supported up to Fedora 34 for PKI 10.12, so the Fedora container has been changed to `fedora:34` and the  COPR repository has been changed to `@pki/10.12`.