### PR TITLE
Override Provider.getService() to log use of deprecated algorithms 

### DIFF
--- a/src/main/java/org/mozilla/jss/netscape/security/util/CertPrettyPrint.java
+++ b/src/main/java/org/mozilla/jss/netscape/security/util/CertPrettyPrint.java
@@ -27,16 +27,14 @@ import java.util.TimeZone;
 
 import org.mozilla.jss.asn1.ASN1Util;
 import org.mozilla.jss.asn1.SET;
-import org.mozilla.jss.pkcs7.ContentInfo;
-import org.mozilla.jss.pkcs7.SignedData;
-
-
 import org.mozilla.jss.netscape.security.x509.CertificateExtensions;
 import org.mozilla.jss.netscape.security.x509.CertificateX509Key;
 import org.mozilla.jss.netscape.security.x509.Extension;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 import org.mozilla.jss.netscape.security.x509.X509CertInfo;
 import org.mozilla.jss.netscape.security.x509.X509Key;
+import org.mozilla.jss.pkcs7.ContentInfo;
+import org.mozilla.jss.pkcs7.SignedData;
 
 /**
  * This class will display the certificate content in predefined

--- a/src/main/java/org/mozilla/jss/pkcs7/SignerInfo.java
+++ b/src/main/java/org/mozilla/jss/pkcs7/SignerInfo.java
@@ -4,16 +4,37 @@
 
 package org.mozilla.jss.pkcs7;
 
-import java.io.*;
-import org.mozilla.jss.asn1.*;
-import org.mozilla.jss.pkix.primitive.*;
-import org.mozilla.jss.crypto.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.security.InvalidKeyException;
-import java.security.SignatureException;
-import java.security.NoSuchAlgorithmException;
 import java.security.MessageDigest;
-import org.mozilla.jss.*;
+import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import java.security.SignatureException;
+
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.NotInitializedException;
+import org.mozilla.jss.asn1.ANY;
+import org.mozilla.jss.asn1.ASN1Template;
+import org.mozilla.jss.asn1.ASN1Util;
+import org.mozilla.jss.asn1.ASN1Value;
+import org.mozilla.jss.asn1.INTEGER;
+import org.mozilla.jss.asn1.InvalidBERException;
+import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
+import org.mozilla.jss.asn1.OCTET_STRING;
+import org.mozilla.jss.asn1.SEQUENCE;
+import org.mozilla.jss.asn1.SET;
+import org.mozilla.jss.asn1.Tag;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.crypto.DigestAlgorithm;
+import org.mozilla.jss.crypto.ObjectNotFoundException;
+import org.mozilla.jss.crypto.PrivateKey;
+import org.mozilla.jss.crypto.Signature;
+import org.mozilla.jss.crypto.SignatureAlgorithm;
+import org.mozilla.jss.crypto.TokenException;
+import org.mozilla.jss.crypto.X509Certificate;
+import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
 
 /*
  * The high-level interface takes care of all
@@ -306,7 +327,7 @@ public class SignerInfo implements ASN1Value {
             // digest the contents octets of the authenticated attributes
             byte[] enc = ASN1Util.encode(authenticatedAttributes);
             MessageDigest md =
-                        MessageDigest.getInstance(digestAlg.toString());
+                    MessageDigest.getInstance(digestAlg.toString());
             digest = md.digest( enc );
         }
 

--- a/src/test/java/org/mozilla/jss/tests/DigestTest.java
+++ b/src/test/java/org/mozilla/jss/tests/DigestTest.java
@@ -28,8 +28,8 @@ public class DigestTest {
         boolean bTested = false;
 
         // get the digest for the Mozilla-JSS provider
-        java.security.MessageDigest mozillaDigest =
-                java.security.MessageDigest.getInstance(alg,
+        MessageDigest mozillaDigest =
+                MessageDigest.getInstance(alg,
                 MOZ_PROVIDER_NAME);
         mozillaDigestOut = mozillaDigest.digest(toBeDigested);
 
@@ -45,8 +45,8 @@ public class DigestTest {
                 continue;
             }
 
-            java.security.MessageDigest otherDigest =
-                    java.security.MessageDigest.getInstance(alg, provider);
+            MessageDigest otherDigest =
+                    MessageDigest.getInstance(alg, provider);
 
             otherDigestOut =
                     otherDigest.digest(toBeDigested);
@@ -69,8 +69,8 @@ public class DigestTest {
     throws Exception {
         byte[] mozillaDigestOut;
 
-        java.security.MessageDigest mozillaDigest =
-                java.security.MessageDigest.getInstance(alg, MOZ_PROVIDER_NAME);
+        MessageDigest mozillaDigest =
+                MessageDigest.getInstance(alg, MOZ_PROVIDER_NAME);
 
         mozillaDigestOut = mozillaDigest.digest(toBeDigested);
 

--- a/src/test/java/org/mozilla/jss/tests/EnumerationZeroTest.java
+++ b/src/test/java/org/mozilla/jss/tests/EnumerationZeroTest.java
@@ -18,22 +18,6 @@
 
 package org.mozilla.jss.tests;
 
-import org.mozilla.jss.JSSProvider;
-import org.mozilla.jss.netscape.security.util.BitArray;
-import org.mozilla.jss.netscape.security.util.DerInputStream;
-import org.mozilla.jss.netscape.security.util.DerValue;
-import org.mozilla.jss.netscape.security.x509.AuthorityKeyIdentifierExtension;
-import org.mozilla.jss.netscape.security.x509.CRLExtensions;
-import org.mozilla.jss.netscape.security.x509.CRLNumberExtension;
-import org.mozilla.jss.netscape.security.x509.CRLReasonExtension;
-import org.mozilla.jss.netscape.security.x509.Extension;
-import org.mozilla.jss.netscape.security.x509.KeyIdentifier;
-import org.mozilla.jss.netscape.security.x509.RevocationReason;
-import org.mozilla.jss.netscape.security.x509.RevokedCertImpl;
-import org.mozilla.jss.netscape.security.x509.RevokedCertificate;
-import org.mozilla.jss.netscape.security.x509.X500Name;
-import org.mozilla.jss.netscape.security.x509.X509CRLImpl;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -50,6 +34,22 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+
+import org.mozilla.jss.JSSProvider;
+import org.mozilla.jss.netscape.security.util.BitArray;
+import org.mozilla.jss.netscape.security.util.DerInputStream;
+import org.mozilla.jss.netscape.security.util.DerValue;
+import org.mozilla.jss.netscape.security.x509.AuthorityKeyIdentifierExtension;
+import org.mozilla.jss.netscape.security.x509.CRLExtensions;
+import org.mozilla.jss.netscape.security.x509.CRLNumberExtension;
+import org.mozilla.jss.netscape.security.x509.CRLReasonExtension;
+import org.mozilla.jss.netscape.security.x509.Extension;
+import org.mozilla.jss.netscape.security.x509.KeyIdentifier;
+import org.mozilla.jss.netscape.security.x509.RevocationReason;
+import org.mozilla.jss.netscape.security.x509.RevokedCertImpl;
+import org.mozilla.jss.netscape.security.x509.RevokedCertificate;
+import org.mozilla.jss.netscape.security.x509.X500Name;
+import org.mozilla.jss.netscape.security.x509.X509CRLImpl;
 
 /** Class to demonstrate DER encoding failure when using an ASN.1 enumerated type with a value of zero.
  *
@@ -171,7 +171,7 @@ public class EnumerationZeroTest {
             entryExtensions.add(reasonExt);
 
             revokedCerts.add(
-                new RevokedCertImpl(BigInteger.valueOf((long) i), new Date(), entryExtensions));
+                new RevokedCertImpl(BigInteger.valueOf(i), new Date(), entryExtensions));
         }
 
         CRLExtensions crlExtensions = new CRLExtensions();


### PR DESCRIPTION
* Start by deprecating "SHA", "SHA-1", "SHA_1" and SHA1"