### PR TITLE
Tidy up X509CRLImpl

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -6,6 +6,8 @@ jobs:
   build-test:
     name: Build Test
     runs-on: ubuntu-latest
+    env:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
     strategy:
       matrix:
         os:
@@ -33,7 +35,7 @@ jobs:
         apt-get install -y \
             cmake zip unzip \
             g++ libnss3-dev libnss3-tools \
-            openjdk-11-jdk libcommons-lang3-java libslf4j-java junit4
+            openjdk-17-jdk libcommons-lang3-java libslf4j-java junit4
 
     - name: Build JSS binaries, Javadoc, and run tests
       run: ./build.sh --with-tests
@@ -43,6 +45,8 @@ jobs:
   symbol-test:
     name: Symbol Test
     runs-on: ubuntu-latest
+    env:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
     steps:
       - name: Clone repository
         uses: actions/checkout@v2

--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -6,6 +6,8 @@ jobs:
   build:
     name: Building JSS
     runs-on: ubuntu-latest
+    env:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
 
     steps:
     - name: Clone repository
@@ -14,7 +16,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
 
     - name: Build JSS

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project has the following dependencies:
     - Recommended version: 3.48 and above
     - A c and c++ compiler such as [gcc](ttps://gcc.gnu.org/)
     - [zlib](https://zlib.net/)
- - [OpenJDK 1.8.0 or newer](https://openjdk.java.net/)
+ - [OpenJDK 17 or newer](https://openjdk.java.net/)
  - [CMake](https://cmake.org/)
  - [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/)
  - [SLF4J](https://www.slf4j.org/)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,12 +42,19 @@ jobs:
       docker exec -u 0 runner apt-get install -y \
           cmake zip unzip \
           g++ libnss3-dev libnss3-tools \
-          openjdk-11-jdk libcommons-lang3-java libslf4j-java junit4
+          openjdk-17-jdk libcommons-lang3-java libslf4j-java junit4
     condition: or(startsWith(variables.image, 'debian_'), startsWith(variables.image, 'ubuntu_'))
     displayName: Install Debian/Ubuntu dependencies
 
   - script: ./build.sh --with-tests
-    displayName: Build JSS binaries, Javadoc, and run tests
+    condition: or(startsWith(variables.image, 'fedora_'), startsWith(variables.image, 'centos_'))
+    displayName: Build JSS binaries, Javadoc, and run tests on Fedora/CentOS
+
+  - script: ./build.sh --with-tests
+    condition: or(startsWith(variables.image, 'debian_'), startsWith(variables.image, 'ubuntu_'))
+    displayName: Build JSS binaries, Javadoc, and run tests on Debian/Unbuntu
+    env:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
 
 - job: SymbolTest
   pool:

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -270,11 +270,11 @@ macro(jss_config_java)
     list(APPEND JSS_JAVAC_FLAGS "-sourcepath")
     list(APPEND JSS_JAVAC_FLAGS "${PROJECT_SOURCE_DIR}/src/main/java")
 
-    # Ensure we're compatible with JDK 11
+    # Ensure we're compatible with JDK 17
     list(APPEND JSS_JAVAC_FLAGS "-target")
-    list(APPEND JSS_JAVAC_FLAGS "11")
+    list(APPEND JSS_JAVAC_FLAGS "17")
     list(APPEND JSS_JAVAC_FLAGS "-source")
-    list(APPEND JSS_JAVAC_FLAGS "11")
+    list(APPEND JSS_JAVAC_FLAGS "17")
 
     # Handle passed-in javac flags as well; assume they are valid.
     separate_arguments(PASSED_JAVAC_FLAGS UNIX_COMMAND "$ENV{JAVACFLAGS}")
@@ -295,11 +295,11 @@ macro(jss_config_java)
     list(APPEND JSS_TEST_JAVAC_FLAGS "-sourcepath")
     list(APPEND JSS_TEST_JAVAC_FLAGS "${PROJECT_SOURCE_DIR}/src/main/java")
 
-    # Ensure we're compatible with JDK 11
+    # Ensure we're compatible with JDK 17
     list(APPEND JSS_TEST_JAVAC_FLAGS "-target")
-    list(APPEND JSS_TEST_JAVAC_FLAGS "11")
+    list(APPEND JSS_TEST_JAVAC_FLAGS "17")
     list(APPEND JSS_TEST_JAVAC_FLAGS "-source")
-    list(APPEND JSS_TEST_JAVAC_FLAGS "11")
+    list(APPEND JSS_TEST_JAVAC_FLAGS "17")
 
     # Handle passed-in javac flags as well; assume they are valid.
     separate_arguments(PASSED_JAVAC_FLAGS UNIX_COMMAND "$ENV{JAVACFLAGS}")

--- a/cmake/Java.cmake
+++ b/cmake/Java.cmake
@@ -84,8 +84,8 @@ function(javac target)
             -encoding UTF-8
             -cp ${native_classpath}
             -d ${output_dir}
-            -source 11
-            -target 11
+            -source 17
+            -target 17
             @${file_list}
         WORKING_DIRECTORY
             ${source_dir}

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>11</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
         </plugins>
@@ -55,6 +55,7 @@
         <sonar.projectKey>dogtagpki_jss</sonar.projectKey>
         <sonar.organization>dogtagpki</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/tools/Dockerfiles/fedora_rawhide
+++ b/tools/Dockerfiles/fedora_rawhide
@@ -4,8 +4,8 @@ FROM registry.fedoraproject.org/fedora:rawhide
 RUN true \
         && dnf update -y --refresh \
         && dnf install -y dnf-plugins-core gcc make rpm-build cmake \
-                          java-11-openjdk nss-tools \
-                          apache-commons-lang3 gcc-c++ java-11-openjdk-devel \
+                          java-17-openjdk nss-tools \
+                          apache-commons-lang3 gcc-c++ java-17-openjdk-devel \
                           jpackage-utils slf4j nss zlib-devel nss-devel \
                           nspr-devel slf4j-jdk14 junit \
         && mkdir -p /home/sandbox \
@@ -21,7 +21,7 @@ COPY . /home/sandbox/jss
 # Perform the actual RPM build
 WORKDIR /home/sandbox/jss
 CMD true \
-        && export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk \
+        && export JAVA_HOME=/usr/lib/jvm/jre-17-openjdk \
         && export WITH_INTERNET=1 \
         && rm -rf build \
         && mkdir build \


### PR DESCRIPTION
* Reorder modifiers to match the JLS
* Rename static constant to match JLS
* Remove commented out code
* Use pattern matching with instanceof
* Remove unnecessary else clauses
* Use ternary operator where appropriate
* Put array designator on the type not the variable
* Remove unnecessary negation in logic of parse() method