### PR TITLE
Fix Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,9 +2,10 @@
 # https://github.com/Microsoft/azure-pipelines-agent/issues/2043#issuecomment-687983301
 resources:
   containers:
-  - container: fedora_latest
-    image: fedora:latest
-    options: '--name runner -v /usr/bin/docker:/usr/bin/docker:ro'
+  # This no longer works for Fedora
+  # - container: fedora_latest
+  #   image: fedora:latest
+  #   options: '--name runner -v /usr/bin/docker:/usr/bin/docker:ro'
   - container: debian_testing
     image: debian:testing
     options: '--name runner -v /usr/bin/docker:/usr/bin/docker:ro'
@@ -13,46 +14,72 @@ resources:
     options: '--name runner -v /usr/bin/docker:/usr/bin/docker:ro'
 
 jobs:
-- job: BuildTest
+- job: BuildTest_dnf
   pool:
     vmImage: ubuntu-latest
   strategy:
     matrix:
       fedora_latest:
-        image: fedora_latest
-      debian_testing:
-        image: debian_testing
-      ubuntu_rolling:
-        image: ubuntu_rolling
+        image: registry.fedoraproject.org/fedora:latest
       # Disable CentOS due to missing dependencies
       # centos_7:
       #   image: centos:7
       # centos_8:
       #   image: centos:8
-  container: $[variables['image']]
   steps:
   - script: |
-      docker exec -u 0 runner dnf install -y dnf-plugins-core rpm-build
-      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner dnf builddep -y --spec jss.spec
-    condition: or(startsWith(variables.image, 'fedora_'), startsWith(variables.image, 'centos_'))
-    displayName: Install Fedora/CentOS dependencies
+      docker build \
+          --build-arg BASE_IMAGE=$(image) \
+          --target jss-base \
+          --tag jss-base:latest \
+          .
 
+      docker run \
+          --name runner \
+          --privileged \
+          --detach \
+          jss-base:latest
+
+      while :
+      do
+          docker exec runner echo "Runner is ready" && break
+          echo "Waiting for runner..."
+          sleep 1
+          [ $((++i)) -ge 10 ] && exit 1
+      done
+    displayName: Create runner container
+
+  - script: |
+      docker exec runner dnf install -y dnf-plugins-core rpm-build
+      docker exec runner dnf copr enable -y @pki/master
+      docker cp . runner:/root/src
+      docker exec -w /root/src runner dnf builddep -y --spec jss.spec
+    displayName: Install build dependencies
+
+  - script: docker exec -w /root/src runner ./build.sh --with-tests
+    displayName: Build JSS binaries, Javadoc, and run tests
+
+- job: BuildTest_apt
+  pool:
+    vmImage: ubuntu-latest
+  strategy:
+    matrix:
+      debian_testing:
+        image: debian_testing
+      ubuntu_rolling:
+        image: ubuntu_rolling
+  container: $[variables['image']]
+  steps:
   - script: |
       docker exec -u 0 runner apt-get update
       docker exec -u 0 runner apt-get install -y \
           cmake zip unzip \
           g++ libnss3-dev libnss3-tools \
           openjdk-17-jdk libcommons-lang3-java libslf4j-java junit4
-    condition: or(startsWith(variables.image, 'debian_'), startsWith(variables.image, 'ubuntu_'))
-    displayName: Install Debian/Ubuntu dependencies
+    displayName: Install build dependencies
 
   - script: ./build.sh --with-tests
-    condition: or(startsWith(variables.image, 'fedora_'), startsWith(variables.image, 'centos_'))
-    displayName: Build JSS binaries, Javadoc, and run tests on Fedora/CentOS
-
-  - script: ./build.sh --with-tests
-    condition: or(startsWith(variables.image, 'debian_'), startsWith(variables.image, 'ubuntu_'))
-    displayName: Build JSS binaries, Javadoc, and run tests on Debian/Unbuntu
+    displayName: Build JSS binaries, Javadoc, and run tests
     env:
       JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
 


### PR DESCRIPTION
Due to recent changes in Azure or Fedora it's no longer possible to run tests in Azure with the standard Fedora image.

To fix the problem, the `Dockerfile` has been updated to define a new Fedora/CentOS image that provides a `systemd` service. The test job in Azure has been split into two jobs: one for Fedora/CentOS and one for Debian/Ubuntu. The Fedora/CentOS job will build the image, create a container with the image, then run the tests with it, whereas the Debian/Ubuntu job is basically unchanged.

**Note:** The test is now running, but it's failing due to a issue https://github.com/dogtagpki/jss/issues/882:
https://dev.azure.com/dogtagpki/jss/_build/results?buildId=814&view=logs&jobId=185660ed-fcb9-5db1-85f2-144090af2c88