### PR TITLE
Deprecated all SHA-1 constants, classes and enum entries.

### DIFF
--- a/src/main/java/org/mozilla/jss/crypto/Algorithm.java
+++ b/src/main/java/org/mozilla/jss/crypto/Algorithm.java
@@ -154,9 +154,9 @@ public class Algorithm {
     // to the org.mozilla.jss.crypto.PKCS11Algorithm enum.
     protected static final int SEC_OID_PKCS1_MD2_WITH_RSA_ENCRYPTION = 0;
     protected static final int SEC_OID_PKCS1_MD5_WITH_RSA_ENCRYPTION = 1;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int SEC_OID_PKCS1_SHA1_WITH_RSA_ENCRYPTION = 2;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int SEC_OID_ANSIX9_DSA_SIGNATURE_WITH_SHA1_DIGEST = 3;
     protected static final int SEC_OID_PKCS1_RSA_ENCRYPTION = 4;
     protected static final int CKM_RSA_PKCS_KEY_PAIR_GEN = 5;
@@ -175,26 +175,26 @@ public class Algorithm {
 
     protected static final int SEC_OID_PKCS5_PBE_WITH_MD2_AND_DES_CBC = 18;
     protected static final int SEC_OID_PKCS5_PBE_WITH_MD5_AND_DES_CBC = 19;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int SEC_OID_PKCS5_PBE_WITH_SHA1_AND_DES_CBC = 20;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int SEC_OID_PKCS12_V2_PBE_WITH_SHA1_AND_128_BIT_RC4 = 21;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int SEC_OID_PKCS12_V2_PBE_WITH_SHA1_AND_40_BIT_RC4 = 22;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int SEC_OID_PKCS12_V2_PBE_WITH_SHA1_AND_3KEY_TRIPLE_DES_CBC = 23;
     protected static final int SEC_OID_MD2 = 24;
     protected static final int SEC_OID_MD5 = 25;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int SEC_OID_SHA1 = 26;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int CKM_SHA_1_HMAC = 27;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int SEC_OID_PKCS12_V2_PBE_WITH_SHA1_AND_128_BIT_RC2_CBC = 28;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int SEC_OID_PKCS12_V2_PBE_WITH_SHA1_AND_40_BIT_RC2_CBC = 29;
     protected static final int SEC_OID_RC2_CBC = 30;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int CKM_PBA_SHA1_WITH_SHA1_HMAC = 31;
 
     // AES
@@ -212,7 +212,7 @@ public class Algorithm {
     protected static final int SEC_OID_PKCS1_SHA384_WITH_RSA_ENCRYPTION = 42;
     protected static final int SEC_OID_PKCS1_SHA512_WITH_RSA_ENCRYPTION = 43;
     protected static final int SEC_OID_ANSIX962_EC_PUBLIC_KEY = 44;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     protected static final int SEC_OID_ANSIX962_ECDSA_SHA1_SIGNATURE = 45;
     protected static final int CKM_EC_KEY_PAIR_GEN = 46;
     protected static final int SEC_OID_ANSIX962_ECDSA_SHA256_SIGNATURE = 47;

--- a/src/main/java/org/mozilla/jss/crypto/DigestAlgorithm.java
+++ b/src/main/java/org/mozilla/jss/crypto/DigestAlgorithm.java
@@ -66,7 +66,7 @@ public class DigestAlgorithm extends Algorithm {
     /**
      * The SHA-1 digest algorithm, from Uncle Sam.
      */
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final DigestAlgorithm SHA1 = new DigestAlgorithm
         (SEC_OID_SHA1, "SHA-1", OBJECT_IDENTIFIER.ALGORITHM.subBranch(26), 20);
 

--- a/src/main/java/org/mozilla/jss/crypto/HMACAlgorithm.java
+++ b/src/main/java/org/mozilla/jss/crypto/HMACAlgorithm.java
@@ -53,7 +53,7 @@ public class HMACAlgorithm extends DigestAlgorithm {
      * symmetric key together with SHA-X digesting to create a form of
      * signature.
      */
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final HMACAlgorithm SHA1 = new HMACAlgorithm
         (CKM_SHA_1_HMAC, "SHA-1-HMAC",
              OBJECT_IDENTIFIER.ALGORITHM.subBranch(26), 20);

--- a/src/main/java/org/mozilla/jss/crypto/KeyGenAlgorithm.java
+++ b/src/main/java/org/mozilla/jss/crypto/KeyGenAlgorithm.java
@@ -119,7 +119,7 @@ public class KeyGenAlgorithm extends Algorithm {
             null);
 
     //////////////////////////////////////////////////////////////
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final KeyGenAlgorithm PBA_SHA1_HMAC = new KeyGenAlgorithm(
             CKM_PBA_SHA1_WITH_SHA1_HMAC,
             "PBA/SHA1/HMAC",
@@ -127,7 +127,7 @@ public class KeyGenAlgorithm extends Algorithm {
             null,
             PBEKeyGenParams.class);
 
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final KeyGenAlgorithm SHA1_HMAC = new KeyGenAlgorithm(
             CKM_SHA_1_HMAC,
             "SHA1/HMAC",

--- a/src/main/java/org/mozilla/jss/crypto/PBEAlgorithm.java
+++ b/src/main/java/org/mozilla/jss/crypto/PBEAlgorithm.java
@@ -92,14 +92,14 @@ public class PBEAlgorithm extends KeyGenAlgorithm {
             PKCS5.subBranch(3), EncryptionAlgorithm.DES_CBC, 8 );
 
     //////////////////////////////////////////////////////////////
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final PBEAlgorithm
     PBE_SHA1_DES_CBC = new PBEAlgorithm(
         SEC_OID_PKCS5_PBE_WITH_SHA1_AND_DES_CBC, "PBE/SHA1/DES/CBC", 56,
             PKCS5.subBranch(10), EncryptionAlgorithm.DES_CBC, 8 );
 
     //////////////////////////////////////////////////////////////
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final PBEAlgorithm
     PBE_SHA1_RC4_128 = new PBEAlgorithm(
         SEC_OID_PKCS12_V2_PBE_WITH_SHA1_AND_128_BIT_RC4,
@@ -107,7 +107,7 @@ public class PBEAlgorithm extends KeyGenAlgorithm {
             EncryptionAlgorithm.RC4, 20 );
 
     //////////////////////////////////////////////////////////////
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final PBEAlgorithm
     PBE_SHA1_RC4_40 = new PBEAlgorithm(
         SEC_OID_PKCS12_V2_PBE_WITH_SHA1_AND_40_BIT_RC4,
@@ -115,7 +115,7 @@ public class PBEAlgorithm extends KeyGenAlgorithm {
             EncryptionAlgorithm.RC4, 20 );
 
     //////////////////////////////////////////////////////////////
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final PBEAlgorithm
     PBE_SHA1_DES3_CBC = new PBEAlgorithm(
         SEC_OID_PKCS12_V2_PBE_WITH_SHA1_AND_3KEY_TRIPLE_DES_CBC,
@@ -123,7 +123,7 @@ public class PBEAlgorithm extends KeyGenAlgorithm {
             EncryptionAlgorithm.DES3_CBC, 20 );
 
     //////////////////////////////////////////////////////////////
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final PBEAlgorithm
     PBE_SHA1_RC2_128_CBC = new PBEAlgorithm(
         SEC_OID_PKCS12_V2_PBE_WITH_SHA1_AND_128_BIT_RC2_CBC,
@@ -131,7 +131,7 @@ public class PBEAlgorithm extends KeyGenAlgorithm {
             EncryptionAlgorithm.RC2_CBC, 20 );
 
     //////////////////////////////////////////////////////////////
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final PBEAlgorithm
     PBE_SHA1_RC2_40_CBC = new PBEAlgorithm(
         SEC_OID_PKCS12_V2_PBE_WITH_SHA1_AND_40_BIT_RC2_CBC,

--- a/src/main/java/org/mozilla/jss/crypto/PKCS11Algorithm.java
+++ b/src/main/java/org/mozilla/jss/crypto/PKCS11Algorithm.java
@@ -16,13 +16,13 @@ public enum PKCS11Algorithm {
     CKM_EC_KEY_PAIR_GEN (Algorithm.CKM_EC_KEY_PAIR_GEN, PKCS11Constants.CKM_EC_KEY_PAIR_GEN),
     CKM_NSS_AES_KEY_WRAP (Algorithm.CKM_NSS_AES_KEY_WRAP, PKCS11Constants.CKM_NSS_AES_KEY_WRAP),
     CKM_NSS_AES_KEY_WRAP_PAD (Algorithm.CKM_NSS_AES_KEY_WRAP_PAD, PKCS11Constants.CKM_NSS_AES_KEY_WRAP_PAD),
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     CKM_PBA_SHA1_WITH_SHA1_HMAC (Algorithm.CKM_PBA_SHA1_WITH_SHA1_HMAC, PKCS11Constants.CKM_PBA_SHA1_WITH_SHA1_HMAC),
     CKM_RC2_CBC_PAD (Algorithm.CKM_RC2_CBC_PAD, PKCS11Constants.CKM_RC2_CBC_PAD),
     CKM_RC2_KEY_GEN (Algorithm.CKM_RC2_KEY_GEN, PKCS11Constants.CKM_RC2_KEY_GEN),
     CKM_RC4_KEY_GEN (Algorithm.CKM_RC4_KEY_GEN, PKCS11Constants.CKM_RC4_KEY_GEN),
     CKM_RSA_PKCS_KEY_PAIR_GEN (Algorithm.CKM_RSA_PKCS_KEY_PAIR_GEN, PKCS11Constants.CKM_RSA_PKCS_KEY_PAIR_GEN),
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     CKM_SHA_1_HMAC (Algorithm.CKM_SHA_1_HMAC, PKCS11Constants.CKM_SHA_1_HMAC),
     CKM_SHA_256_HMAC (Algorithm.CKM_SHA256_HMAC, PKCS11Constants.CKM_SHA256_HMAC),
     CKM_SHA_384_HMAC (Algorithm.CKM_SHA384_HMAC, PKCS11Constants.CKM_SHA384_HMAC),

--- a/src/main/java/org/mozilla/jss/crypto/SignatureAlgorithm.java
+++ b/src/main/java/org/mozilla/jss/crypto/SignatureAlgorithm.java
@@ -122,7 +122,7 @@ public class SignatureAlgorithm extends Algorithm {
                 OBJECT_IDENTIFIER.PKCS1.subBranch(4) );
 
     //////////////////////////////////////////////////////////////////////
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final SignatureAlgorithm
     RSASignatureWithSHA1Digest =
         new SignatureAlgorithm(SEC_OID_PKCS1_SHA1_WITH_RSA_ENCRYPTION,
@@ -130,7 +130,7 @@ public class SignatureAlgorithm extends Algorithm {
             OBJECT_IDENTIFIER.PKCS1.subBranch(5) );
 
     //////////////////////////////////////////////////////////////////////
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final SignatureAlgorithm
     DSASignatureWithSHA1Digest =
         new SignatureAlgorithm(SEC_OID_ANSIX9_DSA_SIGNATURE_WITH_SHA1_DIGEST,
@@ -138,7 +138,7 @@ public class SignatureAlgorithm extends Algorithm {
             ANSI_X9_ALGORITHM.subBranch(3) );
 
     //////////////////////////////////////////////////////////////////////
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final SignatureAlgorithm
     ECSignatureWithSHA1Digest =
         new SignatureAlgorithm(SEC_OID_ANSIX962_ECDSA_SHA1_SIGNATURE,

--- a/src/main/java/org/mozilla/jss/crypto/SymmetricKey.java
+++ b/src/main/java/org/mozilla/jss/crypto/SymmetricKey.java
@@ -17,7 +17,7 @@ public interface SymmetricKey extends javax.crypto.SecretKey {
     public static final Type DES3 = Type.DES3;
     public static final Type RC4 = Type.RC4;
     public static final Type RC2 = Type.RC2;
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final Type SHA1_HMAC = Type.SHA1_HMAC;
     public static final Type SHA256_HMAC = Type.SHA256_HMAC;
     public static final Type SHA384_HMAC = Type.SHA384_HMAC;
@@ -91,7 +91,7 @@ public interface SymmetricKey extends javax.crypto.SecretKey {
         public static final Type DESede = DES3;
         public static final Type RC4 = new Type(new String[] { "RC4" }, KeyGenAlgorithm.RC4, KeyType.RC4);
         public static final Type RC2 = new Type(new String[] { "RC2" }, KeyGenAlgorithm.RC2, KeyType.RC4);
-        @Deprecated(since="5.0.0", forRemoval=true)
+        @Deprecated(since="5.0.1", forRemoval=true)
         public static final Type SHA1_HMAC = new Type(
                 new String[] { "SHA1_HMAC", "SHA1-HMAC", "SHA1HMAC", "HMAC_SHA1", "HMAC-SHA1", "HMACSHA1" },
                 KeyGenAlgorithm.SHA1_HMAC, KeyType.SHA1_HMAC);
@@ -104,7 +104,7 @@ public interface SymmetricKey extends javax.crypto.SecretKey {
         public static final Type SHA512_HMAC = new Type(
                 new String[] { "SHA512_HMAC", "SHA512-HMAC", "SHA512HMAC", "HMAC_SHA512", "HMAC-SHA512", "HMACSHA512" },
                 KeyGenAlgorithm.SHA512_HMAC, KeyType.SHA512_HMAC);
-        @Deprecated(since="5.0.0", forRemoval=true)
+        @Deprecated(since="5.0.1", forRemoval=true)
         public static final Type PBA_SHA1_HMAC = new Type(new String[] { "PBA_SHA1_HMAC" },
                 KeyGenAlgorithm.PBA_SHA1_HMAC, null);
         public static final Type AES = new Type(new String[] { "AES" }, KeyGenAlgorithm.AES, KeyType.AES);

--- a/src/main/java/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
+++ b/src/main/java/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
@@ -786,7 +786,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
     private static final int MD2_data[] = { 1, 2, 840, 113549, 2, 2 };
     private static final int MD5_data[] = { 1, 2, 840, 113549, 2, 5 };
     // sha = { 1, 3, 14, 3, 2, 18 };
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     private static final int SHA1_OIW_data[] = { 1, 3, 14, 3, 2, 26 };
     private static final int SHA256_data[] = { 2, 16, 840, 1, 101, 3, 4, 2, 1 };
     private static final int SHA384_data[] = { 2, 16, 840, 1, 101, 3, 4, 2, 2 };
@@ -810,7 +810,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * many people refer to FIPS 180 (which has an error) as defining SHA.
      * OID = 1.3.14.3.2.26
      */
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final ObjectIdentifier SHA_oid = new ObjectIdentifier(SHA1_OIW_data);
 
     public static final ObjectIdentifier SHA256_oid = new ObjectIdentifier(SHA256_data);
@@ -835,7 +835,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
                                          { 1, 2, 840, 10045, 4, 1 };
 
     public static final ObjectIdentifier ANSIX962_EC_Public_Key_oid = new ObjectIdentifier(ANSI_X962_public_key_data);
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final ObjectIdentifier ANSIX962_SHA1_With_EC_oid = new ObjectIdentifier(ANSI_X962_sha1_with_ec_data);
 
     /*
@@ -899,7 +899,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
     /*
      * COMMON SIGNATURE ALGORITHMS
      */
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     private static final int sha1WithEC_data[] =
                                    { 1, 2, 840, 10045, 4, 1 };
     private static final int sha224WithEC_data[] =
@@ -914,7 +914,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
                                    { 1, 2, 840, 113549, 1, 1, 2 };
     private static final int md5WithRSAEncryption_data[] =
                                    { 1, 2, 840, 113549, 1, 1, 4 };
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     private static final int sha1WithRSAEncryption_data[] =
                                    { 1, 2, 840, 113549, 1, 1, 5 };
     private static final int sha256WithRSAEncryption_data[] =
@@ -923,23 +923,23 @@ public class AlgorithmId implements Serializable, DerEncoder {
                                    { 1, 2, 840, 113549, 1, 1, 12 };
     private static final int sha512WithRSAEncryption_data[] =
                                    { 1, 2, 840, 113549, 1, 1, 13 };
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     private static final int sha1WithRSAEncryption_OIW_data[] =
                                    { 1, 3, 14, 3, 2, 29 };
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     private static final int shaWithDSA_OIW_data[] =
                                    { 1, 3, 14, 3, 2, 13 };
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     private static final int sha1WithDSA_OIW_data[] =
                                    { 1, 3, 14, 3, 2, 27 };
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     private static final int dsaWithSHA1_PKIX_data[] =
                                    { 1, 2, 840, 10040, 4, 3 };
 
     private static final int rsaPSS_data[] =
                                    { 1, 2, 840, 113549, 1, 1, 10 };
 
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final ObjectIdentifier sha1WithEC_oid = new
             ObjectIdentifier(sha1WithEC_data);
 
@@ -979,7 +979,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
     /**
      * The proper one for sha1/rsa
      */
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final ObjectIdentifier sha1WithRSAEncryption_oid = new
             ObjectIdentifier(sha1WithRSAEncryption_data);
 
@@ -1006,7 +1006,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * encrypted using an RSA private key; defined in NIST OIW.
      * OID = 1.3.14.3.2.29
      */
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final ObjectIdentifier sha1WithRSAEncryption_OIW_oid = new
             ObjectIdentifier(sha1WithRSAEncryption_OIW_data);
 
@@ -1016,7 +1016,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * This should not be used.
      * OID = 1.3.14.3.2.13
      */
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final ObjectIdentifier shaWithDSA_OIW_oid = new ObjectIdentifier(shaWithDSA_OIW_data);
 
     /**
@@ -1024,7 +1024,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * SHA1 digest is signed using the Digital Signing Algorithm (DSA).
      * OID = 1.3.14.3.2.27
      */
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final ObjectIdentifier sha1WithDSA_OIW_oid = new ObjectIdentifier(sha1WithDSA_OIW_data);
 
     /**
@@ -1032,13 +1032,13 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * SHA1 digest is signed using the Digital Signing Algorithm (DSA).
      * OID = 1.2.840.10040.4.3
      */
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final ObjectIdentifier sha1WithDSA_oid = new ObjectIdentifier(dsaWithSHA1_PKIX_data);
 
     /**
      * Supported signing algorithms for a DSA key.
      */
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final String[] DSA_SIGNING_ALGORITHMS = new String[]
     { "SHA1withDSA" };
 

--- a/src/main/java/org/mozilla/jss/pkcs11/KeyType.java
+++ b/src/main/java/org/mozilla/jss/pkcs11/KeyType.java
@@ -242,7 +242,7 @@ public final class KeyType {
                         );
 
     //////////////////////////////////////////////////////////////
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     static public final KeyType
     SHA1_HMAC = new KeyType(new Algorithm[]
                             {

--- a/src/main/java/org/mozilla/jss/pkcs12/AuthenticatedSafes.java
+++ b/src/main/java/org/mozilla/jss/pkcs12/AuthenticatedSafes.java
@@ -53,7 +53,7 @@ public class AuthenticatedSafes implements ASN1Value {
     /**
      * The default PBE key generation algorithm: SHA-1 with RC2 40-bit CBC.
      */
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static final PBEAlgorithm DEFAULT_KEY_GEN_ALG =
                 PBEAlgorithm.PBE_SHA1_RC2_40_CBC;
 

--- a/src/main/java/org/mozilla/jss/provider/java/security/JSSMessageDigestSpi.java
+++ b/src/main/java/org/mozilla/jss/provider/java/security/JSSMessageDigestSpi.java
@@ -100,7 +100,7 @@ public abstract class JSSMessageDigestSpi extends MessageDigestSpi {
       }
     }
 
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static class SHA1 extends JSSMessageDigestSpi {
         public SHA1() {
             super( DigestAlgorithm.SHA1 );

--- a/src/main/java/org/mozilla/jss/provider/java/security/JSSSignatureSpi.java
+++ b/src/main/java/org/mozilla/jss/provider/java/security/JSSSignatureSpi.java
@@ -191,13 +191,13 @@ public class JSSSignatureSpi extends java.security.SignatureSpi {
             "name/value parameters not supported");
     }
 
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static class DSA extends JSSSignatureSpi {
         public DSA() {
             super(SignatureAlgorithm.DSASignatureWithSHA1Digest);
         }
     }
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static class SHA1EC extends JSSSignatureSpi {
         public SHA1EC() {
             super(SignatureAlgorithm.ECSignatureWithSHA1Digest);

--- a/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSKeyGeneratorSpi.java
+++ b/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSKeyGeneratorSpi.java
@@ -103,13 +103,13 @@ public class JSSKeyGeneratorSpi extends javax.crypto.KeyGeneratorSpi {
             super(KeyGenAlgorithm.RC2);
         }
     }
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static class HmacSHA1 extends JSSKeyGeneratorSpi {
         public HmacSHA1() {
             super(KeyGenAlgorithm.SHA1_HMAC);
         }
     }
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static class PBAHmacSHA1 extends JSSKeyGeneratorSpi {
         public PBAHmacSHA1() {
             super(KeyGenAlgorithm.PBA_SHA1_HMAC);

--- a/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSMacSpi.java
+++ b/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSMacSpi.java
@@ -139,7 +139,7 @@ public class JSSMacSpi extends javax.crypto.MacSpi {
         throw new CloneNotSupportedException();
     }
 
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static class HmacSHA1 extends JSSMacSpi {
         public HmacSHA1() {
             super(HMACAlgorithm.SHA1, "HmacSHA1");

--- a/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSSecretKeyFactorySpi.java
+++ b/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSSecretKeyFactorySpi.java
@@ -386,35 +386,35 @@ public class JSSSecretKeyFactorySpi extends SecretKeyFactorySpi {
         }
     }
 
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static class PBE_SHA1_DES_CBC extends JSSSecretKeyFactorySpi {
         public PBE_SHA1_DES_CBC() {
             super(PBEAlgorithm.PBE_SHA1_DES_CBC);
         }
     }
 
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static class PBE_SHA1_DES3_CBC extends JSSSecretKeyFactorySpi {
         public PBE_SHA1_DES3_CBC() {
             super(PBEAlgorithm.PBE_SHA1_DES3_CBC);
         }
     }
 
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static class PBE_SHA1_RC4_128 extends JSSSecretKeyFactorySpi {
         public PBE_SHA1_RC4_128() {
             super(PBEAlgorithm.PBE_SHA1_RC4_128);
         }
     }
 
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static class HmacSHA1 extends JSSSecretKeyFactorySpi {
         public HmacSHA1() {
             super(KeyGenAlgorithm.SHA1_HMAC);
         }
     }
 
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     public static class PBAHmacSHA1 extends JSSSecretKeyFactorySpi {
         public PBAHmacSHA1() {
             super(KeyGenAlgorithm.PBA_SHA1_HMAC);

--- a/src/main/java/org/mozilla/jss/ssl/SSLSignatureScheme.java
+++ b/src/main/java/org/mozilla/jss/ssl/SSLSignatureScheme.java
@@ -2,7 +2,7 @@ package org.mozilla.jss.ssl;
 
 public enum SSLSignatureScheme {
     ssl_sig_none (0),
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     ssl_sig_rsa_pkcs1_sha1 (0x0201),
     ssl_sig_rsa_pkcs1_sha256 (0x0401),
     ssl_sig_rsa_pkcs1_sha384 (0x0501),
@@ -18,14 +18,14 @@ public enum SSLSignatureScheme {
     ssl_sig_rsa_pss_pss_sha256 (0x0809),
     ssl_sig_rsa_pss_pss_sha384 (0x080a),
     ssl_sig_rsa_pss_pss_sha512 (0x080b),
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     ssl_sig_dsa_sha1 (0x0202),
     ssl_sig_dsa_sha256 (0x0402),
     ssl_sig_dsa_sha384 (0x0502),
     ssl_sig_dsa_sha512 (0x0602),
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     ssl_sig_ecdsa_sha1 (0x0203),
-    @Deprecated(since="5.0.0", forRemoval=true)
+    @Deprecated(since="5.0.1", forRemoval=true)
     ssl_sig_rsa_pkcs1_sha1md5 (0x10101);
 
     private int value;


### PR DESCRIPTION
* Fixed "since" version to `5.0.1`