### PR TITLE
Socket timeout on large post

### DIFF
--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -53,10 +53,13 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     /**
      * Size of the underlying BUFFERs.
      *
-     * Helps to be large enough to fit most common SSL packets during the
-     * initial handshake.
+     * Helps to be large enough to fit well-formed SSL packets during the
+     * initial handshake and subsequent data transfer.
+     *
+     * See MAX_ENCRYPTED_PACKET_LENGTH calculation from Tomcat's
+     *     org.apache.tomcat.util.net.openssl.OpenSSLEngine.
      */
-    protected static int BUFFER_SIZE = 1 << 12;
+    protected static int BUFFER_SIZE = 5 + 1024 + 1024 + 20 + 256 + (1 << 14);
 
     /**
      * Whether or not this SSLEngine is acting as the client end of the

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSession.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSession.java
@@ -13,6 +13,7 @@ import org.mozilla.jss.pkcs11.*;
 import org.mozilla.jss.ssl.*;
 
 public class JSSSession implements SSLSession, AutoCloseable {
+    private static final int MAX_TLS_RECORD_PAYLOAD = (1 << 14);
     private JSSEngine parent;
 
     private int applicationBufferSize;
@@ -43,7 +44,7 @@ public class JSSSession implements SSLSession, AutoCloseable {
     protected JSSSession(JSSEngine engine, int buffer_size) {
         this.parent = engine;
 
-        applicationBufferSize = buffer_size;
+        applicationBufferSize = Math.min(buffer_size, MAX_TLS_RECORD_PAYLOAD);
         packetBufferSize = buffer_size;
 
         this.appDataMap = new HashMap<>();


### PR DESCRIPTION
On low latency networks (LAN), large posts or file uploads would hang near the end of the transfer and report socket timeout exceptions.

On slower networks (VPN), large HTTP requests could silently fail with the input truncated.

I created large.jsp as an example for testing largish posts.  It usually only takes 11kB to 30kB to see this issue.
https://gist.github.com/uplogix-mmcclain/8c7d796b08e55c7fc21e3b38677df7d3

My first attempt at fixing this was #837.  @cipherboy created #838 in response.  The first commit in this series is one of the commits from #838.  The second commit sizes the application buffer to reduce TLS record fragmenting and eliminates the annoying message from Tomcat about resizing buffers beyond what it thinks is maximal: message is triggered by the first commit.