### PR TITLE
Fix #861

### DIFF
--- a/tools/java.security.in
+++ b/tools/java.security.in
@@ -30,14 +30,15 @@
 #
 security.provider.1=org.mozilla.jss.JSSProvider @JSS_CFG_PATH@
 security.provider.2=sun.security.provider.Sun
-security.provider.3=sun.security.rsa.SunRsaSign
-security.provider.4=sun.security.ec.SunEC
-security.provider.5=com.sun.net.ssl.internal.ssl.Provider
-security.provider.6=com.sun.crypto.provider.SunJCE
-security.provider.7=sun.security.jgss.SunProvider
-security.provider.8=com.sun.security.sasl.Provider
-security.provider.9=org.jcp.xml.dsig.internal.dom.XMLDSigRI
-security.provider.10=sun.security.smartcardio.SunPCSC
+security.provider.3=sun.security.ssl.SunJSSE
+security.provider.4=sun.security.rsa.SunRsaSign
+security.provider.5=sun.security.ec.SunEC
+security.provider.6=com.sun.net.ssl.internal.ssl.Provider
+security.provider.7=com.sun.crypto.provider.SunJCE
+security.provider.8=sun.security.jgss.SunProvider
+security.provider.9=com.sun.security.sasl.Provider
+security.provider.10=org.jcp.xml.dsig.internal.dom.XMLDSigRI
+security.provider.11=sun.security.smartcardio.SunPCSC
 
 # Note: JSS and a SunPKCS11-based provider would clash, because it too would
 # initialize NSS. If you see something of the following form in your


### PR DESCRIPTION
The generated `java.security` file did not contain `SunJSSE` provider and OpenJDK 17 requires it explicitly.