### PR TITLE
Modify container cgroup

### DIFF
--- a/tests/bin/runner-init.sh
+++ b/tests/bin/runner-init.sh
@@ -7,7 +7,6 @@ docker run \
     --privileged \
     --tmpfs /tmp \
     --tmpfs /run \
-    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
     -v ${GITHUB_WORKSPACE}:${SHARED} \
     -i \
     ${IMAGE}


### PR DESCRIPTION
Systemd has some problem to run in docker container if the host uses only cgroups2.

This could make the run container failing with the error:

Failed to create /init.scope control group: Read-only file system Failed to allocate manager object: Read-only file system [!!!!!!] Failed to allocate manager object.
Exiting PID 1...

A possible solution is fo use docker.slice as proposed here: https://serverfault.com/questions/1053187/systemd-fails-to-run-in-a-docker-container-when-using-cgroupv2-cgroupns-priva