### PR TITLE
Fix RPM build warnings due to absolute links

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ install(
 
 install(
     CODE "execute_process(
-        COMMAND ln -sf ${JNI_DIR}/jss.jar \$ENV{DESTDIR}${LIB_DIR}/jss/jss.jar
+        COMMAND ln -sf ../../../${JNI_DIR}/jss.jar \$ENV{DESTDIR}${LIB_DIR}/jss/jss.jar
     )"
 )
 

--- a/symkey/CMakeLists.txt
+++ b/symkey/CMakeLists.txt
@@ -96,6 +96,6 @@ install(
 
 install(
     CODE "execute_process(
-        COMMAND ln -sf ${JNI_DIR}/jss-symkey.jar \$ENV{DESTDIR}${LIB_DIR}/jss/jss-symkey.jar
+        COMMAND ln -sf ../../../${JNI_DIR}/jss-symkey.jar \$ENV{DESTDIR}${LIB_DIR}/jss/jss-symkey.jar
     )"
 )


### PR DESCRIPTION
```
RPM build warnings:
    absolute symlink: /usr/lib64/jss/jss-symkey.jar -> /usr/lib/java/jss-symkey.jar
    absolute symlink: /usr/lib64/jss/jss.jar -> /usr/lib/java/jss.jar
```