### PR TITLE
Replace exclusion of i686 with new %{java_arches} macro

### DIFF
--- a/jss.spec
+++ b/jss.spec
@@ -45,8 +45,7 @@ Source:         https://github.com/dogtagpki/jss/archive/v%{version}%{?phase:-}%
 #     > jss-VERSION-RELEASE.patch
 # Patch: jss-VERSION-RELEASE.patch
 
-# Java 17 and md2man are not available on i686
-ExcludeArch: i686
+ExclusiveArch: %{java_arches}
 
 ################################################################################
 # Java


### PR DESCRIPTION
This way we only build on archs that Java builds on.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2104064