### PR TITLE
Fix Bug 2013674 - JSS cannot be properly initialized after using anot…

### DIFF
--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -228,6 +228,12 @@ macro(jss_tests)
         DEPENDS "Setup_DBs"
     )
     jss_test_java(
+	NAME "Mozilla_JSS_NSS_Context"
+        COMMAND "org.mozilla.jss.tests.JSSContextInitTest" "${RESULTS_NSSDB_OUTPUT_DIR}" "${DB_PWD}" 
+        DEPENDS "Setup_DBs"
+    )
+
+    jss_test_java(
         NAME "JSS_Signature_test"
         COMMAND "org.mozilla.jss.tests.SigTest" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
         DEPENDS "Setup_DBs"

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -506,3 +506,9 @@ Java_org_mozilla_jss_crypto_JSSOAEPParameterSpec_releaseNativeResources;
     local:
         *;
 };
+JSS_4.9.3 {
+    global:
+Java_org_mozilla_jss_CryptoManager_initializeAllNativeWithContext;
+    local:
+        *;
+};

--- a/src/main/java/org/mozilla/jss/CryptoManager.java
+++ b/src/main/java/org/mozilla/jss/CryptoManager.java
@@ -495,6 +495,27 @@ public final class CryptoManager implements TokenSupplier
         initialize( new InitializationValues(configDir) );
     }
 
+    public static synchronized void initializeWithContext( String configDir )
+        throws  KeyDatabaseException,
+                CertDatabaseException,
+                AlreadyInitializedException,
+                GeneralSecurityException
+    {
+        InitializationValues values = new InitializationValues(configDir);
+        values.initializeContext = true;
+        initialize( values );
+    }
+
+    public static synchronized void initializeWithContext( InitializationValues values )
+        throws
+        KeyDatabaseException,
+        CertDatabaseException,
+        AlreadyInitializedException,
+        GeneralSecurityException
+    {
+        values.initializeContext = true;
+	initialize( values);
+    }
     /**
      * Initialize the security subsystem.  Opens the databases, loads all
      * PKCS #11 modules, initializes the internal random number generator.
@@ -528,8 +549,10 @@ public final class CryptoManager implements TokenSupplier
                     "Must set ocspResponderCertNickname");
             }
         }
-
-        initializeAllNative2(values.configDir,
+        //Right now, allow only the choice of a full NSS init or a NSS context init, which is useful for libraries,
+        //where the main app may have already initialized nss itself.
+	if(values.initializeContext == true) {
+            initializeAllNativeWithContext(values.configDir,
                             values.certPrefix,
                             values.keyPrefix,
                             values.secmodName,
@@ -557,6 +580,37 @@ public final class CryptoManager implements TokenSupplier
                             values.noPK11Finalize,
                             values.cooperate
                             );
+
+        } else {
+            initializeAllNative2(values.configDir,
+                            values.certPrefix,
+                            values.keyPrefix,
+                            values.secmodName,
+                            values.readOnly,
+                            values.getManufacturerID(),
+                            values.getLibraryDescription(),
+                            values.getInternalTokenDescription(),
+                            values.getInternalKeyStorageTokenDescription(),
+                            values.getInternalSlotDescription(),
+                            values.getInternalKeyStorageSlotDescription(),
+                            values.getFIPSSlotDescription(),
+                            values.getFIPSKeyStorageSlotDescription(),
+                            values.ocspCheckingEnabled,
+                            values.ocspResponderURL,
+                            values.ocspResponderCertNickname,
+                            values.initializeJavaOnly,
+                            values.PKIXVerify,
+                            values.noCertDB,
+                            values.noModDB,
+                            values.forceOpen,
+                            values.noRootInit,
+                            values.optimizeSpace,
+                            values.PK11ThreadSafe,
+                            values.PK11Reload,
+                            values.noPK11Finalize,
+                            values.cooperate
+                            );
+        }
 
         instance = new CryptoManager();
         instance.setPasswordCallback(values.passwordCallback);
@@ -607,6 +661,38 @@ public final class CryptoManager implements TokenSupplier
 
     private static native void
     initializeAllNative2(String configDir,
+                        String certPrefix,
+                        String keyPrefix,
+                        String secmodName,
+                        boolean readOnly,
+                        String manufacturerID,
+                        String libraryDescription,
+                        String internalTokenDescription,
+                        String internalKeyStorageTokenDescription,
+                        String internalSlotDescription,
+                        String internalKeyStorageSlotDescription,
+                        String fipsSlotDescription,
+                        String fipsKeyStorageSlotDescription,
+                        boolean ocspCheckingEnabled,
+                        String ocspResponderURL,
+                        String ocspResponderCertNickname,
+                        boolean initializeJavaOnly,
+                        boolean PKIXVerify,
+                        boolean noCertDB,
+                        boolean noModDB,
+                        boolean forceOpen,
+                        boolean noRootInit,
+                        boolean optimizeSpace,
+                        boolean PK11ThreadSafe,
+                        boolean PK11Reload,
+                        boolean noPK11Finalize,
+                        boolean cooperate)
+        throws KeyDatabaseException,
+        CertDatabaseException,
+        AlreadyInitializedException;
+
+    private static native void
+    initializeAllNativeWithContext(String configDir,
                         String certPrefix,
                         String keyPrefix,
                         String secmodName,

--- a/src/main/java/org/mozilla/jss/InitializationValues.java
+++ b/src/main/java/org/mozilla/jss/InitializationValues.java
@@ -109,6 +109,22 @@ public final class InitializationValues {
      * the databases are opened in read-write mode.
      */
     public boolean readOnly = false;
+    public boolean initializeContext = false;
+
+    /**
+     * Returns boolean value of initializeContext.
+     * <p>The default is <code>"false                     "</code>.
+     *
+     * @return initializeContext.
+     */
+    public boolean getInitializeContext() { return initializeContext; }
+    /**
+     * Sets boolean value of initializeContext.
+     * @param value of initializeContext.
+     */
+    public void setInitializeContext(boolean value) {
+        this.initializeContext = value;
+    }
 
     ////////////////////////////////////////////////////////////////////
     // Manufacturer ID

--- a/src/test/java/org/mozilla/jss/tests/JSSContextInitTest.java
+++ b/src/test/java/org/mozilla/jss/tests/JSSContextInitTest.java
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* This program demonstrates how to sign data with keys from JSS
+ *
+ * The token name can be either the name of a hardware token, or
+ * one of the internal tokens:
+ *  Internal Crypto Services Token
+ *  Internal Key Storage Token    (keys stored in key4.db)
+ */
+package org.mozilla.jss.tests;
+
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.util.Enumeration;
+
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.crypto.KeyPairAlgorithm;
+import org.mozilla.jss.crypto.KeyPairGenerator;
+import org.mozilla.jss.crypto.KeyPairGeneratorSpi;
+import org.mozilla.jss.crypto.Policy;
+import org.mozilla.jss.crypto.Signature;
+import org.mozilla.jss.crypto.SignatureAlgorithm;
+import org.mozilla.jss.pkcs11.PK11Token;
+import org.mozilla.jss.util.Password;
+
+public class JSSContextInitTest {
+
+    public static void usage() {
+        System.out.println(
+                "Usage: java org.mozilla.jss.crypto.JSSContextInitTest <dbdir> <dbpw>" +
+                " [tokenname]");
+    }
+
+    //The purpose of this test is to simply attemt a representative JSS task such as Signing
+    //while having JSS initialized as a NSS Context instead of a full NSS initialization.
+    public static void main(String args[]) throws Exception {
+        CryptoManager manager;
+
+        if (args.length < 2 || args.length > 3) {
+            usage();
+            System.exit(1);
+        }
+
+        CryptoManager.initializeWithContext(args[0]);
+        manager = CryptoManager.getInstance();
+
+	try {
+            testSignatures(manager,args);
+        } catch (Exception e) {
+            System.out.println();
+	    throw new Exception(e);
+        } finally {
+            //Shutdown the manager which has been init with an NSS Context
+            manager.shutdown();
+        }
+
+    }
+
+    private static void testSignatures(CryptoManager manager, String args[]) throws Exception {
+        CryptoToken token;
+        byte[] data = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        byte[] signature;
+        Signature signer;
+        Signature signerPSS;
+        PublicKey pubk;
+        KeyPairGenerator kpgen;
+        KeyPair keyPair;
+
+        /* Print out list of available tokens */
+        Enumeration<CryptoToken> en = manager.getAllTokens();
+        System.out.println("Available tokens:");
+        while (en.hasMoreElements()) {
+            PK11Token p = (PK11Token) en.nextElement();
+            System.out.println(" token : " + p.getName());
+        }
+
+        if (args.length >= 3) {
+            token = manager.getTokenByName(args[2]);
+        } else {
+            //get default internal key storage token
+            token = manager.getInternalKeyStorageToken();
+        }
+
+	String pw = args[1];
+	if(token.isLoggedIn() == false) {
+            Password password = new Password(pw.toCharArray());
+            token.login(password);
+        }
+
+        // Generate an RSA keypair
+        kpgen = token.getKeyPairGenerator(KeyPairAlgorithm.RSA);
+        kpgen.initialize(Policy.RSA_MINIMUM_KEY_SIZE);
+        KeyPairGeneratorSpi.Usage usages[] = {
+            KeyPairGeneratorSpi.Usage.SIGN,
+            KeyPairGeneratorSpi.Usage.VERIFY};
+        KeyPairGeneratorSpi.Usage usages_mask[] = {
+            KeyPairGeneratorSpi.Usage.SIGN,
+            KeyPairGeneratorSpi.Usage.VERIFY};
+
+        kpgen.setKeyPairUsages(usages, usages_mask);
+        keyPair = kpgen.genKeyPair();
+
+        // RSA SHA256
+        signer = token.getSignatureContext(
+                SignatureAlgorithm.RSASignatureWithSHA256Digest);
+        System.out.println("Created a signing context");
+        signer.initSign(
+                (org.mozilla.jss.crypto.PrivateKey) keyPair.getPrivate());
+        System.out.println("initialized the signing operation");
+
+        signer.update(data);
+        System.out.println("updated signature with data");
+        signature = signer.sign();
+        System.out.println("Successfully signed!");
+
+        signer.initVerify(keyPair.getPublic());
+        System.out.println("initialized verification");
+        signer.update(data);
+        System.out.println("updated verification with data");
+        if (signer.verify(signature)) {
+            System.out.println("Signature Verified Successfully!");
+        } else {
+            throw new Exception("ERROR: Signature failed to verify.");
+        }
+
+        signerPSS = token.getSignatureContext(
+                SignatureAlgorithm.RSAPSSSignatureWithSHA256Digest);
+        signerPSS.initSign(
+                (org.mozilla.jss.crypto.PrivateKey) keyPair.getPrivate());
+
+        signerPSS.update(data);
+        signature = signerPSS.sign();
+        System.out.println("PSS Successfully signed!");
+
+        signerPSS.initVerify(keyPair.getPublic());
+        signerPSS.update(data);
+        System.out.println("updated verification with data");
+        if (signerPSS.verify(signature)) {
+            System.out.println("PSS Signature Verified Successfully!");
+        } else {
+            throw new Exception("ERROR: PSS Signature failed to verify.");
+        }
+
+        System.out.println("SignatureTests passed.");
+
+    }
+}


### PR DESCRIPTION
…her NSS-backed security provider

The solution the the bug is to provide a way to initialize JSS such that the underlying nss system is initialized as a context
instead of a full NSS initialization. This allows jss / nss to create it's own nss init scenario. This could be of use where
the main process has already inited nss with a set of params and properties. Allowing say a library loaded into the man process the ability
to do a context based nss init, allows the library to set it's own nss params and not inherit those from the main process.
For instance if a main process has initialized nss to have a read only database, the context init will allow the library to load an nss
context with a read write database.

This is accomplished in a very simple manner with respect to jss. Right now jss allows one singleton instance to be created for a program.
This fix allows the caller to choose to have the singleton to be inited either as a context or a full init. Theoretically the nss context
concept would allow for multiple contexts to be created,but for simplicity, JSS will only allow one such context or full nss init.

The original behavior of doing a full NSS init beneath JSS persists as the default. In order to do a context init the following sample code will suffice:

CryptoManager.initializeWithContext(databaseDir);

manager = CryptoManager.getInstance();
...
...
manager.shutdown().

Notice that  an explicit call to shutdown is recommended because the NSS context inited must be destroyed at the native code level, in oder to not interfere with the main program's nss instance.

If one wants to explicitly specify the Initialization  values, the following call can be used as well:

InitializationValues vals =
                    new InitializationValues(args[0],
                            "", "", "secmod.db");

CryptoManager.initializeWithContext(vals);
CryptoManager manager = CryptoManager.getIntance();

...
...

manager.shutdwown();

Note: That as of this patch , there is no way to call for a context init when using the JCA provider interface. That can be a future improvement.