### PR TITLE
Workaround for NSS 3.81 issues

### DIFF
--- a/jss.spec
+++ b/jss.spec
@@ -80,8 +80,12 @@ BuildRequires:  zip
 BuildRequires:  unzip
 
 BuildRequires:  gcc-c++
-BuildRequires:  nss-devel >= 3.66
-BuildRequires:  nss-tools >= 3.66
+
+# TODO: Remove version upper bound once the issues with NSS 3.81 are resolved:
+# https://github.com/dogtagpki/jss/issues/882
+BuildRequires:  nss-devel >= 3.66, nss < 3.81
+BuildRequires:  nss-tools >= 3.66, nss < 3.81
+
 BuildRequires:  %{java_devel}
 BuildRequires:  jpackage-utils
 BuildRequires:  slf4j
@@ -101,7 +105,10 @@ This only works with gcj. Other JREs require that JCE providers be signed.
 
 Summary:        Java Security Services (JSS)
 
-Requires:       nss >= 3.66
+# TODO: Remove version upper bound once the issues with NSS 3.81 are resolved:
+# https://github.com/dogtagpki/jss/issues/882
+Requires:       nss >= 3.66, nss < 3.81
+
 Requires:       %{java_headless}
 Requires:       jpackage-utils
 Requires:       slf4j


### PR DESCRIPTION
JSS doesn't seem to be working well with NSS 3.81:
https://github.com/dogtagpki/jss/issues/882

As a temporary workaround the RPM spec has been updated to require an older NSS version. Once the issues are resolved this limitation should be removed.