### PR TITLE
Add doc for deprecated methods in X509CertImpl

### DIFF
--- a/docs/changes/v5.2.0/API-Changes.adoc
+++ b/docs/changes/v5.2.0/API-Changes.adoc
@@ -1,0 +1,6 @@
+= API Changes =
+
+== Deprecate getSubjectDN() and getIssuerDN() in X509CertImpl ==
+
+The `getSubjectDN()` and `getIssuerDN()` in `org.mozilla.jss.netscape.security.x509.X509CertImpl` have been deprecated.
+Use `getSubjectName()` and `getIssuerName()` or `getSubjectX500Principal​()` and `getIssuerX500Principal​()` instead.

--- a/src/main/java/org/mozilla/jss/netscape/security/x509/X509CertImpl.java
+++ b/src/main/java/org/mozilla/jss/netscape/security/x509/X509CertImpl.java
@@ -722,8 +722,10 @@ public class X509CertImpl extends X509Certificate
      * Gets the subject distinguished name from the certificate.
      *
      * @return the subject name.
+     * @deprecated Use getSubjectName() or getSubjectX500Principal() instead.
      */
     @Override
+    @Deprecated(since="5.2.0")
     public Principal getSubjectDN() {
         return getSubjectName();
     }
@@ -756,8 +758,10 @@ public class X509CertImpl extends X509Certificate
      * Gets the issuer distinguished name from the certificate.
      *
      * @return the issuer name.
+     * @deprecated Use getIssuerName() or getIssuerX500Principal() instead.
      */
     @Override
+    @Deprecated(since="5.2.0")
     public Principal getIssuerDN() {
         return getIssuerName();
     }


### PR DESCRIPTION
https://github.com/edewata/jss/blob/deprecation/docs/changes/v5.2.0/API-Changes.adoc