### PR TITLE
Fix symkey/jss parallel build issues

### DIFF
--- a/symkey/CMakeLists.txt
+++ b/symkey/CMakeLists.txt
@@ -8,6 +8,8 @@ javac(symkey-classes
         ${CLASSES_OUTPUT_DIR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
+    DEPENDS
+        generate_java
 )
 
 # TODO: merge into jss.jar


### PR DESCRIPTION
The symkey library includes dependencies into JSS; this requires that
the JSS classes have already been built (which occurs during the
`generate_java` build target). However, because there was no dependency
between symkey and jss projects, a highly parallel CMake backend like
ninja (or make, given enough cores) would fail to build JSS with import
errors due to missing JSS classes. Adding a dependency on the
`generate_java` build target fixes the ordering.

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`