### PR TITLE
Update OpenLDAP clients to use -H option

### DIFF
--- a/tests/bin/ds-create.sh
+++ b/tests/bin/ds-create.sh
@@ -13,7 +13,7 @@ sed -i \
 
 dscreate from-file ds.inf
 
-ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 << EOF
+ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 << EOF
 dn: dc=example,dc=com
 objectClass: domain
 dc: example


### PR DESCRIPTION
The latest OpenLDAP clients no longer have the `-h` option so the the tests have been updated to use the `-H` option instead.

https://github.com/dogtagpki/pki/wiki/DS-Installation