### PR TITLE
Prevent SHA-1 from being used by default - prefer SHA-256

### DIFF
--- a/src/main/java/org/mozilla/jss/CryptoManager.java
+++ b/src/main/java/org/mozilla/jss/CryptoManager.java
@@ -571,13 +571,13 @@ public final class CryptoManager implements TokenSupplier
         // Force class load before we install the provider. Otherwise we get
         // an infinite loop as the Security manager tries to instantiate the
         // digest to verify its own JAR file.
-        JSSMessageDigestSpi mds = new JSSMessageDigestSpi.SHA1();
+        JSSMessageDigestSpi mds = new JSSMessageDigestSpi.SHA256();
         logger.debug("Loaded " + mds);
 
         // Force the KeyType class to load before we can install JSS as a
         // provider.  JSS's signature provider accesses KeyType.
         KeyType kt = KeyType.getKeyTypeFromAlgorithm(
-            SignatureAlgorithm.RSASignatureWithSHA1Digest);
+            SignatureAlgorithm.RSASignatureWithSHA256Digest);
         logger.debug("Loaded " + kt);
 
         if( values.installJSSProvider ) {

--- a/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
+++ b/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
@@ -305,7 +305,7 @@ public class PKCS12Util {
 
     BigInteger createLocalID(byte[] bytes) throws Exception {
 
-        MessageDigest md = MessageDigest.getInstance("SHA");
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
         md.update(bytes);
         return new BigInteger(1, md.digest());
     }

--- a/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
+++ b/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
@@ -76,10 +76,10 @@ public class PKCS12Util {
 
     public final static String NO_ENCRYPTION = "none";
 
-    public final static List<PBEAlgorithm> SUPPORTED_CERT_ENCRYPTIONS = Arrays.asList(new PBEAlgorithm[] {
+    public final static List<PBEAlgorithm> SUPPORTED_CERT_ENCRYPTIONS = Arrays.asList(
             null, // none
             PBEAlgorithm.PBE_SHA1_RC2_40_CBC
-    });
+    );
 
     public final static List<PBEAlgorithm> SUPPORTED_KEY_ENCRYPTIONS = Arrays.asList(new PBEAlgorithm[] {
             PBEAlgorithm.PBE_PKCS5_PBES2,
@@ -299,7 +299,7 @@ public class PKCS12Util {
     }
 
     BigInteger createLocalID(X509Certificate cert) throws Exception {
-        // SHA1 hash of the X509Cert DER encoding
+        // SHA-256 hash of the X509Cert DER encoding
         return createLocalID(cert.getEncoded());
     }
 

--- a/src/main/java/org/mozilla/jss/pkcs12/AuthenticatedSafes.java
+++ b/src/main/java/org/mozilla/jss/pkcs12/AuthenticatedSafes.java
@@ -51,10 +51,10 @@ public class AuthenticatedSafes implements ASN1Value {
     private static final int SALT_LENGTH = 20;
 
     /**
-     * The default PBE key generation algorithm: SHA-1 with RC2 40-bit CBC.
+     * The default PBE key generation algorithm: PBES2 with AES 128-bit CBC.
      */
     public static final PBEAlgorithm DEFAULT_KEY_GEN_ALG =
-                PBEAlgorithm.PBE_SHA1_RC2_40_CBC;
+                PBEAlgorithm.PBE_PKCS5_PBES2;
 
     // security dynamics has a weird way of packaging things, we'll
     // work with it for debugging

--- a/src/main/java/org/mozilla/jss/pkcs12/MacData.java
+++ b/src/main/java/org/mozilla/jss/pkcs12/MacData.java
@@ -115,24 +115,24 @@ public class MacData implements ASN1Value {
 
         try {
             // generate key from password and salt
-            KeyGenerator kg = token.getKeyGenerator(KeyGenAlgorithm.PBA_SHA1_HMAC);
+            KeyGenerator kg = token.getKeyGenerator(KeyGenAlgorithm.SHA256_HMAC);
             kg.setCharToByteConverter(new PasswordConverter());
             kg.initialize(params);
             SymmetricKey key = kg.generate();
 
             // perform the digesting
-            JSSMessageDigest digest = token.getDigestContext(HMACAlgorithm.SHA1);
+            JSSMessageDigest digest = token.getDigestContext(HMACAlgorithm.SHA256);
             digest.initHMAC(key);
             byte[] digestBytes = digest.digest(toBeMACed);
 
             // put everything into a DigestInfo
-            AlgorithmIdentifier algID = new AlgorithmIdentifier(DigestAlgorithm.SHA1.toOID());
+            AlgorithmIdentifier algID = new AlgorithmIdentifier(DigestAlgorithm.SHA256.toOID());
             this.mac = new DigestInfo(algID, new OCTET_STRING(digestBytes));
             this.macSalt = new OCTET_STRING(macSalt);
             this.macIterationCount = new INTEGER(iterations);
 
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA-1 HMAC algorithm not found on internal " +
+            throw new RuntimeException("SHA-256 HMAC algorithm not found on internal " +
                     "token: " + e.getMessage(), e);
 
         } catch (InvalidAlgorithmParameterException e) {

--- a/src/main/java/org/mozilla/jss/pkcs12/SafeBag.java
+++ b/src/main/java/org/mozilla/jss/pkcs12/SafeBag.java
@@ -285,7 +285,7 @@ public final class SafeBag implements ASN1Value {
     {
       try {
 
-        PBEAlgorithm pbeAlg = PBEAlgorithm.PBE_SHA1_DES3_CBC;
+        PBEAlgorithm pbeAlg = PBEAlgorithm.PBE_PKCS5_PBES2;
         final int DEFAULT_ITERATIONS = 1;
         byte[] salt = new byte[pbeAlg.getSaltLength()];
 
@@ -293,7 +293,7 @@ public final class SafeBag implements ASN1Value {
         rand.nextBytes(salt);
 
         EncryptedPrivateKeyInfo epki= EncryptedPrivateKeyInfo.createPBE(
-                PBEAlgorithm.PBE_SHA1_DES3_CBC, password, salt,
+                pbeAlg, password, salt,
                 DEFAULT_ITERATIONS, new PasswordConverter(), privk);
 
         SET attributes = new SET();

--- a/src/main/java/org/mozilla/jss/pkcs12/SafeBag.java
+++ b/src/main/java/org/mozilla/jss/pkcs12/SafeBag.java
@@ -193,7 +193,7 @@ public final class SafeBag implements ASN1Value {
     /**
      * Creates a SafeBag that contains an X.509 Certificate.
      * The SafeBag will have a <i>localKeyID</i> attribute equal
-     *  to the SHA-1 hash of the certificate, and a <i>friendlyName</i>
+     *  to the SHA-256 hash of the certificate, and a <i>friendlyName</i>
      *  attribute equal to the supplied string.  This is the way Communicator
      *  makes a CertBag.  The same <i>localKeyID</i> attribute should be stored
      *  in the matching private key bag.
@@ -255,13 +255,13 @@ public final class SafeBag implements ASN1Value {
      *  and certificate.
      *
      * @param derCert A DER-encoded X.509 certificate.
-     * @return The SHA-1 hash of the cert, which should be used as the
+     * @return The SHA-256 hash of the cert, which should be used as the
      *      localKeyID attribute for the cert's SafeBag.
      */
     public static final byte[]
     getLocalKeyIDFromCert(byte[] derCert)
             throws DigestException, NoSuchAlgorithmException {
-        MessageDigest digester = MessageDigest.getInstance("SHA-1");
+        MessageDigest digester = MessageDigest.getInstance("SHA-256");
         return digester.digest(derCert);
     }
 

--- a/src/main/java/org/mozilla/jss/provider/java/security/RSAPSSAlgorithmParameters.java
+++ b/src/main/java/org/mozilla/jss/provider/java/security/RSAPSSAlgorithmParameters.java
@@ -24,8 +24,8 @@ import org.mozilla.jss.util.Assert;
  * PSSAlgorithmSpec instance and the DER-encoded form.
  *
  * RSASSA-PSS-params ::= SEQUENCE {
- *  hashAlgorithm      [0] OAEP-PSSDigestAlgorithms  DEFAULT sha1,
- * maskGenAlgorithm   [1] PKCS1MGFAlgorithms  DEFAULT mgf1SHA1,
+ *  hashAlgorithm      [0] OAEP-PSSDigestAlgorithms  DEFAULT sha256,
+ * maskGenAlgorithm   [1] PKCS1MGFAlgorithms  DEFAULT mgf1SHA256,
  * saltLength         [2] INTEGER  DEFAULT 20,
  *  trailerField       [3] INTEGER  DEFAULT 1
  * }
@@ -47,7 +47,7 @@ import org.mozilla.jss.util.Assert;
  *  }
  */
 public class RSAPSSAlgorithmParameters extends AlgorithmParametersSpi {
-    public final static AlgorithmId defaultHashAlg = new AlgorithmId(AlgorithmId.SHA_oid);
+    public final static AlgorithmId defaultHashAlg = new AlgorithmId(AlgorithmId.SHA256_oid);
     public final static AlgorithmId defaultMaskGenFunc  = new AlgorithmId(AlgorithmId.MGF1_oid);
     public final static BigInt          defaultSaltLen = new BigInt(20);
     public final static BigInt          defaultTrailerField = new BigInt(1);

--- a/src/main/java/org/mozilla/jss/provider/java/security/RSAPSSAlgorithmParameters.java
+++ b/src/main/java/org/mozilla/jss/provider/java/security/RSAPSSAlgorithmParameters.java
@@ -4,19 +4,20 @@
 
 package org.mozilla.jss.provider.java.security;
 
-import java.security.*;
+import java.io.IOException;
+import java.security.AlgorithmParametersSpi;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
-import java.security.spec.PSSParameterSpec;
 import java.security.spec.MGF1ParameterSpec;
-import java.io.IOException;
-import org.mozilla.jss.util.Assert;
+import java.security.spec.PSSParameterSpec;
+
 import org.mozilla.jss.netscape.security.util.BigInt;
-import org.mozilla.jss.netscape.security.x509.AlgorithmId;
-import org.mozilla.jss.netscape.security.util.DerOutputStream;
 import org.mozilla.jss.netscape.security.util.DerInputStream;
+import org.mozilla.jss.netscape.security.util.DerOutputStream;
 import org.mozilla.jss.netscape.security.util.DerValue;
 import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
+import org.mozilla.jss.netscape.security.x509.AlgorithmId;
+import org.mozilla.jss.util.Assert;
 
 /**
  * A RSAPSSAlgorithmParameter implements the trandcoding between a
@@ -210,28 +211,28 @@ public class RSAPSSAlgorithmParameters extends AlgorithmParametersSpi {
         int trailer = spec.getTrailerField();
 
         // Create the hash alg and mask gen func objects
-        if (hashAlgName.equals("SHA-256")) {
-            hashAlg = new AlgorithmId(AlgorithmId.SHA256_oid);
+        if (hashAlgName.equals("SHA-1") || hashAlgName.equals("SHA")) {
+            hashAlg = new AlgorithmId(AlgorithmId.SHA_oid);
         }  else if(hashAlgName.equals("SHA-512")) {
             hashAlg = new AlgorithmId(AlgorithmId.SHA512_oid);
         }  else if(hashAlgName.equals("SHA-384")) {
             hashAlg = new AlgorithmId(AlgorithmId.SHA384_oid);
         } else {
-            // Default to SHA-1 per above ASN.1 encoding.
-            hashAlg = new AlgorithmId(AlgorithmId.SHA_oid);
+            // Default to SHA-256
+            hashAlg = new AlgorithmId(AlgorithmId.SHA256_oid);
         }
     }
 
     private String getSpecAlgName(String algName) {
-        if ("SHA256".equals(algName)) {
-            return "SHA-256";
+        if ("SHA1".equals(algName) || "SHA".equals(algName)) {
+            return "SHA-1";
         } else if("SHA384".equals(algName)) {
             return "SHA-384";
         } else if("SHA512".equals(algName)) {
             return "SHA-512";
         } else {
-            // Default to SHA-1 per above ASN.1 encoding.
-            return "SHA-1";
+            // Default to SHA-256
+            return "SHA-256";
         }
     }
 }

--- a/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSSecretKeyFactorySpi.java
+++ b/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSSecretKeyFactorySpi.java
@@ -322,7 +322,7 @@ public class JSSSecretKeyFactorySpi extends SecretKeyFactorySpi {
         int iterationCount = 2;
 
         // generate a PBE key the old-fashioned way
-        keygen = tok.getKeyGenerator(PBEAlgorithm.PBE_SHA1_DES3_CBC);
+        keygen = tok.getKeyGenerator(PBEAlgorithm.PBE_PKCS5_PBMAC1);
         PBEKeyGenParams jssKeySpec =
             new PBEKeyGenParams(pw, salt, iterationCount);
         keygen.initialize(jssKeySpec);
@@ -330,7 +330,7 @@ public class JSSSecretKeyFactorySpi extends SecretKeyFactorySpi {
         byte[] keydata = symk.getKeyData();
 
         // generate a PBE key with the JCE
-        SecretKeyFactory keyFact = SecretKeyFactory.getInstance("PBEWithSHA1AndDESede", "Mozilla-JSS");
+        SecretKeyFactory keyFact = SecretKeyFactory.getInstance("PBEWithSHA256AndDESede", "Mozilla-JSS");
         newKey = (SecretKeyFacade) keyFact.generateSecret(jssKeySpec);
         byte[] newkeydata = newKey.key.getKeyData();
         if( ! java.util.Arrays.equals(keydata, newkeydata) ) {

--- a/src/test/java/org/mozilla/jss/tests/CrossHMACTest.java
+++ b/src/test/java/org/mozilla/jss/tests/CrossHMACTest.java
@@ -4,11 +4,14 @@
 package org.mozilla.jss.tests;
 
 import java.security.MessageDigest;
-import org.mozilla.jss.CryptoManager;
-import java.security.Security;
 import java.security.Provider;
-import javax.crypto.*;
-import javax.crypto.spec.*;
+import java.security.Security;
+
+import javax.crypto.Mac;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.SecretKeyFacade;
 import org.mozilla.jss.util.PasswordCallback;
@@ -128,11 +131,11 @@ public class CrossHMACTest {
         try {
             CrossHMACTest hmacTest = new CrossHMACTest(argv);
 
-            //The secret key must be a JSS key. That is, it must be an 
+            //The secret key must be a JSS key. That is, it must be an
             //instanceof org.mozilla.jss.crypto.SecretKeyFacade.
 
             //Generate the secret key using PKCS # 5 password Based Encryption
-            //we have to specify a salt and an iteration count.  
+            //we have to specify a salt and an iteration count.
 
             PBEKeySpec pbeKeySpec;
             SecretKeyFactory keyFac;
@@ -145,7 +148,7 @@ public class CrossHMACTest {
 
             pbeKeySpec = new PBEKeySpec("password".toCharArray(),
                     salt, iterationCount);
-            keyFac = SecretKeyFactory.getInstance("PBEWithSHA1AndDES3",
+            keyFac = SecretKeyFactory.getInstance("PBEWithMD5AndDES",
                     "Mozilla-JSS");
             sk = (SecretKeyFacade) keyFac.generateSecret(pbeKeySpec);
 

--- a/src/test/java/org/mozilla/jss/tests/EnumerationZeroTest.java
+++ b/src/test/java/org/mozilla/jss/tests/EnumerationZeroTest.java
@@ -127,7 +127,7 @@ public class EnumerationZeroTest {
             return new AuthorityKeyIdentifierExtension(ki, null, null);
         }
         catch (NoSuchAlgorithmException e) {
-            throw new IOException("Could not find SHA1 implementation", e);
+            throw new IOException("Could not find SHA256 implementation", e);
         }
     }
 

--- a/src/test/java/org/mozilla/jss/tests/EnumerationZeroTest.java
+++ b/src/test/java/org/mozilla/jss/tests/EnumerationZeroTest.java
@@ -18,22 +18,6 @@
 
 package org.mozilla.jss.tests;
 
-import org.mozilla.jss.JSSProvider;
-import org.mozilla.jss.netscape.security.util.BitArray;
-import org.mozilla.jss.netscape.security.util.DerInputStream;
-import org.mozilla.jss.netscape.security.util.DerValue;
-import org.mozilla.jss.netscape.security.x509.AuthorityKeyIdentifierExtension;
-import org.mozilla.jss.netscape.security.x509.CRLExtensions;
-import org.mozilla.jss.netscape.security.x509.CRLNumberExtension;
-import org.mozilla.jss.netscape.security.x509.CRLReasonExtension;
-import org.mozilla.jss.netscape.security.x509.Extension;
-import org.mozilla.jss.netscape.security.x509.KeyIdentifier;
-import org.mozilla.jss.netscape.security.x509.RevocationReason;
-import org.mozilla.jss.netscape.security.x509.RevokedCertImpl;
-import org.mozilla.jss.netscape.security.x509.RevokedCertificate;
-import org.mozilla.jss.netscape.security.x509.X500Name;
-import org.mozilla.jss.netscape.security.x509.X509CRLImpl;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -50,6 +34,22 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+
+import org.mozilla.jss.JSSProvider;
+import org.mozilla.jss.netscape.security.util.BitArray;
+import org.mozilla.jss.netscape.security.util.DerInputStream;
+import org.mozilla.jss.netscape.security.util.DerValue;
+import org.mozilla.jss.netscape.security.x509.AuthorityKeyIdentifierExtension;
+import org.mozilla.jss.netscape.security.x509.CRLExtensions;
+import org.mozilla.jss.netscape.security.x509.CRLNumberExtension;
+import org.mozilla.jss.netscape.security.x509.CRLReasonExtension;
+import org.mozilla.jss.netscape.security.x509.Extension;
+import org.mozilla.jss.netscape.security.x509.KeyIdentifier;
+import org.mozilla.jss.netscape.security.x509.RevocationReason;
+import org.mozilla.jss.netscape.security.x509.RevokedCertImpl;
+import org.mozilla.jss.netscape.security.x509.RevokedCertificate;
+import org.mozilla.jss.netscape.security.x509.X500Name;
+import org.mozilla.jss.netscape.security.x509.X509CRLImpl;
 
 /** Class to demonstrate DER encoding failure when using an ASN.1 enumerated type with a value of zero.
  *
@@ -111,7 +111,7 @@ public class EnumerationZeroTest {
     public static AuthorityKeyIdentifierExtension buildAuthorityKeyIdentifier(RSAPublicKey key)
         throws IOException {
         try {
-            MessageDigest d = MessageDigest.getInstance("SHA-1");
+            MessageDigest d = MessageDigest.getInstance("SHA-256");
 
             byte[] encodedKey = key.getEncoded();
 
@@ -171,7 +171,7 @@ public class EnumerationZeroTest {
             entryExtensions.add(reasonExt);
 
             revokedCerts.add(
-                new RevokedCertImpl(BigInteger.valueOf((long) i), new Date(), entryExtensions));
+                new RevokedCertImpl(BigInteger.valueOf(i), new Date(), entryExtensions));
         }
 
         CRLExtensions crlExtensions = new CRLExtensions();

--- a/src/test/java/org/mozilla/jss/tests/EnumerationZeroTest.java
+++ b/src/test/java/org/mozilla/jss/tests/EnumerationZeroTest.java
@@ -102,7 +102,7 @@ public class EnumerationZeroTest {
      *   parameters              ANY DEFINED BY algorithm OPTIONAL  }
      * </pre>
      *
-     * A KeyIdentifier is a SHA-1 digest of the subjectPublicKey bit string from the ASN.1 above.
+     * A KeyIdentifier is a SHA-256 digest of the subjectPublicKey bit string.
      *
      * @param key the RSAPublicKey to use
      * @return an AuthorityKeyIdentifierExtension based on the key

--- a/src/test/java/org/mozilla/jss/tests/HmacTest.java
+++ b/src/test/java/org/mozilla/jss/tests/HmacTest.java
@@ -3,6 +3,7 @@ package org.mozilla.jss.tests;
 
 
 import java.security.Key;
+
 import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKeyFactory;
@@ -10,7 +11,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.InitializationValues;
-
 import org.mozilla.jss.crypto.CryptoToken;
 
 


### PR DESCRIPTION
I have dropped any default/hard-coded references to `SHA-1` and replaced them with references to `SHA-256`. Points to note:

- References to `PBEAlgorithm.PBE_SHA1_DES3_CBC` were replaced by `PBEAlgorithm.PBE_PKCS5_PBES2`, which is the default of the `SUPPORTED_KEY_ENCRYPTIONS`.
- The default of the `SUPPORTED_CERT_ENCRYPTIONS` is `null`, so it is OK that the only algorithm in the `List` is a `SHA-1` algortihm.