### PR TITLE
Use ExcludeArch on older platforms

### DIFF
--- a/jss.spec
+++ b/jss.spec
@@ -45,7 +45,11 @@ Source:         https://github.com/dogtagpki/jss/archive/v%{version}%{?phase:-}%
 #     > jss-VERSION-RELEASE.patch
 # Patch: jss-VERSION-RELEASE.patch
 
+%if 0%{?fedora} && 0%{?fedora} > 35
 ExclusiveArch: %{java_arches}
+%else
+ExcludeArch: i686
+%endif
 
 ################################################################################
 # Java


### PR DESCRIPTION
`java_arches` macro is only available on newer platforms, so the spec file has been modified to use `ExcludeArch` on older platforms.

This will fix COPR builds on older Fedora versions and RHEL.