### PR TITLE
Sonarcloud token

### DIFF
--- a/.github/workflows/code-analysis-pull.yml
+++ b/.github/workflows/code-analysis-pull.yml
@@ -1,0 +1,102 @@
+name: Code Analysis for Pull Fork
+on:
+  workflow_run:
+    workflows: ["Code Analysis"]
+    types:
+      - completed
+jobs:
+
+  retrieve-pr:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      pr-number: ${{ steps.pr-artifact-script.outputs.result }}
+    steps:
+      - name: 'Download PR artifact'
+        uses: actions/github-script@v3.1.0
+        id: download-pr
+        with:
+          result-encoding: string
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            if (matchArtifact == null){
+              core.setFailed("No PR artifact");
+              return "False";
+            }
+            var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+            return "True";
+
+      - name: Unzip the pr
+        if: steps.download-pr.outputs.result == 'True'
+        run: unzip pr.zip
+
+      - name: Retrieve the pr number
+        if: success()
+        id: pr-artifact-script
+        uses: actions/github-script@v3.1.0
+        with:
+          result-encoding: string
+          script: |
+            var fs = require('fs');
+            var pr_number = Number(fs.readFileSync('./NR'));
+            return pr_number;
+
+  build:
+    name: Code analysis
+    needs: retrieve-pr
+    runs-on: ubuntu-latest
+    env:
+      HAVE_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN  != '' }}
+    steps:
+      - name: Stop if no Sonar secret
+        if:  ${{ env.HAVE_SONAR_TOKEN == 'false' }}
+        run: exit 1
+
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze with SonarCloud
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: >
+          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+          -Dsonar.c.file.suffixes= -Dsonar.cpp.file.suffixes=- -Dsonar.objc.file.suffixes=-
+          -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+          -Dsonar.pullrequest.key=${{ needs.retrieve-pr.outputs.pr-number }}
+          -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}
+          -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+  
+

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -39,3 +39,18 @@ jobs:
           mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
           -Dsonar.c.file.suffixes= -Dsonar.cpp.file.suffixes=- -Dsonar.objc.file.suffixes=-
 
+  get-pr-ref:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    name: Sonar cloud PR fork analyses deferring
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+
+      - name: Upload pr as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -6,7 +6,7 @@ jobs:
     name: Code analysis
     runs-on: ubuntu-latest
     env:
-      HAVE_SONAR_SECRET: ${{ secrets.SONAR_TOKEN  != '' }}
+      HAVE_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN  != '' }}
     steps:
       - name: Stop if no Sonar secret
         if:  ${{ env.HAVE_SONAR_TOKEN == 'false' }}

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -2,9 +2,16 @@ name: Code Analysis
 on: [push, pull_request]
 jobs:
   build:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     name: Code analysis
     runs-on: ubuntu-latest
+    env:
+      HAVE_SONAR_SECRET: ${{ secrets.SONAR_TOKEN  != '' }}
     steps:
+      - name: Stop if no Sonar secret
+        if:  ${{ env.HAVE_SONAR_TOKEN == 'false' }}
+        run: exit 1
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis


### PR DESCRIPTION
Sonarcloud plug-in for maven allows to publish analyses without token if the project accept anonymous users. This allows to perform analysis on pull request from fork repository but have a side effect. Actions run in the fork can update analysis on Sonarcloud. As an example, the list of branch in Sonarcloud projects includes some branches from fork repository.

User could update also the analysis on master branch working in the fork.

Configuration on Sonarcloud is updated to avoid this behaviour and the change in this PR will work allows to work with PR from fork repositories.