### PR TITLE
Fix Bug 2100807 - pki-tomcat/kra unable to decrypt when using RSA-OAE…

### DIFF
--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -401,21 +401,9 @@ macro(jss_config_symbols)
         message(WARNING "Your NSS version doesn't support NIST SP800-108 KBKDF; some features of JSS won't work.")
     endif()
 
-    try_compile(CK_HAVE_COMPILING_OAEP
-                ${CMAKE_BINARY_DIR}/results
-                ${CMAKE_SOURCE_DIR}/tools/tests/oaep.c
-                CMAKE_FLAGS
-                    "-DINCLUDE_DIRECTORIES=${CMAKE_REQUIRED_INCLUDES}"
-                    "-DREQUIRED_FLAGS=${CMAKE_REQUIRED_FLAGS}"
-                LINK_OPTIONS ${JSS_LD_FLAGS}
-                OUTPUT_VARIABLE COMP_OUT)
-    if (CK_HAVE_COMPILING_OAEP)
-        set(HAVE_NSS_OAEP TRUE)
-    else()
-        message(WARNING "Your NSS version doesn't support RSA-OAEP key wra/unwrap; some features of JSS won't work.")
-        message(WARNING "Compile output: ${COMP_OUT}")
-    endif()
-
+    # Assume OAEP support and set the define required.
+    set(HAVE_NSS_OAEP TRUE)
+    message(WARNING "Assuming OAEP support.")
 
     if(HAVE_NSS_CMAC)
         try_run(CK_HAVE_WORKING_CMAC


### PR DESCRIPTION
…P padding in RHEL9 with FIPS enabled.

Remove the cmake test for OAEP since we can assume from this point forward nss has OAEP support.
The compile test was failing in a false negative fashion and it was determined to be more efficient to
simply remove the test completely instead of fixing it.