### PR TITLE
Fix memory leak on each TLS connection

### DIFF
--- a/src/main/java/org/mozilla/jss/nss/SSLFDProxy.java
+++ b/src/main/java/org/mozilla/jss/nss/SSLFDProxy.java
@@ -1,6 +1,5 @@
 package org.mozilla.jss.nss;
 
-import java.lang.IllegalArgumentException;
 import java.util.ArrayList;
 
 import org.mozilla.jss.crypto.X509Certificate;
@@ -42,13 +41,14 @@ public class SSLFDProxy extends PRFDProxy {
 
     @Override
     protected synchronized void releaseNativeResources() throws Exception {
-        synchronized (globalRef) {
-            if (globalRef != null) {
-                try {
-                    globalRef.close();
-                } finally {
-                    globalRef = null;
-                }
+
+        super.releaseNativeResources();
+
+        if (globalRef != null) {
+            try {
+                globalRef.close();
+            } finally {
+                globalRef = null;
             }
         }
     }

--- a/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -4,17 +4,39 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.nio.channels.WritableByteChannel;
-import java.nio.channels.Channels;
-import java.security.PublicKey;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.security.PublicKey;
 
-import javax.net.ssl.*;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509TrustManager;
 
-import org.mozilla.jss.nss.*;
-import org.mozilla.jss.pkcs11.*;
-import org.mozilla.jss.provider.javax.crypto.*;
-import org.mozilla.jss.ssl.*;
+import org.mozilla.jss.nss.BadCertHandler;
+import org.mozilla.jss.nss.Buffer;
+import org.mozilla.jss.nss.BufferProxy;
+import org.mozilla.jss.nss.Cert;
+import org.mozilla.jss.nss.CertAuthHandler;
+import org.mozilla.jss.nss.PR;
+import org.mozilla.jss.nss.PRErrors;
+import org.mozilla.jss.nss.PRFDProxy;
+import org.mozilla.jss.nss.SSL;
+import org.mozilla.jss.nss.SSLErrors;
+import org.mozilla.jss.nss.SSLFDProxy;
+import org.mozilla.jss.nss.SSLPreliminaryChannelInfo;
+import org.mozilla.jss.nss.SecurityStatusResult;
+import org.mozilla.jss.pkcs11.PK11Cert;
+import org.mozilla.jss.provider.javax.crypto.JSSNativeTrustManager;
+import org.mozilla.jss.ssl.SSLAlertDescription;
+import org.mozilla.jss.ssl.SSLAlertEvent;
+import org.mozilla.jss.ssl.SSLAlertLevel;
+import org.mozilla.jss.ssl.SSLCipher;
+import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
+import org.mozilla.jss.ssl.SSLVersion;
+import org.mozilla.jss.ssl.SSLVersionRange;
 
 /**
  * The reference JSSEngine implementation.
@@ -1651,10 +1673,10 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         if (!closed_fd && ssl_fd != null) {
             try {
                 SSL.RemoveCallbacks(ssl_fd);
-                PR.Close(ssl_fd);
                 ssl_fd.close();
+                ssl_fd = null;
             } catch (Exception e) {
-                debug("Got exception trying to cleanup SSLFD: " + e.getMessage());
+                logger.error("Got exception trying to cleanup SSLFD", e);
             } finally {
                 closed_fd = true;
             }
@@ -1670,6 +1692,15 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             write_buf = null;
         }
     }
+
+    // During testing with Tomcat 8.5, most instances did not call
+    // cleanup, so all the JNI resources end up getting leaked: ssl_fd
+    // (and its global ref), read_buf, and write_buf.
+    @Override
+    protected void finalize() {
+        cleanup();
+    }
+
 
     private class CertValidationTask extends CertAuthHandler {
         public CertValidationTask(SSLFDProxy fd) {

--- a/src/main/java/org/mozilla/jss/util/GlobalRefProxy.java
+++ b/src/main/java/org/mozilla/jss/util/GlobalRefProxy.java
@@ -12,7 +12,5 @@ public class GlobalRefProxy extends NativeProxy {
     private static native byte[] refOf(Object target);
 
     @Override
-    protected synchronized void releaseNativeResources() {
-        clear();
-    }
+    protected native void releaseNativeResources();
 }


### PR DESCRIPTION
Each TLS connection is leaking a bunch of data that isn't in the heap
and so after 25k requests Tomcat uses about 2.5GB resident memory.

There are large number of relationships that point at each other and we
need to break the cycle so JSSEngineReferenceImpl's finalizer can run
and clear all the native resources these point at.

The lowest impact place to break the cycle was at SSLAlertEvent.engine.
This relationship doesn't seem to be used anywhere.  Once the cycle is
broken, JSSEngineReferenceImpl can be garbage collected and the
finalizer can run.

Signed-off-by: Chris Kelley <ckelley@redhat.com>