### PR TITLE
Fix Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,16 @@
-# Workaround to install sudo
+# Provide docker in container for installing dependencies as root.
 # https://github.com/Microsoft/azure-pipelines-agent/issues/2043#issuecomment-687983301
 resources:
   containers:
+  - container: fedora_latest
+    image: fedora:latest
+    options: '--name runner -v /usr/bin/docker:/usr/bin/docker:ro'
   - container: debian_testing
     image: debian:testing
-    options: '--name ci-container -v /usr/bin/docker:/tmp/docker:ro'
+    options: '--name runner -v /usr/bin/docker:/usr/bin/docker:ro'
   - container: ubuntu_rolling
     image: ubuntu:rolling
-    options: '--name ci-container -v /usr/bin/docker:/tmp/docker:ro'
+    options: '--name runner -v /usr/bin/docker:/usr/bin/docker:ro'
 
 jobs:
 - job: BuildTest
@@ -16,7 +19,7 @@ jobs:
   strategy:
     matrix:
       fedora_latest:
-        image: fedora:latest
+        image: fedora_latest
       debian_testing:
         image: debian_testing
       ubuntu_rolling:
@@ -29,19 +32,14 @@ jobs:
   container: $[variables['image']]
   steps:
   - script: |
-      sudo dnf install -y dnf-plugins-core rpm-build
-      sudo dnf builddep -y --spec jss.spec
-    condition: or(startsWith(variables.image, 'fedora:'), startsWith(variables.image, 'centos:'))
+      docker exec -u 0 runner dnf install -y dnf-plugins-core rpm-build
+      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner dnf builddep -y --spec jss.spec
+    condition: or(startsWith(variables.image, 'fedora_'), startsWith(variables.image, 'centos_'))
     displayName: Install Fedora/CentOS dependencies
 
   - script: |
-      # Workaround to install sudo
-      # https://github.com/Microsoft/azure-pipelines-agent/issues/2043#issuecomment-687983301
-      /tmp/docker exec -t -u 0 ci-container \
-          apt-get update
-      /tmp/docker exec -t -u 0 -e DEBIAN_FRONTEND=noninteractive ci-container \
-          apt-get -o Dpkg::Options::="--force-confold" -y install sudo
-      sudo apt-get install -y \
+      docker exec -u 0 runner apt-get update
+      docker exec -u 0 runner apt-get install -y \
           cmake zip unzip \
           g++ libnss3-dev libnss3-tools \
           openjdk-11-jdk libcommons-lang3-java libslf4j-java junit4


### PR DESCRIPTION
The build tests in Azure pipelines have been updated to provide `docker` in the container for installing the dependencies as `root`, so it's no longer necessary to use `sudo`.

Resolves: #820