### PR TITLE
Use %{_jvmdir} macro when defining java_home

### DIFF
--- a/jss.spec
+++ b/jss.spec
@@ -34,7 +34,7 @@ Source:         https://github.com/dogtagpki/%{name}/archive/v%{version}%{?_phas
 
 %define java_devel java-11-openjdk-devel
 %define java_headless java-11-openjdk-headless
-%define java_home /usr/lib/jvm/jre-11-openjdk
+%define java_home %{_jvmdir}/jre-11-openjdk
 
 ################################################################################
 # Build Options


### PR DESCRIPTION
This was fixed on master already, but didn't make it into this branch.