### PR TITLE
Fix the compilation error on Sonarclod with maven

### DIFF
--- a/.github/workflows/code-analysis-pull.yml
+++ b/.github/workflows/code-analysis-pull.yml
@@ -92,7 +92,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: >
-          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+          mvn -pl base,examples -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
           -Dsonar.c.file.suffixes= -Dsonar.cpp.file.suffixes=- -Dsonar.objc.file.suffixes=-
           -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
           -Dsonar.pullrequest.key=${{ needs.retrieve-pr.outputs.pr-number }}

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -36,7 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: >
-          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+          mvn -pl base,examples -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
           -Dsonar.c.file.suffixes= -Dsonar.cpp.file.suffixes=- -Dsonar.objc.file.suffixes=-
 
   get-pr-ref:


### PR DESCRIPTION
After the PR #869 maven build does not work if the CMake build is not
execute before. This is due to properly generate the header for the native
code.

Since Sonarcloud is configured with maven build and it does not check c
code for the moment, the native module has been disabled for the code
analysis.