### PR TITLE
Allow other build tests to continue if one fails

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -6,6 +6,7 @@ jobs:
   build-test:
     name: Build Test
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         os:


### PR DESCRIPTION
Currently if a build job fails on e.g. Fedora, the Ubuntu job will cancel. This makes it hard to see whether the other jobs are afflicted with a similar issue, so add continue-on-error so all jobs run to completion.