### PR TITLE
Drop default COPR repo

### DIFF
--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -54,18 +54,41 @@ jobs:
       - name: Load jss-runner image
         run: docker load --input jss-runner.tar
 
-      - name: Run container
+      - name: Run JSS container
         run: |
           IMAGE=jss-runner \
           NAME=pki \
           HOSTNAME=pki.example.com \
           tests/bin/runner-init.sh
 
-      - name: Build PKI
+      - name: Import JSS packages from jss-builder
+        run: |
+          docker pull ghcr.io/dogtagpki/jss-builder:latest
+          docker create --name=jss-builder ghcr.io/dogtagpki/jss-builder:latest
+          docker cp jss-builder:/root/jss/build/RPMS/. /tmp/RPMS/
+
+      - name: Import Tomcat JSS packages from tomcatjss-builder
+        run: |
+          docker pull ghcr.io/dogtagpki/tomcatjss-builder:latest
+          docker create --name=tomcatjss-builder ghcr.io/dogtagpki/tomcatjss-builder:latest
+          docker cp tomcatjss-builder:/root/tomcatjss/build/RPMS/. /tmp/RPMS/
+
+      - name: Import LDAP SDK packages from ldapjdk-builder
+        run: |
+          docker pull ghcr.io/dogtagpki/ldapjdk-builder:latest
+          docker create --name=ldapjdk-builder ghcr.io/dogtagpki/ldapjdk-builder:latest
+          docker cp ldapjdk-builder:/root/ldapjdk/build/RPMS/. /tmp/RPMS/
+
+      - name: Install build dependencies
         run: |
           docker exec pki dnf install -y git rpm-build
           docker exec pki git clone https://github.com/dogtagpki/pki
-          docker exec pki dnf build-dep -y --spec pki/pki.spec
+          docker exec pki dnf builddep -y --skip-unavailable --spec pki/pki.spec
+          docker cp /tmp/RPMS/. pki:/root/RPMS/
+          docker exec pki bash -c "dnf localinstall -y /root/RPMS/*"
+
+      - name: Build and install PKI
+        run: |
           docker exec pki pki/build.sh --with-timestamp --with-commit-id rpm
           docker exec pki bash -c "dnf install -y /root/build/pki/RPMS/*.rpm"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Publish jss-builder image
         run: |
           docker load --input jss-builder.tar
-          docker tag jss-builder ghcr.io/${{ github.repository_owner }}/jss-builder
-          docker push ghcr.io/${{ github.repository_owner }}/jss-builder
+          docker tag jss-builder ghcr.io/${{ github.repository_owner }}/jss-builder:latest
+          docker push ghcr.io/${{ github.repository_owner }}/jss-builder:latest
 
       - name: Retrieve jss-runner image
         uses: actions/cache@v3
@@ -50,5 +50,5 @@ jobs:
       - name: Publish jss-runner image
         run: |
           docker load --input jss-runner.tar
-          docker tag jss-runner ghcr.io/${{ github.repository_owner }}/jss-runner
-          docker push ghcr.io/${{ github.repository_owner }}/jss-runner
+          docker tag jss-runner ghcr.io/${{ github.repository_owner }}/jss-runner:latest
+          docker push ghcr.io/${{ github.repository_owner }}/jss-runner:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@
 #
 
 ARG BASE_IMAGE="registry.fedoraproject.org/fedora:latest"
-ARG COPR_REPO="@pki/master"
+ARG COPR_REPO=""
 
 ################################################################################
 FROM $BASE_IMAGE AS jss-base
 
-RUN dnf install -y systemd \
+RUN dnf install -y dnf-plugins-core systemd \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
@@ -22,7 +22,7 @@ FROM jss-base AS jss-deps
 ARG COPR_REPO
 
 # Enable COPR repo if specified
-RUN if [ -n "$COPR_REPO" ]; then dnf install -y dnf-plugins-core; dnf copr enable -y $COPR_REPO; fi
+RUN if [ -n "$COPR_REPO" ]; then dnf copr enable -y $COPR_REPO; fi
 
 # Install JSS runtime dependencies
 RUN dnf install -y dogtag-jss \

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -12,7 +12,7 @@ echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
 if [ "$BASE64_REPO" == "" ]
 then
-    REPO="@pki/master"
+    REPO=""
 else
     REPO=$(echo "$BASE64_REPO" | base64 -d)
 fi


### PR DESCRIPTION
The GitHub workflows have been modified to no longer use a COPR repo by default. Instead, it will install packages from GitHub Packages. The Azure Pipelines still have a dependency on COPR. It will be removed separately later.