### PR TITLE
Fix memory leak on each TLS connection

### DIFF
--- a/src/main/java/org/mozilla/jss/nss/SSLFDProxy.java
+++ b/src/main/java/org/mozilla/jss/nss/SSLFDProxy.java
@@ -1,6 +1,5 @@
 package org.mozilla.jss.nss;
 
-import java.lang.IllegalArgumentException;
 import java.util.ArrayList;
 
 import org.mozilla.jss.crypto.X509Certificate;
@@ -42,13 +41,14 @@ public class SSLFDProxy extends PRFDProxy {
 
     @Override
     protected synchronized void releaseNativeResources() throws Exception {
-        synchronized (globalRef) {
-            if (globalRef != null) {
-                try {
-                    globalRef.close();
-                } finally {
-                    globalRef = null;
-                }
+
+        super.releaseNativeResources();
+
+        if (globalRef != null) {
+            try {
+                globalRef.close();
+            } finally {
+                globalRef = null;
             }
         }
     }

--- a/src/main/java/org/mozilla/jss/util/GlobalRefProxy.java
+++ b/src/main/java/org/mozilla/jss/util/GlobalRefProxy.java
@@ -12,7 +12,5 @@ public class GlobalRefProxy extends NativeProxy {
     private static native byte[] refOf(Object target);
 
     @Override
-    protected synchronized void releaseNativeResources() {
-        clear();
-    }
+    protected native void releaseNativeResources();
 }


### PR DESCRIPTION
Each TLS connection is leaking a bunch of data that isn't in the heap
and so after 25k requests Tomcat uses about 2.5GB resident memory.

There are large number of relationships that point at each other and we
need to break the cycle so JSSEngineReferenceImpl's finalizer can run
and clear all the native resources these point at.

The lowest impact place to break the cycle was at SSLAlertEvent.engine.
This relationship doesn't seem to be used anywhere.  Once the cycle is
broken, JSSEngineReferenceImpl can be garbage collected and the
finalizer can run.

Signed-off-by: Chris Kelley <ckelley@redhat.com>