### PR TITLE
Fix COPR build failure

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,5 +1,6 @@
 srpm:
 	dnf install -y git
+	git config --global --add safe.directory ${PWD}
 	./build.sh --with-timestamp --with-commit-id srpm
 	if [[ "${outdir}" != "" ]]; then \
 	    mv ${HOME}/build/jss/SRPMS/* ${outdir}; \


### PR DESCRIPTION
The `.copr/Makefile` has been updated to fix COPR build failure caused by changes in Git 2.35.2:
```
fatal: unsafe repository (<current dir> is owned by someone else)
```

https://stackoverflow.com/questions/71901632/fatal-unsafe-repository-home-repon-is-owned-by-someone-else