### PR TITLE
Only send fully-formed record fragments to NSS

### DIFF
--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -53,10 +53,13 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     /**
      * Size of the underlying BUFFERs.
      *
-     * Helps to be large enough to fit most common SSL packets during the
-     * initial handshake.
+     * Helps to be large enough to fit well-formed SSL packets during the
+     * initial handshake and subsequent data transfer.
+     *
+     * See MAX_ENCRYPTED_PACKET_LENGTH calculation from Tomcat's
+     *     org.apache.tomcat.util.net.openssl.OpenSSLEngine.
      */
-    protected static int BUFFER_SIZE = 1 << 12;
+    protected static int BUFFER_SIZE = 5 + 1024 + 1024 + 20 + 256 + (1 << 14);
 
     /**
      * Whether or not this SSLEngine is acting as the client end of the


### PR DESCRIPTION
In the SSLEngine's `unwrap(...)` method, we previously let NSS handle all
validation on the source `ByteBuffer`. While this limits the amount of TLS
protocol knowledge `JSSEngine` needs to have, it has the unfortunate side
effect of not always being able to expose the required
`WOULD_BLOCK_ERROR` status to the application; see the related pull
request below for a discussion on why this is problematic.

This change instead parses `src` for full record fragments, passing only
completed fragments to NSS. This ensures NSS never blocks waiting for
more data (as upon getting a full record, should release back to the
network layer to fetch more data) -- and also ensure applications are
properly informed when the network hasn't provided enough data to parse
a record fragment.

See also: https://github.com/dogtagpki/jss/pull/837

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`

--- 

This needs to be tested against Tomcat; @jmagne can you try a Dogtag deployment with this and see if [`testssl.sh`](https://testssl.sh/) or `sslscan` cause any high CPU usage when run against it?

@uplogix-mmcclain Could you take a look as well?