### PR TITLE
Replace deprecated X509Certificate.getSubjectDN() and getIssuerDN()

### DIFF
--- a/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
+++ b/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
@@ -25,7 +25,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
-import java.security.Principal;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
@@ -37,6 +36,7 @@ import java.util.List;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
+import javax.security.auth.x500.X500Principal;
 
 import org.apache.commons.lang3.StringUtils;
 import org.mozilla.jss.CryptoManager;
@@ -687,7 +687,7 @@ public class PKCS12Util {
         X509CertImpl cert = new X509CertImpl(x509cert);
         certInfo.setCert(cert);
 
-        Principal subjectDN = cert.getSubjectDN();
+        X500Principal subjectDN = cert.getSubjectX500Principal();
         logger.debug("   Subject DN: " + subjectDN);
 
         SET bagAttrs = bag.getBagAttributes();
@@ -851,7 +851,7 @@ public class PKCS12Util {
             throws CertificateException {
 
         for (PKCS12CertInfo certInfo : pkcs12.getCertInfos()) {
-            Principal certSubjectDN = certInfo.getCert().getSubjectDN();
+            X500Principal certSubjectDN = certInfo.getCert().getSubjectX500Principal();
 
             try {
                 LdapName certSubjdn  = new LdapName(certSubjectDN.toString());

--- a/src/main/java/org/mozilla/jss/netscape/security/util/Cert.java
+++ b/src/main/java/org/mozilla/jss/netscape/security/util/Cert.java
@@ -260,8 +260,8 @@ public class Cert {
         // build maps
         for (java.security.cert.X509Certificate cert : certs) {
 
-            String subjectDN = cert.getSubjectDN().toString();
-            String issuerDN = cert.getIssuerDN().toString();
+            String subjectDN = cert.getSubjectX500Principal().toString();
+            String issuerDN = cert.getIssuerX500Principal().toString();
 
             if (certMap.containsKey(subjectDN)) {
                 throw new Exception("Duplicate certificate: " + subjectDN);

--- a/src/main/java/org/mozilla/jss/netscape/security/util/CertPrettyPrint.java
+++ b/src/main/java/org/mozilla/jss/netscape/security/util/CertPrettyPrint.java
@@ -229,7 +229,7 @@ public class CertPrettyPrint {
             //XXX I18N IssuerDN ?
             sb.append(pp.indent(12) + resource.getString(
                     PrettyPrintResources.TOKEN_ISSUER) +
-                    mX509Cert.getIssuerDN().toString() + "\n");
+                    mX509Cert.getIssuerX500Principal() + "\n");
             sb.append(pp.indent(12) + resource.getString(
                     PrettyPrintResources.TOKEN_VALIDITY) + "\n");
             String notBefore = dateFormater.format(mX509Cert.getNotBefore());
@@ -287,7 +287,7 @@ public class CertPrettyPrint {
             //XXX I18N SubjectDN ?
             sb.append(pp.indent(12) + resource.getString(
                     PrettyPrintResources.TOKEN_SUBJECT) +
-                    mX509Cert.getSubjectDN().toString() + "\n");
+                    mX509Cert.getSubjectX500Principal() + "\n");
             sb.append(pp.indent(12) + resource.getString(
                     PrettyPrintResources.TOKEN_SPKI) + "\n");
 

--- a/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
+++ b/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
@@ -30,8 +30,8 @@ import javax.net.ssl.X509TrustManager;
 
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NotInitializedException;
-import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.netscape.security.util.Cert;
+import org.mozilla.jss.pkcs11.PK11Cert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class JSSTrustManager implements X509TrustManager {
         certChain = Cert.sortCertificateChain(certChain);
 
         for (X509Certificate cert : certChain) {
-            logger.debug("JSSTrustManager:  - " + cert.getSubjectDN());
+            logger.debug("JSSTrustManager:  - " + cert.getSubjectX500Principal());
         }
 
         // get CA certs
@@ -84,7 +84,7 @@ public class JSSTrustManager implements X509TrustManager {
 
     public void checkCert(X509Certificate cert, X509Certificate[] caCerts, String keyUsage) throws Exception {
 
-        logger.debug("JSSTrustManager: checkCert(" + cert.getSubjectDN() + "):");
+        logger.debug("JSSTrustManager: checkCert(" + cert.getSubjectX500Principal() + "):");
 
         boolean[] aki = cert.getIssuerUniqueID();
         logger.debug("JSSTrustManager: cert AKI: " + Arrays.toString(aki));
@@ -93,7 +93,7 @@ public class JSSTrustManager implements X509TrustManager {
         for (X509Certificate caCert : caCerts) {
 
             boolean[] ski = caCert.getSubjectUniqueID();
-            logger.debug("JSSTrustManager: SKI of " + caCert.getSubjectDN() + ": " + Arrays.toString(ski));
+            logger.debug("JSSTrustManager: SKI of " + caCert.getSubjectX500Principal() + ": " + Arrays.toString(ski));
 
             try {
                 cert.verify(caCert.getPublicKey(), "Mozilla-JSS");
@@ -105,10 +105,10 @@ public class JSSTrustManager implements X509TrustManager {
         }
 
         if (issuer == null) {
-            throw new CertificateException("Unable to validate signature: " + cert.getSubjectDN());
+            throw new CertificateException("Unable to validate signature: " + cert.getSubjectX500Principal());
         }
 
-        logger.debug("JSSTrustManager: cert signed by " + issuer.getSubjectDN());
+        logger.debug("JSSTrustManager: cert signed by " + issuer.getSubjectX500Principal());
 
         logger.debug("JSSTrustManager: checking validity range:");
         logger.debug("JSSTrustManager:  - not before: " + cert.getNotBefore());
@@ -134,7 +134,7 @@ public class JSSTrustManager implements X509TrustManager {
                 logger.debug("JSSTrustManager: configured to allow null extended key usages field");
             } else {
                 String msg = "Missing EKU: " + keyUsage +
-                    ". Certificate with subject DN `" + cert.getSubjectDN() + "` had ";
+                    ". Certificate with subject DN `" + cert.getSubjectX500Principal() + "` had ";
                 if (extendedKeyUsages == null) {
                     msg += "no EKU extension";
                 } else {

--- a/src/test/java/org/mozilla/jss/tests/BenchmarkSSLSocket.java
+++ b/src/test/java/org/mozilla/jss/tests/BenchmarkSSLSocket.java
@@ -13,6 +13,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
+
 import org.mozilla.jss.provider.javax.crypto.JSSNativeTrustManager;
 
 /**
@@ -112,7 +113,7 @@ public class BenchmarkSSLSocket {
                         // i = 1 skips the CA certificate
                         for (int i = 1; i < a.length; i++) {
                             java.security.cert.X509Certificate x509 = (java.security.cert.X509Certificate) a[i];
-                            jks.setCertificateEntry(x509.getSubjectDN().toString(), x509);
+                            jks.setCertificateEntry(x509.getSubjectX500Principal().toString(), x509);
                         }
                     }
                 }

--- a/src/test/java/org/mozilla/jss/tests/ChainSortingTest.java
+++ b/src/test/java/org/mozilla/jss/tests/ChainSortingTest.java
@@ -230,7 +230,7 @@ public class ChainSortingTest {
         } catch (Exception e) {
             String message = e.getMessage();
 
-            String expected = "Duplicate certificate: " + subCA.getSubjectDN();
+            String expected = "Duplicate certificate: " + subCA.getSubjectX500Principal();
             Assert.assertEquals(expected, message);
         }
     }
@@ -249,7 +249,7 @@ public class ChainSortingTest {
         } catch (Exception e) {
             String message = e.getMessage();
 
-            String expected = "Branched chain: " + subCA.getSubjectDN();
+            String expected = "Branched chain: " + subCA.getSubjectX500Principal();
             Assert.assertEquals(expected, message);
         }
     }
@@ -269,7 +269,7 @@ public class ChainSortingTest {
             String message = e.getMessage();
 
             String expected = "Multiple leaf certificates: [" +
-                    rootCA.getSubjectDN() + "], [" + admin.getSubjectDN() + "]";
+                    rootCA.getSubjectX500Principal() + "], [" + admin.getSubjectX500Principal() + "]";
             Assert.assertEquals(expected, message);
         }
     }

--- a/src/test/java/org/mozilla/jss/tests/ListCerts.java
+++ b/src/test/java/org/mozilla/jss/tests/ListCerts.java
@@ -68,7 +68,7 @@ public class ListCerts {
                     cf.generateCertificate(bais);
                 bais.close();
 
-                System.out.println("Subject " + jdkCert.getSubjectDN());
+                System.out.println("Subject " + jdkCert.getSubjectX500Principal());
                 System.out.println("Signature oid " + jdkCert.getSigAlgName());
                 /* non critical extensions */
                 Set<String> nonCritSet = jdkCert.getNonCriticalExtensionOIDs();


### PR DESCRIPTION
The `X509Certificate.getSubjectDN()` and `getIssuerDN()` have been replaced with `getSubjectX500Principal()` and `getIssuerX500Principal()`, respectively, except where the values are converted into `X500Name`.