### PR TITLE
Related: Bug 1964176 - KRA PKCS12 support for nCipher sw v12.72+

### DIFF
--- a/src/main/java/org/mozilla/jss/util/jssutil.c
+++ b/src/main/java/org/mozilla/jss/util/jssutil.c
@@ -1166,7 +1166,6 @@ JSS_KeyExchange(PK11SlotInfo *slot, CK_MECHANISM_TYPE type,
 
          rsaParams.pe = 0x10001;
          attrFlags |= PK11_ATTR_SESSION;
-         attrFlags |= PK11_ATTR_EXTRACTABLE;
          attrFlags |= (PK11_ATTR_SENSITIVE | PK11_ATTR_PRIVATE);
 
          privKey = PK11_GenerateKeyPairWithOpFlags(slot, CKM_RSA_PKCS_KEY_PAIR_GEN,


### PR DESCRIPTION
Found an issue which was causing the need to add the "explicitness" flag
to the cknfracstrc file.

With this fix that flag will no longer be required.