### PR TITLE
Run shellcheck in JSS CI

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -53,3 +53,12 @@ jobs:
         with:
           name: pr
           path: pr/
+
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+


### PR DESCRIPTION
Currently the job fails because of a few warnings, but should be quick to fix in a separate PR.