### PR TITLE
Fix test failure introduced by efforts to fix shellcheck warnings

### DIFF
--- a/tests/bin/tomcat-start-wait.sh
+++ b/tests/bin/tomcat-start-wait.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 NAME=$1
 URL=$2
 
@@ -8,32 +7,30 @@ then
     echo "Usage: tomcat-start-wait.sh <name> <URL>"
     exit 1
 fi
-
 if [ "$MAX_WAIT" == "" ]
 then
     MAX_WAIT=60 # seconds
 fi
-
 start_time=$(date +%s)
-
 while :
 do
     sleep 1
 
-    if [ ! "$(docker exec "$NAME" curl -IkSs "$URL")" ]
+    docker exec "$NAME" curl -IkSs "$URL"
+
+    if [ $? -eq 0 ]
     then
         break
     fi
 
     current_time=$(date +%s)
-    elapsed_time=$(("$current_time" - "$start_time"))
+    elapsed_time=$(expr "$current_time" - "$start_time")
 
     if [ "$elapsed_time" -ge "$MAX_WAIT" ]
     then
         echo "Tomcat did not start after ${MAX_WAIT}s"
         exit 1
     fi
-
     echo "Waiting for Tomcat to start (${elapsed_time}s)"
 done
 


### PR DESCRIPTION
A partial reversion which preserves the test while still allowing `shellcheck` to not issue warnings. 