### PR TITLE
Update workflows to use not deeprecated actions

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -19,7 +19,7 @@ jobs:
     container: ${{ matrix.os }}
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Java
       uses: actions/setup-java@v3
@@ -66,7 +66,7 @@ jobs:
       JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get JNI symbols in the code
         run: |
@@ -90,7 +90,7 @@ jobs:
     container: 'fedora:latest'
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Java
       uses: actions/setup-java@v3

--- a/.github/workflows/code-analysis-pull.yml
+++ b/.github/workflows/code-analysis-pull.yml
@@ -78,7 +78,7 @@ jobs:
         if:  ${{ env.HAVE_SONAR_TOKEN == 'false' }}
         run: exit 1
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -11,22 +11,22 @@ jobs:
       - name: Stop if no Sonar secret
         if:  ${{ env.HAVE_SONAR_TOKEN == 'false' }}
         run: exit 1
-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: 'zulu'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -50,7 +50,7 @@ jobs:
           echo ${{ github.event.pull_request.base.ref }} > ./pr/BaseBranch
 
       - name: Upload pr as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pr
           path: pr/
@@ -59,7 +59,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:

--- a/.github/workflows/known_failures.yml
+++ b/.github/workflows/known_failures.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Clone the repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build and Run the Docker Image
       run: bash tools/run_container.sh "${{ matrix.image }}" || echo "::warning ::Job exited with status $?"

--- a/.github/workflows/pkcs11-tests.yml
+++ b/.github/workflows/pkcs11-tests.yml
@@ -11,7 +11,7 @@ jobs:
       repo: ${{ steps.init.outputs.repo }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -29,13 +29,13 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -62,7 +62,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -11,7 +11,7 @@ jobs:
       repo: ${{ steps.init.outputs.repo }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -29,13 +29,13 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -62,7 +62,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3
@@ -98,7 +98,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3
@@ -189,7 +189,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ca-${{ matrix.os }}
           path: |

--- a/.github/workflows/tomcat-tests.yml
+++ b/.github/workflows/tomcat-tests.yml
@@ -11,7 +11,7 @@ jobs:
       repo: ${{ steps.init.outputs.repo }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -29,13 +29,13 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -63,7 +63,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload artifacts from server container
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: https-nss-test-${{ matrix.os }}
           path: |

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -8,7 +8,7 @@ else
 fi
 
 echo "MATRIX: $MATRIX"
-echo "::set-output name=matrix::$MATRIX"
+echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
 if [ "$BASE64_REPO" == "" ]
 then
@@ -18,4 +18,4 @@ else
 fi
 
 echo "REPO: $REPO"
-echo "::set-output name=repo::$REPO"
+echo "repo=$REPO" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Some action are using [Node.js v12 and this has been deprecated by GitHub](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

Additionally, the use of [`set-state` and `set-output` has been deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

Therefore the workflows are updated to the new version of the actions.