### PR TITLE
Update PKCS11Constants

### DIFF
--- a/docs/changes/v5.2.0/API-Changes.adoc
+++ b/docs/changes/v5.2.0/API-Changes.adoc
@@ -4,3 +4,15 @@
 
 The `getSubjectDN()` and `getIssuerDN()` in `org.mozilla.jss.netscape.security.x509.X509CertImpl` have been deprecated.
 Use `getSubjectName()` and `getIssuerName()` or `getSubjectX500Principal​()` and `getIssuerX500Principal​()` instead.
+
+== PKCS11Constants Changes ==
+
+The `PKCS11Constants` class has been updated to include the new constants introduced in NSS 3.73:
+
+* `CKO_NSS_VALIDATION`
+* `CKA_NSS_VALIDATION_TYPE`
+* `CKA_NSS_VALIDATION_VERSION`
+* `CKA_NSS_VALIDATION_LEVEL`
+* `CKA_NSS_VALIDATION_MODULE_ID`
+
+NOTE: These constants should only be used with NSS 3.73 or later.

--- a/src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java
+++ b/src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java
@@ -6283,6 +6283,13 @@ public interface PKCS11Constants {
      *
      * Source file: /usr/include/nss3/pkcs11n.h
      */
+    public static final long CKO_NSS_VALIDATION = 0xCE534357L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
     public static final long CKK_NSS = 0xCE534350L;
 
     /**
@@ -6529,6 +6536,34 @@ public interface PKCS11Constants {
      * Source file: /usr/include/nss3/pkcs11n.h
      */
     public static final long CKA_NSS_EMAIL_DISTRUST_AFTER = 0xCE534374L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKA_NSS_VALIDATION_TYPE = 0xCE534374L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKA_NSS_VALIDATION_VERSION = 0xCE534375L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKA_NSS_VALIDATION_LEVEL = 0xCE534376L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKA_NSS_VALIDATION_MODULE_ID = 0xCE534377L;
 
     /**
      * Content automatically generated; see NSS documentation for more information.


### PR DESCRIPTION
The PKCS11Constants class has been updated to include the new constants introduced in NSS 3.73.

Resolves: https://github.com/dogtagpki/jss/issues/832