### PR TITLE
"Fix Bug 2001169 - Audit event 'ACCESS_SESSION_ESTABLISH' is not gener…

### DIFF
--- a/src/main/java/org/mozilla/jss/ssl/SSLAlertEvent.java
+++ b/src/main/java/org/mozilla/jss/ssl/SSLAlertEvent.java
@@ -9,6 +9,7 @@ import java.util.EventObject;
 import javax.net.ssl.SSLException;
 
 import org.mozilla.jss.nss.SSLFDProxy;
+import org.mozilla.jss.ssl.javax.JSSEngine;
 
 public class SSLAlertEvent extends EventObject {
 
@@ -17,6 +18,7 @@ public class SSLAlertEvent extends EventObject {
     int level;
     int description;
 
+    transient JSSEngine engine;
     SSLAlertLevel levelEnum;
     SSLAlertDescription descriptionEnum;
 
@@ -57,11 +59,19 @@ public class SSLAlertEvent extends EventObject {
     }
 
     public SSLSocket getSocket() {
-        return (SSLSocket) getSource();
+        Object obj = getSource();
+	if( obj != null && obj instanceof SSLSocket) {
+            return (SSLSocket) obj;
+	}
+	return null;
     }
 
     public SSLFDProxy getFileDesc() {
-        return (SSLFDProxy) getSource();
+        Object obj = getSource();
+	if( obj != null && obj instanceof SSLFDProxy) { 
+            return (SSLFDProxy) getSource();
+        }
+        return null;
     }
 
     public int getLevel() {
@@ -98,6 +108,13 @@ public class SSLAlertEvent extends EventObject {
     public void setDescription(SSLAlertDescription description) {
         this.descriptionEnum = description;
         this.description = description.getID();
+    }
+
+    public JSSEngine getEngine() {
+        return engine;
+    }
+    public void setEngine(JSSEngine new_engine) {
+        engine = new_engine;
     }
 
     public SSLException toException() {

--- a/src/main/java/org/mozilla/jss/ssl/SSLAlertEvent.java
+++ b/src/main/java/org/mozilla/jss/ssl/SSLAlertEvent.java
@@ -60,18 +60,13 @@ public class SSLAlertEvent extends EventObject {
 
     public SSLSocket getSocket() {
         Object obj = getSource();
-	if( obj != null && obj instanceof SSLSocket) {
-            return (SSLSocket) obj;
-	}
-	return null;
+        return obj instanceof SSLSocket ? (SSLSocket) obj : null;
     }
 
     public SSLFDProxy getFileDesc() {
         Object obj = getSource();
-	if( obj != null && obj instanceof SSLFDProxy) { 
-            return (SSLFDProxy) getSource();
-        }
-        return null;
+        return obj instanceof SSLFDProxy ? (SSLFDProxy) obj : null;
+
     }
 
     public int getLevel() {

--- a/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
+++ b/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
@@ -39,11 +39,7 @@ public class SSLHandshakeCompletedEvent extends EventObject {
      * cert data; null if on a SSLEngine.
      */
     public SSLSecurityStatus getStatus() throws SocketException {
-        if (getSocket() != null) {
-            return getSocket().getStatus();
-        }
-
-        return null;
+        return getSocket() != null ? getSocket().getStatus() : null;
     }
     
     /**
@@ -51,11 +47,7 @@ public class SSLHandshakeCompletedEvent extends EventObject {
      */
     public SSLSocket getSocket() {
         Object obj = getSource();
-        if (obj != null && obj instanceof SSLSocket) {
-            return (SSLSocket)getSource();
-        }
-
-        return null;
+        return obj instanceof SSLSocket ? (SSLSocket) obj : null;
     }
 
     /**
@@ -63,10 +55,6 @@ public class SSLHandshakeCompletedEvent extends EventObject {
      */
     public JSSEngine getEngine() {
         Object obj = getSource();
-        if (obj != null  && obj instanceof JSSEngine) {
-            return (JSSEngine)getSource();
-        }
-
-        return null;
+        return obj instanceof JSSEngine ? (JSSEngine) obj : null;
     }
 }

--- a/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
+++ b/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
@@ -12,6 +12,8 @@ package org.mozilla.jss.ssl;
 import java.net.*;
 import java.util.*;
 
+import org.mozilla.jss.ssl.javax.JSSEngine;
+
 /*
  * right now, this only extends EventObject, but it will eventually
  * extend javax.net.ssl.HandshakeCompletedEvent
@@ -25,21 +27,46 @@ public class SSLHandshakeCompletedEvent extends EventObject {
     private static final long serialVersionUID = 1L;
 
     public SSLHandshakeCompletedEvent(SSLSocket socket) {
-	super(socket);
+        super(socket);
+    }
+
+    public SSLHandshakeCompletedEvent(JSSEngine engine) {
+        super(engine);
     }
     
     /**
-     * get security information about this socket, including
-     * cert data
+     * Get security information about this socket, including
+     * cert data; null if on a SSLEngine.
      */
     public SSLSecurityStatus getStatus() throws SocketException {
-	return getSocket().getStatus();
+        if (getSocket() != null) {
+            return getSocket().getStatus();
+        }
+
+        return null;
     }
     
     /**
-     * get socket on which the event occured
+     * Get socket on which the event occurred; null if on a SSLEngine.
      */
     public SSLSocket getSocket() {
-	return (SSLSocket)getSource();
+        Object obj = getSource();
+        if (obj != null && obj instanceof SSLSocket) {
+            return (SSLSocket)getSource();
+        }
+
+        return null;
+    }
+
+    /**
+     * Get engine on which the event occurred; null if on a SSLSocket.
+     */
+    public JSSEngine getEngine() {
+        Object obj = getSource();
+        if (obj != null  && obj instanceof JSSEngine) {
+            return (JSSEngine)getSource();
+        }
+
+        return null;
     }
 }

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -1,6 +1,8 @@
 package org.mozilla.jss.ssl.javax;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EventListener;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -20,7 +22,11 @@ import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.pkcs11.PK11PrivKey;
 import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
 import org.mozilla.jss.provider.javax.crypto.JSSTrustManager;
+import org.mozilla.jss.ssl.SSLAlertEvent;
 import org.mozilla.jss.ssl.SSLCipher;
+import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
+import org.mozilla.jss.ssl.SSLHandshakeCompletedListener;
+import org.mozilla.jss.ssl.SSLSocketListener;
 import org.mozilla.jss.ssl.SSLVersion;
 import org.mozilla.jss.ssl.SSLVersionRange;
 import org.slf4j.Logger;
@@ -200,6 +206,11 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     private final static AtomicBoolean sessionCacheInitialized = new AtomicBoolean();
 
     /**
+     * Set of listeners to fire on events (SSL alerts, handshake completed).
+     */
+    private Collection<? extends EventListener> listeners = new ArrayList<>();
+
+    /**
      * Constructor for a JSSEngine, providing no hints for an internal
      * session reuse strategy and no key.
      *
@@ -326,6 +337,7 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
 
         ret.setAlias(certAlias);
         ret.setHostname(hostname);
+        ret.setListeners(listeners);
 
         return ret;
     }
@@ -336,7 +348,8 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
      *
      * Aligning with the parent implementation, this calls:
      *  - setEnabledCipherSuites when getCipherSuites is non-null,
-     *  - setEnabledProtocols when getProtocols is non-null, and
+     *  - setEnabledProtocols when getProtocols is non-null,
+     *  - setListeners when getListeners is non-null, and
      *  - setWantClientAuth and setNeedClientAuth.
      *
      * This doesn't yet understand from the parent implementation, the
@@ -397,6 +410,11 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
         // it.
         if (parsed.getHostname() != null) {
             setHostname(parsed.getHostname());
+        }
+
+        // When we have some listeners, we should add it to our copy.
+        if (parsed.getListeners() != null) {
+            setListeners(parsed.getListeners());
         }
     }
 
@@ -934,6 +952,68 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     @Override
     public boolean getWantClientAuth() {
         return want_client_auth;
+    }
+
+    /**
+     * Sets a SSLSocketListener on this object.
+     */
+    public void setListeners(Collection<? extends EventListener> new_listeners) {
+        listeners = new_listeners;
+    }
+
+    /**
+     * Gets the set of SSLSocketListeners on this object.
+     */
+    public Collection<? extends EventListener> getListeners() {
+        return listeners;
+    }
+
+    /**
+     * Fires any and all SSLSocketListeners on the specified alert received event.
+     *
+     * To be used by other implementations of JSSEngine.
+     */
+    protected void fireAlertReceived(SSLAlertEvent event) {
+        if (listeners != null) {
+            for (EventListener event_listener : listeners) {
+                if (event_listener instanceof SSLSocketListener) {
+                    SSLSocketListener socket_listener = (SSLSocketListener) event_listener;
+                    socket_listener.alertReceived(event);
+                }
+            }
+        }
+    }
+
+    /**
+     * Fires any and all SSLSocketListeners on the specified alert sent event.
+     *
+     * To be used by other implementations of JSSEngine.
+     */
+    protected void fireAlertSent(SSLAlertEvent event) {
+        if (listeners != null) {
+            for (EventListener event_listener : listeners) {
+                if (event_listener instanceof SSLSocketListener) {
+                    SSLSocketListener socket_listener = (SSLSocketListener) event_listener;
+                    socket_listener.alertSent(event);
+                }
+            }
+        }
+    }
+
+    /**
+     * Fires any and all SSLHandshakeCompletedListener on the specified event.
+     *
+     * To be used by other implementations of JSSEngine.
+     */
+    protected void fireHandshakeComplete(SSLHandshakeCompletedEvent event) {
+        if (listeners != null) {
+            for (EventListener event_listener : listeners) {
+                if (event_listener instanceof SSLHandshakeCompletedListener) {
+                    SSLHandshakeCompletedListener handshake_listener = (SSLHandshakeCompletedListener) event_listener;
+                    handshake_listener.handshakeCompleted(event);
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -939,6 +939,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         while (ssl_fd.inboundOffset < ssl_fd.inboundAlerts.size()) {
             SSLAlertEvent event = ssl_fd.inboundAlerts.get(ssl_fd.inboundOffset);
             ssl_fd.inboundOffset += 1;
+	    event.setEngine(this);
 
             if (event.getLevelEnum() == SSLAlertLevel.WARNING && event.getDescriptionEnum() == SSLAlertDescription.CLOSE_NOTIFY) {
                 debug("Got inbound CLOSE_NOTIFY alert");
@@ -946,6 +947,9 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             }
 
             debug("JSSEngine: Got inbound alert: " + event);
+
+            // Fire inbound alert prior to raising any exception.
+            fireAlertReceived(event);
 
             // Not every SSL Alert is fatal; toException() only returns a
             // SSLException on fatal instances. We shouldn't return NULL
@@ -959,6 +963,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         while (ssl_fd.outboundOffset < ssl_fd.outboundAlerts.size()) {
             SSLAlertEvent event = ssl_fd.outboundAlerts.get(ssl_fd.outboundOffset);
             ssl_fd.outboundOffset += 1;
+            event.setEngine(this);
 
             if (event.getLevelEnum() == SSLAlertLevel.WARNING && event.getDescriptionEnum() == SSLAlertDescription.CLOSE_NOTIFY) {
                 debug("Sent outbound CLOSE_NOTIFY alert.");
@@ -966,6 +971,11 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             }
 
             debug("JSSEngine: Got outbound alert: " + event);
+
+            // Fire outbound alert prior to raising any exception. Note that
+            // this still triggers after this alert is written to the output
+            // wire buffer.
+            fireAlertSent(event);
 
             SSLException exception = event.toException();
             if (exception != null) {
@@ -1078,6 +1088,9 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
             // Also update our session information here.
             session.refreshData();
+
+            // Finally, fire any handshake completed event listeners now.
+            fireHandshakeComplete(new SSLHandshakeCompletedEvent(this));
 
             return;
         }

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSParameters.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSParameters.java
@@ -26,6 +26,7 @@ public class JSSParameters extends SSLParameters {
     private SSLVersionRange range;
     private String alias;
     private String hostname;
+    private Collection<? extends EventListener> listeners;
 
     public JSSParameters() {
         // Choose our default set of SSLParameters here; default to null
@@ -193,5 +194,13 @@ public class JSSParameters extends SSLParameters {
 
     public void setHostname(String server_hostname) {
         hostname = server_hostname;
+    }
+
+    public Collection<? extends EventListener> getListeners() {
+        return listeners;
+    }
+
+    public void setListeners(Collection<? extends EventListener> new_listeners) {
+        listeners = new_listeners;
     }
 }

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocket.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocket.java
@@ -293,6 +293,25 @@ public class JSSServerSocket extends SSLServerSocket {
         engine.setTrustManagers(xtms);
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<? extends EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<? extends EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     /* == stubs over SSLServerSocket == */
 
     /**

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocketChannel.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSServerSocketChannel.java
@@ -64,6 +64,25 @@ public class JSSServerSocketChannel extends ServerSocketChannel {
         return this;
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<? extends EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<? extends EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     @Override
     public <T> T getOption(SocketOption<T> name) throws IOException {
         if (parent == null) {

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
@@ -428,6 +428,25 @@ public class JSSSocket extends SSLSocket {
         engine.setTrustManagers(xtms);
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<? extends EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<? extends EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     /* == stubs over SSLSocket == */
 
     /**

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -408,6 +408,25 @@ public class JSSSocketChannel extends SocketChannel {
         }
     }
 
+    /**
+     * Set the listeners this SSLSocket will fire on certain events.
+     *
+     * @see JSSEngine#setListeners(Collection)
+     */
+    public void setListeners(Collection<? extends EventListener> listeners) {
+        engine.setListeners(listeners);
+    }
+
+    /**
+     * Gets the current list of event listeners this SSLSocket will fire on
+     * certain events.
+     *
+     * @see JSSEngine#getListeners()
+     */
+    public Collection<? extends EventListener> getListeners() {
+        return engine.getListeners();
+    }
+
     /* == generic stubs for SocketChannel */
 
     @Override


### PR DESCRIPTION
…ating for PKI instances acting as Server [10.2.1]

    This fix allows us to actually see ssl connection events in the audit log from the pki /server perspective.
    This fill will also require support bug fixes for both pki and tomcatjss.

Based on original code contributed by Alex Ascheel, (cipherboy)."

This was a change made by @jmagne to fix bug: 2001169 for RHCS 10.2.1, Originally he only made the change on the `v4.9.x` branch but it needs to go to master as well. 

Tested locally by building and installing JSS, tomcatjss, and pki and observed the AUDIT logs:
```
0.https-jsse-nio-8443-exec-15 - [05/Nov/2021:15:31:17 GMT] [14] [6] [AuditEvent=ACCESS_SESSION_ESTABLISH][ClientIP=--][ServerIP=--][SubjectID=--][Outcome=Success] access session establish success
0.https-jsse-nio-8443-exec-16 - [05/Nov/2021:15:31:17 GMT] [14] [6] [AuditEvent=ACCESS_SESSION_TERMINATED][ClientIP=--][ServerIP=--][SubjectID=--][Outcome=Success][Info=serverAlertReceived: CLOSE_NOTIFY] access session terminated

```