### PR TITLE
Fix synchronized overload

### DIFF
--- a/base/src/main/java/org/mozilla/jss/asn1/CountingStream.java
+++ b/base/src/main/java/org/mozilla/jss/asn1/CountingStream.java
@@ -31,7 +31,7 @@ class CountingStream extends InputStream {
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         source.mark(readlimit);
         markpos = count;
         if (DEBUG) {
@@ -81,7 +81,7 @@ class CountingStream extends InputStream {
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         source.reset();
         if (DEBUG) {
             System.out.println("reset from " + count + " to " + markpos);

--- a/base/src/main/java/org/mozilla/jss/ssl/SSLServerSocket.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/SSLServerSocket.java
@@ -188,7 +188,7 @@ public class SSLServerSocket extends java.net.ServerSocket {
      * @param timeout The timeout time in milliseconds.
      */
     @Override
-    public void setSoTimeout(int timeout) {
+    public synchronized void setSoTimeout(int timeout) {
         base.setTimeout(timeout);
     }
 
@@ -198,7 +198,7 @@ public class SSLServerSocket extends java.net.ServerSocket {
      * @return The timeout time in milliseconds.
      */
     @Override
-    public int getSoTimeout() {
+    public synchronized int getSoTimeout() {
         return base.getTimeout();
     }
 


### PR DESCRIPTION
Some extended class overload synchronized methods with not synchronized methods. This in theory could generate error although it is not the case as [discussed here](https://wiki.sei.cmu.edu/confluence/display/java/TSM00-J.+Do+not+override+thread-safe+methods+with+methods+that+are+not+thread-safe).

Actually, some of these methods overload methods of the class `Vector` and it is not clear to me if the synchronized is really required. If it is required then we have to add, otherwise it could be better to replace with  `ArrayList` as suggested in the java documentation.
