### PR TITLE
Fix certificate signature algorithm not valid

### DIFF
--- a/base/src/test/java/org/mozilla/jss/tests/GenerateTestCert.java
+++ b/base/src/test/java/org/mozilla/jss/tests/GenerateTestCert.java
@@ -303,8 +303,13 @@ public class GenerateTestCert {
         int rand,
         SEQUENCE extensions) throws Exception {
 
-        AlgorithmIdentifier sigAlgID = new AlgorithmIdentifier(sigAlg.toOID());
-
+        AlgorithmIdentifier sigAlgID = null;
+        if(keyType.equals("RSA")) {
+            sigAlgID = new AlgorithmIdentifier(sigAlg.toOID(), null);
+        }
+        else {
+            sigAlgID = new AlgorithmIdentifier(sigAlg.toOID());
+        }
         Name issuer = new Name();
         issuer.addCountryName("US");
         issuer.addOrganizationName("Mozilla");

--- a/base/src/test/java/org/mozilla/jss/tests/SSLClientAuth.java
+++ b/base/src/test/java/org/mozilla/jss/tests/SSLClientAuth.java
@@ -73,7 +73,7 @@ public class SSLClientAuth implements Runnable {
     public static Certificate makeCert(String issuerName, String subjectName,
             int serialNumber, PrivateKey privKey, PublicKey pubKey, int rand,
             SEQUENCE extensions) throws Exception {
-        AlgorithmIdentifier sigAlgID = new AlgorithmIdentifier( sigAlg.toOID());
+        AlgorithmIdentifier sigAlgID = new AlgorithmIdentifier( sigAlg.toOID(), null);
 
         Name issuer = new Name();
         issuer.addCountryName("US");


### PR DESCRIPTION
Certificate generated for the test are not valid when _RSA_ is used because the signature algorithm in the `signature` field of `TBSCertificate` section is different from the `signatureAlgorithm` field. The last was including an empty parameter not presenti in the first.

I have added the empty parameter and now the certificate are the valid.

Fix  #882