### PR TITLE
Don't hold onto threads after they're gone

### DIFF
--- a/src/main/java/org/mozilla/jss/CryptoManager.java
+++ b/src/main/java/org/mozilla/jss/CryptoManager.java
@@ -1066,8 +1066,7 @@ public final class CryptoManager implements TokenSupplier
 
     public static final boolean JSS_DEBUG = getJSSDebug();
 
-    // Hashtable is synchronized.
-    private Hashtable<Thread, CryptoToken> perThreadTokenTable = new Hashtable<>();
+    private ThreadLocal<CryptoToken> threadToken = new ThreadLocal<CryptoToken>();
 
     /**
      * Sets the default token for the current thread. This token will
@@ -1084,9 +1083,9 @@ public final class CryptoManager implements TokenSupplier
     @Override
     public void setThreadToken(CryptoToken token) {
         if( token != null ) {
-            perThreadTokenTable.put(Thread.currentThread(), token);
+            threadToken.set(token);
         } else {
-            perThreadTokenTable.remove(Thread.currentThread());
+            threadToken.remove();
         }
     }
 
@@ -1104,8 +1103,7 @@ public final class CryptoManager implements TokenSupplier
      */
     @Override
     public CryptoToken getThreadToken() {
-        CryptoToken tok =
-            perThreadTokenTable.get(Thread.currentThread());
+        CryptoToken tok = threadToken.get();
         if( tok == null ) {
             tok = getInternalKeyStorageToken();
         }

--- a/src/main/java/org/mozilla/jss/CryptoManager.java
+++ b/src/main/java/org/mozilla/jss/CryptoManager.java
@@ -9,7 +9,6 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Vector;
 
@@ -1066,7 +1065,7 @@ public final class CryptoManager implements TokenSupplier
 
     public static final boolean JSS_DEBUG = getJSSDebug();
 
-    private ThreadLocal<CryptoToken> threadToken = new ThreadLocal<CryptoToken>();
+    private ThreadLocal<CryptoToken> threadToken = new ThreadLocal<>();
 
     /**
      * Sets the default token for the current thread. This token will


### PR DESCRIPTION
If threads are dynamically created and destroyed and
CryptoManager.setThreadToken() is called, a Hashtable will hold onto
references of Threads long after they should be garbage collected.