### PR TITLE
Add doctype and missing html tags

### DIFF
--- a/base/src/main/java/org/mozilla/jss/SecretDecoderRing/package.html
+++ b/base/src/main/java/org/mozilla/jss/SecretDecoderRing/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.SecretDecoderRing</title></head>
 <body>
 A facility for encrypting and decrypting small amounts of data with
 a symmetric key. This is most commonly used for encrypting password files

--- a/base/src/main/java/org/mozilla/jss/asn1/package.html
+++ b/base/src/main/java/org/mozilla/jss/asn1/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.asn1</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/crypto/package.html
+++ b/base/src/main/java/org/mozilla/jss/crypto/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.crypto</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/package.html
+++ b/base/src/main/java/org/mozilla/jss/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/pkcs10/package.html
+++ b/base/src/main/java/org/mozilla/jss/pkcs10/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html  lang="en">
+<head><title>org.mozilla.jss.pkcs10</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/pkcs12/package.html
+++ b/base/src/main/java/org/mozilla/jss/pkcs12/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.pkcs12</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/pkcs7/package.html
+++ b/base/src/main/java/org/mozilla/jss/pkcs7/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.pkcs7</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/pkix/cert/package.html
+++ b/base/src/main/java/org/mozilla/jss/pkix/cert/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.pkix.cert</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/pkix/cmc/package.html
+++ b/base/src/main/java/org/mozilla/jss/pkix/cmc/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.pkix.cmc</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/pkix/cmmf/package.html
+++ b/base/src/main/java/org/mozilla/jss/pkix/cmmf/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.pkix.cmmf</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/pkix/cms/package.html
+++ b/base/src/main/java/org/mozilla/jss/pkix/cms/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.pkix.cms</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/pkix/crmf/package.html
+++ b/base/src/main/java/org/mozilla/jss/pkix/crmf/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.pkix.crmf</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/pkix/primitive/package.html
+++ b/base/src/main/java/org/mozilla/jss/pkix/primitive/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.pkix.primitive</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->

--- a/base/src/main/java/org/mozilla/jss/ssl/package.html
+++ b/base/src/main/java/org/mozilla/jss/ssl/package.html
@@ -1,4 +1,6 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head><title>org.mozilla.jss.ssl</title></head>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->


### PR DESCRIPTION
Missing elements identified by Sonarcloud in html files.

Actually, these files are manipulated by javadoc so it should not be needed!