### PR TITLE
Sonarclout project name changes

### DIFF
--- a/.github/workflows/code-analysis-pull.yml
+++ b/.github/workflows/code-analysis-pull.yml
@@ -92,8 +92,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: >
-          mvn -pl base,examples -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
-          -Dsonar.c.file.suffixes= -Dsonar.cpp.file.suffixes=- -Dsonar.objc.file.suffixes=-
+          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=dogtagpki_jss 
           -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
           -Dsonar.pullrequest.key=${{ needs.retrieve-pr.outputs.pr-number }}
           -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -36,8 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: >
-          mvn -pl base,examples -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
-          -Dsonar.c.file.suffixes= -Dsonar.cpp.file.suffixes=- -Dsonar.objc.file.suffixes=-
+          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=dogtagpki_jss 
 
   get-pr-ref:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
 
     <properties>
         <revision>5.3.0-SNAPSHOT</revision>
-        <sonar.projectKey>dogtagpki_jss</sonar.projectKey>
         <sonar.organization>dogtagpki</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
According to sonarcloud documentation the project id should not go
anymore in the pom.xml but it is derived or can be provided in the
command line.

The definition in the pom.xml generate an error