### PR TITLE
Make the base branch generic

### DIFF
--- a/.github/workflows/code-analysis-pull.yml
+++ b/.github/workflows/code-analysis-pull.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pr-number: ${{ steps.pr-artifact-script.outputs.result }}
+      pr-base: ${{ steps.pr-base-script.outputs.result }}
     steps:
       - name: 'Download PR artifact'
         uses: actions/github-script@v3.1.0
@@ -55,6 +56,17 @@ jobs:
             var pr_number = Number(fs.readFileSync('./NR'));
             return pr_number;
 
+      - name: Retrieve the pr base
+        if: success()
+        id: pr-base-script
+        uses: actions/github-script@v3.1.0
+        with:
+          result-encoding: string
+          script: |
+            var fs = require('fs');
+            var pr_base = fs.readFileSync('./BaseBranch');
+            return pr_base;
+
   build:
     name: Code analysis
     needs: retrieve-pr
@@ -74,9 +86,10 @@ jobs:
 
       - name: Rebase to master
         run: |
-          git remote add jss https://github.com/dogtagpki/jss.git
+          git config user.name "GitHub Workflow Action"
+          git remote add jss ${{ github.event.repository.clone_url }} 
           git fetch jss
-          git rebase jss/master
+          git rebase jss/${{ needs.retrieve-pr.outputs.pr-base }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v1

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -43,10 +43,11 @@ jobs:
     name: Sonar cloud PR fork analyses deferring
     runs-on: ubuntu-latest
     steps:
-      - name: Save PR number
+      - name: Save PR information
         run: |
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
+          echo ${{ github.event.pull_request.base.ref }} > ./pr/BaseBranch
 
       - name: Upload pr as artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
In case of commits to different branches the rebase has to be performed against the base branch of the PR. However, the code analysis execute in a `workflow_run` event and it has no information of the PR base, as in the [docuemtnation](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-example-51).

The available options are:
- to store the base branch during the original PR event and retrieve this information during the workflow run
- to retrieve the base branch using some javascript code interacting with GitHab rest API.

The former is followed here.
Of course, in order to work Sonarcloud in all the branch these have to include the relative workflows but this is required in any case to perform the analysis of them.