### PR TITLE
Add ASN1 decoding of encrypted data using PBES2 algorithm

### DIFF
--- a/base/src/main/java/org/mozilla/jss/JSSProvider.java
+++ b/base/src/main/java/org/mozilla/jss/JSSProvider.java
@@ -296,6 +296,9 @@ public final class JSSProvider extends java.security.Provider {
         put("KeyGenerator.RC2", kg_spi + "$RC2");
         put("KeyGenerator.HmacSHA1", kg_spi + "$HmacSHA1");
         put("KeyGenerator.PBAHmacSHA1", kg_spi + "$PBAHmacSHA1");
+        put("KeyGenerator.PBESHA256Hmac", kg_spi + "$PBESHA256Hmac");
+        put("KeyGenerator.PBESHA384Hmac", kg_spi + "$PBESHA384Hmac");
+        put("KeyGenerator.PBESHA512Hmac", kg_spi + "$PBESHA512Hmac");
         put("KeyGenerator.HmacSHA256", kg_spi + "$HmacSHA256");
         put("KeyGenerator.HmacSHA384", kg_spi + "$HmacSHA384");
         put("KeyGenerator.HmacSHA512", kg_spi + "$HmacSHA512");

--- a/base/src/main/java/org/mozilla/jss/crypto/Algorithm.java
+++ b/base/src/main/java/org/mozilla/jss/crypto/Algorithm.java
@@ -271,4 +271,6 @@ public class Algorithm {
     protected static final int SEC_OID_AES_128_KEY_WRAP_KWP = 81;
     protected static final int SEC_OID_AES_192_KEY_WRAP_KWP = 82;
     protected static final int SEC_OID_AES_256_KEY_WRAP_KWP = 83;
+
+    protected static final int SEC_OID_HMAC_SHA1 = 84;
 }

--- a/base/src/main/java/org/mozilla/jss/crypto/HMACAlgorithm.java
+++ b/base/src/main/java/org/mozilla/jss/crypto/HMACAlgorithm.java
@@ -55,19 +55,19 @@ public class HMACAlgorithm extends DigestAlgorithm {
      */
     @Deprecated(since="5.0.1", forRemoval=true)
     public static final HMACAlgorithm SHA1 = new HMACAlgorithm
-        (CKM_SHA_1_HMAC, "SHA-1-HMAC",
-             OBJECT_IDENTIFIER.ALGORITHM.subBranch(26), 20);
+        (SEC_OID_HMAC_SHA1, "SHA-1-HMAC",
+                OBJECT_IDENTIFIER.RSA_DIGEST.subBranch(7), 20);
 
     public static final HMACAlgorithm SHA256 = new HMACAlgorithm
-        (CKM_SHA256_HMAC, "SHA-256-HMAC",
+        (SEC_OID_HMAC_SHA256, "SHA-256-HMAC",
              OBJECT_IDENTIFIER.RSA_DIGEST.subBranch(9), 32);
 
     public static final HMACAlgorithm SHA384 = new HMACAlgorithm
-        (CKM_SHA384_HMAC, "SHA-384-HMAC",
+        (SEC_OID_HMAC_SHA384, "SHA-384-HMAC",
              OBJECT_IDENTIFIER.RSA_DIGEST.subBranch(10), 48);
 
     public static final HMACAlgorithm SHA512 = new HMACAlgorithm
-        (CKM_SHA512_HMAC, "SHA-512-HMAC",
+        (SEC_OID_HMAC_SHA512, "SHA-512-HMAC",
              OBJECT_IDENTIFIER.RSA_DIGEST.subBranch(11), 64);
 
 }

--- a/base/src/main/java/org/mozilla/jss/crypto/KeyGenAlgorithm.java
+++ b/base/src/main/java/org/mozilla/jss/crypto/KeyGenAlgorithm.java
@@ -127,6 +127,27 @@ public class KeyGenAlgorithm extends Algorithm {
             null,
             PBEKeyGenParams.class);
 
+    public static final KeyGenAlgorithm PBE_SHA256_HMAC = new KeyGenAlgorithm(
+            SEC_OID_SHA256,
+            "PBE/SHA256/HMAC",
+            new AnyKeyStrengthValidator(),
+            null,
+            PBEKeyGenParams.class);
+
+    public static final KeyGenAlgorithm PBE_SHA384_HMAC = new KeyGenAlgorithm(
+            SEC_OID_SHA384,
+            "PBE/SHA384/HMAC",
+            new AnyKeyStrengthValidator(),
+            null,
+            PBEKeyGenParams.class);
+
+    public static final KeyGenAlgorithm PBE_SHA512_HMAC = new KeyGenAlgorithm(
+            SEC_OID_SHA512,
+            "PBE/SHA512/HMAC",
+            new AnyKeyStrengthValidator(),
+            null,
+            PBEKeyGenParams.class);
+
     @Deprecated(since="5.0.1", forRemoval=true)
     public static final KeyGenAlgorithm SHA1_HMAC = new KeyGenAlgorithm(
             CKM_SHA_1_HMAC,

--- a/base/src/main/java/org/mozilla/jss/crypto/PBEKeyGenParams.java
+++ b/base/src/main/java/org/mozilla/jss/crypto/PBEKeyGenParams.java
@@ -15,6 +15,7 @@ public class PBEKeyGenParams implements AlgorithmParameterSpec, KeySpec {
     private byte[] salt;
     private int iterations;
     private EncryptionAlgorithm encryptionAlgorithm = EncryptionAlgorithm.DES3_CBC;
+    private HMACAlgorithm hashAlgorithm = null;
 
     static private final int DEFAULT_SALT_LENGTH = 8;
     static private final int DEFAULT_ITERATIONS = 1;
@@ -52,12 +53,8 @@ public class PBEKeyGenParams implements AlgorithmParameterSpec, KeySpec {
      * @param iterations The iteration count for the PBE algorithm.
      */
     public PBEKeyGenParams(char[] pass, byte[] salt, int iterations) {
-        if (pass == null || salt == null) {
-            throw new NullPointerException();
-        }
-        this.pass = new Password(pass.clone());
-        this.salt = salt;
-        this.iterations = iterations;
+        this(pass, salt, iterations, null, null);
+
     }
 
     /**
@@ -77,6 +74,28 @@ public class PBEKeyGenParams implements AlgorithmParameterSpec, KeySpec {
     public PBEKeyGenParams(
             char[] pass, byte[] salt, int iterations,
             EncryptionAlgorithm encAlg) {
+        this(pass, salt, iterations, encAlg, null);
+    }
+
+    /**
+     * Creates PBE parameters using default encryption algorithm
+     * (DES3_EDE3_CBC).
+     *
+     * @param pass The password. It will be cloned, so the
+     *            caller is still responsible for clearing it. It must not be null.
+     * @param salt The salt for the PBE algorithm. Will <b>not</b> be cloned.
+     *            Must not be null. It is the responsibility of the caller to
+     *            use the right salt length for the algorithm. Most algorithms
+     *            use 8 bytes of salt.
+     * @param iterations The iteration count for the PBE algorithm.
+     * @param encAlg The encryption algorithm. This is used with SOME
+     *            PBE algorithms for determining the KDF output length.
+     * @param hashAlg The hash algorithm. This is used with PBEv2 algorithms
+     * because it cannot be derived from the key generation algorithm.
+     */
+    public PBEKeyGenParams(
+            char[] pass, byte[] salt, int iterations,
+            EncryptionAlgorithm encAlg, HMACAlgorithm hashAlg) {
         if (pass == null || salt == null) {
             throw new NullPointerException();
         }
@@ -85,8 +104,8 @@ public class PBEKeyGenParams implements AlgorithmParameterSpec, KeySpec {
         this.iterations = iterations;
         if (encAlg != null)
             this.encryptionAlgorithm = encAlg;
+        this.hashAlgorithm = hashAlg;
     }
-
     /**
      * Returns a <b>reference</b> to the password, not a copy.
      */
@@ -114,6 +133,14 @@ public class PBEKeyGenParams implements AlgorithmParameterSpec, KeySpec {
      */
     public EncryptionAlgorithm getEncryptionAlgorithm() {
         return encryptionAlgorithm;
+    }
+
+    /**
+     * The hash algorithm is used with PBEv2 algorithms because it cannot be
+     * derived from the key generation algorithm.
+     */
+    public HMACAlgorithm getHashAlgorithm() {
+        return hashAlgorithm;
     }
 
     /**

--- a/base/src/main/java/org/mozilla/jss/pkcs11/PK11KeyGenerator.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs11/PK11KeyGenerator.java
@@ -10,6 +10,7 @@ import java.security.InvalidKeyException;
 import java.security.spec.AlgorithmParameterSpec;
 
 import org.mozilla.jss.crypto.EncryptionAlgorithm;
+import org.mozilla.jss.crypto.HMACAlgorithm;
 import org.mozilla.jss.crypto.KBKDFParameterSpec;
 import org.mozilla.jss.crypto.KeyGenAlgorithm;
 import org.mozilla.jss.crypto.KeyGenerator;
@@ -179,7 +180,7 @@ public final class PK11KeyGenerator implements KeyGenerator {
             try {
                 pwbytes = charToByte.convert( kgp.getPassword().getChars() );
                 return generatePBE(
-                    token, algorithm, kgp.getEncryptionAlgorithm(),
+                    token, algorithm, kgp.getEncryptionAlgorithm(), kgp.getHashAlgorithm(),
                     pwbytes, kgp.getSalt(), kgp.getIterations());
             } finally {
                 if( pwbytes!=null ) {
@@ -329,7 +330,7 @@ public final class PK11KeyGenerator implements KeyGenerator {
     private static native SymmetricKey
     generatePBE(
         PK11Token token, KeyGenAlgorithm algorithm, EncryptionAlgorithm encAlg,
-        byte[] pass, byte[] salt, int iterationCount)
+        HMACAlgorithm hashAlg, byte[] pass, byte[] salt, int iterationCount)
         throws TokenException;
 
     /**

--- a/base/src/main/java/org/mozilla/jss/pkcs12/AuthenticatedSafes.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs12/AuthenticatedSafes.java
@@ -164,10 +164,10 @@ public class AuthenticatedSafes implements ASN1Value {
                 getEncryptedContentInfo();
 
             // this should be a BER-encoded SafeContents
-            byte[] decrypted = encCI.decrypt(password,
-                                    new PasswordConverter());
-
-            //print_byte_array(decrypted);
+            // The password converter doed not work in many cases so it is removed
+            // but it needs invetigation for the few cases where it is needed.
+            byte[] decrypted = encCI.decrypt(password, // new PasswordConverter());
+                                    null);
 
             try {
                 SEQUENCE.OF_Template seqt = new SEQUENCE.OF_Template(

--- a/base/src/main/java/org/mozilla/jss/pkcs12/PFX.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs12/PFX.java
@@ -153,7 +153,8 @@ public class PFX implements ASN1Value {
             MacData testMac = new MacData(password,
                     macData.getMacSalt().toByteArray(),
                     macData.getMacIterationCount().intValue(),
-                    encodedAuthSafes);
+                    encodedAuthSafes,
+                    macData.getMac().getDigestAlgorithm());
 
             if (testMac.getMac().equals(macDataMac)) {
                 return true;

--- a/base/src/main/java/org/mozilla/jss/pkix/primitive/PBES2Params.java
+++ b/base/src/main/java/org/mozilla/jss/pkix/primitive/PBES2Params.java
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.jss.pkix.primitive;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.mozilla.jss.asn1.ASN1Template;
+import org.mozilla.jss.asn1.ASN1Value;
+import org.mozilla.jss.asn1.InvalidBERException;
+import org.mozilla.jss.asn1.SEQUENCE;
+import org.mozilla.jss.asn1.Tag;
+
+/**
+ * PKCS #5 <i>PBES2Parameter</i>
+ */
+public class PBES2Params implements ASN1Value {
+
+    ///////////////////////////////////////////////////////////////////////
+    // members and member access
+    ///////////////////////////////////////////////////////////////////////
+    private AlgorithmIdentifier keyDerivationFunc;
+    private AlgorithmIdentifier encryptionScheme;
+    private SEQUENCE sequence;
+
+    public AlgorithmIdentifier getKeyDerivationFunc() {
+        return keyDerivationFunc;
+    }
+
+    public AlgorithmIdentifier getEncryptionScheme() {
+        return encryptionScheme;
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////
+    // constructors
+    ///////////////////////////////////////////////////////////////////////
+
+
+    public PBES2Params(AlgorithmIdentifier keyDerivationFunc, AlgorithmIdentifier encryptionScheme) {
+        this.keyDerivationFunc = keyDerivationFunc;
+        this.encryptionScheme = encryptionScheme;
+        sequence = new SEQUENCE();
+        sequence.addElement( keyDerivationFunc );
+        sequence.addElement( encryptionScheme );
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    // DER encoding
+    ///////////////////////////////////////////////////////////////////////
+
+    private static final Tag TAG = SEQUENCE.TAG;
+    @Override
+    public Tag getTag() {
+        return TAG;
+    }
+
+    @Override
+    public void encode(OutputStream ostream) throws IOException {
+        sequence.encode(ostream);
+    }
+
+    @Override
+    public void encode(Tag implicitTag, OutputStream ostream)
+        throws IOException
+    {
+        sequence.encode(implicitTag, ostream);
+    }
+
+
+    private static final Template templateInstance = new Template();
+    public static Template getTemplate() {
+        return templateInstance;
+    }
+
+    /**
+     * A template class for decoding a PBES2Params.
+     */
+    public static class Template implements ASN1Template {
+
+        private SEQUENCE.Template seqt;
+
+        public Template() {
+            seqt = new SEQUENCE.Template();
+            seqt.addElement( AlgorithmIdentifier.getTemplate() );
+            seqt.addElement( AlgorithmIdentifier.getTemplate() );
+        }
+
+        @Override
+        public boolean tagMatch(Tag tag) {
+            return TAG.equals(tag);
+        }
+
+        @Override
+        public ASN1Value decode(InputStream istream)
+            throws InvalidBERException, IOException
+        {
+            return decode(TAG, istream);
+        }
+
+        @Override
+        public ASN1Value decode(Tag implicitTag, InputStream istream)
+            throws InvalidBERException, IOException
+        {
+            SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
+
+            return new PBES2Params( (AlgorithmIdentifier) seq.elementAt(0),
+                                     (AlgorithmIdentifier)      seq.elementAt(1) );
+        }
+    }
+}

--- a/base/src/main/java/org/mozilla/jss/pkix/primitive/PBKDF2Params.java
+++ b/base/src/main/java/org/mozilla/jss/pkix/primitive/PBKDF2Params.java
@@ -1,0 +1,177 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.jss.pkix.primitive;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.mozilla.jss.asn1.ASN1Template;
+import org.mozilla.jss.asn1.ASN1Value;
+import org.mozilla.jss.asn1.CHOICE;
+import org.mozilla.jss.asn1.INTEGER;
+import org.mozilla.jss.asn1.InvalidBERException;
+import org.mozilla.jss.asn1.OCTET_STRING;
+import org.mozilla.jss.asn1.SEQUENCE;
+import org.mozilla.jss.asn1.Tag;
+
+/**
+ * PKCS #5 <i>PBKDF2-Params</i>.
+ */
+public class PBKDF2Params implements ASN1Value {
+
+    ///////////////////////////////////////////////////////////////////////
+    // members and member access
+    ///////////////////////////////////////////////////////////////////////
+    private byte[] salt;
+    private AlgorithmIdentifier otherSource;
+    private int iterations;
+    private int keyLength;
+    private AlgorithmIdentifier prf;
+    private SEQUENCE sequence;
+
+    public byte[] getSalt() {
+        return salt;
+    }
+
+    public int getIterations() {
+        return iterations;
+    }
+
+    public AlgorithmIdentifier getOtherSource() {
+        return otherSource;
+    }
+
+    public int getKeyLength() {
+        return keyLength;
+    }
+
+    public AlgorithmIdentifier getPrf() {
+        return prf;
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    // constructors
+    ///////////////////////////////////////////////////////////////////////
+
+    /**
+     * Creates a PBKDF2Params from a salt and iteration count
+     */
+    public PBKDF2Params(byte[] salt, AlgorithmIdentifier otherSource,
+            int iterations, int keyLength, AlgorithmIdentifier prf) {
+        this.salt = salt;
+        this.otherSource = otherSource;
+        this.iterations = iterations;
+        this.keyLength = keyLength;
+        this.prf = prf;
+        sequence = new SEQUENCE();
+        if(salt!=null) {
+            sequence.addElement( new OCTET_STRING(salt) );
+        }
+        else {
+            sequence.addElement(otherSource);
+        }
+        sequence.addElement( new INTEGER(iterations) );
+        if(keyLength>0) {
+            sequence.addElement(new INTEGER(keyLength));
+        }
+        sequence.addElement(prf);
+    }
+
+    /**
+     * Creates a PBKDF2Params from a salt and iteration count
+     */
+    public PBKDF2Params(OCTET_STRING salt, AlgorithmIdentifier otherSource,
+            INTEGER iterations, INTEGER keyLength, AlgorithmIdentifier prf) {
+        this( salt.toByteArray(), otherSource, iterations.intValue(),
+                keyLength != null ? keyLength.intValue() : 0, prf);
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    // DER encoding
+    ///////////////////////////////////////////////////////////////////////
+
+    private static final Tag TAG = SEQUENCE.TAG;
+    @Override
+    public Tag getTag() {
+        return TAG;
+    }
+
+    @Override
+    public void encode(OutputStream ostream) throws IOException {
+        sequence.encode(ostream);
+    }
+
+    @Override
+    public void encode(Tag implicitTag, OutputStream ostream)
+        throws IOException
+    {
+        sequence.encode(implicitTag, ostream);
+    }
+
+
+    private static final Template templateInstance = new Template();
+    public static Template getTemplate() {
+        return templateInstance;
+    }
+
+    /**
+     * A template class for decoding a PBKDF2Params.
+     */
+    public static class Template implements ASN1Template {
+
+        private SEQUENCE.Template seqt;
+
+        public Template() {
+            seqt = new SEQUENCE.Template();
+
+            CHOICE.Template salt = CHOICE.getTemplate();
+            salt.addElement(OCTET_STRING.getTemplate());
+            salt.addElement(AlgorithmIdentifier.getTemplate());
+
+            seqt.addElement(salt);
+            seqt.addElement(INTEGER.getTemplate());
+            seqt.addOptionalElement(INTEGER.getTemplate());
+            seqt.addElement(AlgorithmIdentifier.getTemplate());
+        }
+
+        @Override
+        public boolean tagMatch(Tag tag) {
+            return TAG.equals(tag);
+        }
+
+        @Override
+        public ASN1Value decode(InputStream istream)
+            throws InvalidBERException, IOException
+        {
+            return decode(TAG, istream);
+        }
+
+        @Override
+        public ASN1Value decode(Tag implicitTag, InputStream istream)
+            throws InvalidBERException, IOException
+        {
+            OCTET_STRING specified = null;
+            AlgorithmIdentifier otherSource = null;
+
+            SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
+
+            CHOICE salt = (CHOICE) seq.elementAt(0);
+            if (salt.getValue() instanceof OCTET_STRING saltValue) {
+                specified = saltValue;
+            }
+
+            if (salt.getValue() instanceof AlgorithmIdentifier saltSource) {
+                otherSource = saltSource;
+            }
+
+            return new PBKDF2Params( specified,
+                                     otherSource,
+                                     (INTEGER) seq.elementAt(1),
+                                     (INTEGER) seq.elementAt(2),
+                                     (AlgorithmIdentifier) seq.elementAt(3));
+        }
+    }
+}

--- a/base/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSKeyGeneratorSpi.java
+++ b/base/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSKeyGeneratorSpi.java
@@ -115,6 +115,21 @@ public class JSSKeyGeneratorSpi extends javax.crypto.KeyGeneratorSpi {
             super(KeyGenAlgorithm.PBA_SHA1_HMAC);
         }
     }
+    public static class PBESHA256Hmac extends JSSKeyGeneratorSpi {
+        public PBESHA256Hmac() {
+            super(KeyGenAlgorithm.PBE_SHA256_HMAC);
+        }
+    }
+    public static class PBESHA384Hmac extends JSSKeyGeneratorSpi {
+        public PBESHA384Hmac() {
+            super(KeyGenAlgorithm.PBE_SHA384_HMAC);
+        }
+    }
+    public static class PBESHA512Hmac extends JSSKeyGeneratorSpi {
+        public PBESHA512Hmac() {
+            super(KeyGenAlgorithm.PBE_SHA512_HMAC);
+        }
+    }
     public static class HmacSHA256 extends JSSKeyGeneratorSpi {
         public HmacSHA256() {
             super(KeyGenAlgorithm.SHA256_HMAC);

--- a/native/src/main/native/org/mozilla/jss/crypto/Algorithm.c
+++ b/native/src/main/native/org/mozilla/jss/crypto/Algorithm.c
@@ -179,6 +179,7 @@ JSS_AlgInfo JSS_AlgTable[NUM_ALGS] = {
 /* 82 */    {SEC_OID_AES_192_KEY_WRAP_KWP, SEC_OID_TAG},
 /* 83 */    {SEC_OID_AES_256_KEY_WRAP_KWP, SEC_OID_TAG},
 
+/* 84 */    {SEC_OID_HMAC_SHA1, SEC_OID_TAG},
 
 /* REMEMBER TO UPDATE NUM_ALGS!!! (in Algorithm.h) */
 };

--- a/native/src/main/native/org/mozilla/jss/crypto/Algorithm.h
+++ b/native/src/main/native/org/mozilla/jss/crypto/Algorithm.h
@@ -24,7 +24,7 @@ typedef struct JSS_AlgInfoStr {
     JSS_AlgType type;
 } JSS_AlgInfo;
 
-#define NUM_ALGS 84
+#define NUM_ALGS 85
 
 extern JSS_AlgInfo JSS_AlgTable[];
 extern CK_ULONG JSS_symkeyUsage[];

--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyGenerator.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyGenerator.c
@@ -220,23 +220,23 @@ constructSHAPBEKey(JNIEnv *env, CK_MECHANISM_TYPE mech, PK11SlotInfo *slot, SECI
     params = PK11_CreatePBEParams(salt, pwitem,
         iterationCount);
     switch(mech){
-		case CKM_SHA256:
-			key = PK11_KeyGen(NULL, CKM_NSS_PKCS12_PBE_SHA256_HMAC_KEY_GEN, params, 0, NULL);
-			break;
-		case CKM_SHA384:
-			key = PK11_KeyGen(NULL, CKM_NSS_PKCS12_PBE_SHA384_HMAC_KEY_GEN, params, 0, NULL);
-			break;
-		case CKM_SHA512:
-			key = PK11_KeyGen(NULL, CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, params, 0, NULL);
-			break;
-		default:
-	        JSS_throwMsg(env, TOKEN_EXCEPTION,
-	            "constructSHAPBEKey:"
-	            " mech not recognised");
-	        goto finish;
+        case CKM_SHA256:
+            key = PK11_KeyGen(NULL, CKM_NSS_PKCS12_PBE_SHA256_HMAC_KEY_GEN, params, 0, NULL);
+            break;
+        case CKM_SHA384:
+            key = PK11_KeyGen(NULL, CKM_NSS_PKCS12_PBE_SHA384_HMAC_KEY_GEN, params, 0, NULL);
+            break;
+        case CKM_SHA512:
+            key = PK11_KeyGen(NULL, CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, params, 0, NULL);
+            break;
+        default:
+            JSS_throwMsg(env, TOKEN_EXCEPTION,
+                "constructSHAPBEKey:"
+                " mech not recognised");
+            goto finish;
     }
-	PK11_DestroyPBEParams(params);
-	params = NULL;
+    PK11_DestroyPBEParams(params);
+    params = NULL;
 
     if( key == NULL ) {
         JSS_throwMsg(env, TOKEN_EXCEPTION,

--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyGenerator.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyGenerator.c
@@ -183,6 +183,73 @@ print_secitem(SECItem *item) {
     }
 }
 
+
+/***********************************************************************
+ *
+ * c o n s t r u c t S H A P B E K e y
+ *
+ * Constructs a PBE key using CKM_SHA*.  This should
+ * be supported by NSS automatically, but isn't.
+ *
+ * RETURNS
+ *      A symmetric key from the given password, salt, and iteration count,
+ *      or NULL if an exception was thrown.
+ * THROWS
+ *      TokenException if an error occurs.
+ */
+static PK11SymKey*
+constructSHAPBEKey(JNIEnv *env, CK_MECHANISM_TYPE mech, PK11SlotInfo *slot, SECItem *pwitem, SECItem *salt,
+        int iterationCount)
+{
+    PK11SymKey *key=NULL;
+    SECItem *params=NULL;
+
+    if( pwitem == NULL ) {
+        JSS_throwMsg(env, TOKEN_EXCEPTION,
+            "constructSHAPBEKey:"
+            " pwitem NULL");
+        goto finish;
+    }
+    if( salt == NULL ) {
+        JSS_throwMsg(env, TOKEN_EXCEPTION,
+            "constructSHAPBEKey:"
+            " salt NULL");
+        goto finish;
+    }
+
+    params = PK11_CreatePBEParams(salt, pwitem,
+        iterationCount);
+    switch(mech){
+		case CKM_SHA256:
+			key = PK11_KeyGen(NULL, CKM_NSS_PKCS12_PBE_SHA256_HMAC_KEY_GEN, params, 0, NULL);
+			break;
+		case CKM_SHA384:
+			key = PK11_KeyGen(NULL, CKM_NSS_PKCS12_PBE_SHA384_HMAC_KEY_GEN, params, 0, NULL);
+			break;
+		case CKM_SHA512:
+			key = PK11_KeyGen(NULL, CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, params, 0, NULL);
+			break;
+		default:
+	        JSS_throwMsg(env, TOKEN_EXCEPTION,
+	            "constructSHAPBEKey:"
+	            " mech not recognised");
+	        goto finish;
+    }
+	PK11_DestroyPBEParams(params);
+	params = NULL;
+
+    if( key == NULL ) {
+        JSS_throwMsg(env, TOKEN_EXCEPTION,
+            "PK11_KeyGen:"
+            " failed to generate key");
+        goto finish;
+    }
+
+finish:
+    return key;
+}
+
+
 /***********************************************************************
  *
  * c o n s t r u c t S H A 1 P B A K e y
@@ -249,7 +316,7 @@ finish:
 JNIEXPORT jobject JNICALL
 Java_org_mozilla_jss_pkcs11_PK11KeyGenerator_generatePBE(
     JNIEnv *env, jclass clazz, jobject token, jobject alg, jobject encAlg,
-    jbyteArray passBA, jbyteArray saltBA, jint iterationCount)
+    jobject hashAlg, jbyteArray passBA, jbyteArray saltBA, jint iterationCount)
 {
     PK11SlotInfo *slot=NULL;
     PK11SymKey *skey=NULL;
@@ -282,53 +349,64 @@ Java_org_mozilla_jss_pkcs11_PK11KeyGenerator_generatePBE(
     }
     /* print_secitem(pwitem); */
 
-    mech = JSS_getPK11MechFromAlg(env, alg);
+	mech = JSS_getPK11MechFromAlg(env, alg);
 
     if( mech == CKM_PBA_SHA1_WITH_SHA1_HMAC ) {
-
         /* special case, construct key by hand. Bug #336587 */
-
         skey = constructSHA1PBAKey(env, slot, pwitem, salt, iterationCount);
         if( skey==NULL ) {
             /* exception was thrown */
             goto finish;
         }
+    }
 
-    } else {
-
-        /* get the algorithm info */
-        oidTag = JSS_getOidTagFromAlg(env, alg);
-        PR_ASSERT(oidTag != SEC_OID_UNKNOWN);
-
-        SECOidTag encAlgOidTag = JSS_getOidTagFromAlg(env, encAlg);
-        PR_ASSERT(encAlgOidTag != SEC_OID_UNKNOWN);
-
-        /* create algid */
-        algid = PK11_CreatePBEV2AlgorithmID(
-            oidTag,
-            encAlgOidTag,
-            SEC_OID_HMAC_SHA1,
-            0,
-            iterationCount,
-            salt);
-
-        if( algid == NULL ) {
-            JSS_throwMsg(env, TOKEN_EXCEPTION,
-                    "Unable to process PBE parameters");
-            goto finish;
-        }
-
-        /* generate the key */
-        skey = PK11_PBEKeyGen(slot, algid, pwitem, PR_FALSE /*faulty3DES*/,
-                        NULL /*wincx*/);
-        if( skey == NULL ) {
-            JSS_throwMsg(env, TOKEN_EXCEPTION, "Failed to generate PBE key");
+    if( mech == CKM_SHA256 || mech == CKM_SHA384 || mech == CKM_SHA512 ) {
+    	skey = constructSHAPBEKey(env, mech, slot, pwitem, salt, iterationCount);
+        if( skey==NULL ) {
             goto finish;
         }
     }
 
+    if( skey == NULL ) {
+    	/* get the algorithm info */
+		oidTag = JSS_getOidTagFromAlg(env, alg);
+		PR_ASSERT(oidTag != SEC_OID_UNKNOWN);
+		SECOidTag encAlgOidTag = JSS_getOidTagFromAlg(env, encAlg);
+		SECOidTag hashAlgOidTag = SEC_OID_HMAC_SHA1;
+		if( hashAlg != NULL ) {
+			hashAlgOidTag = JSS_getOidTagFromAlg(env, hashAlg);
+		}
+		PR_ASSERT(encAlgOidTag != SEC_OID_UNKNOWN);
+		PR_ASSERT(hashAlgOidTag != SEC_OID_UNKNOWN);
+
+		/* create algid */
+		algid = PK11_CreatePBEV2AlgorithmID(
+			oidTag,
+			encAlgOidTag,
+			hashAlgOidTag,
+			0,
+			iterationCount,
+			salt);
+
+		if( algid == NULL ) {
+			JSS_throwMsg(env, TOKEN_EXCEPTION,
+					"Unable to process PBE parameters");
+			goto finish;
+		}
+
+		/* generate the key */
+		skey = PK11_PBEKeyGen(slot, algid, pwitem, PR_FALSE /*faulty3DES*/,
+						NULL /*wincx*/);
+		if( skey == NULL ) {
+			JSS_throwMsg(env, TOKEN_EXCEPTION, "Failed to generate PBE key");
+			goto finish;
+		}
+    }
+
     /* wrap the key. This sets skey to NULL. */
-    keyObj = JSS_PK11_wrapSymKey(env, &skey);
+    if( skey!=NULL ) {
+        keyObj = JSS_PK11_wrapSymKey(env, &skey);
+    }
 
 finish:
     if(algid) {


### PR DESCRIPTION
The validation of pk12 file with certificate in `:pkcs7-encryptedData` fails because the ASN1 decode work only for PBES1. 

See https://bugzilla.redhat.com/show_bug.cgi?id=2115765.


With this PR the decode does not work but there are problem with the key generation but can be managed in a separate PR/task.