### PR TITLE
Add jss-dist image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 jss-builder.tar
+jss-dist.tar
 jss-runner.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,24 @@ jobs:
           key: jss-builder-${{ matrix.os }}-${{ github.sha }}
           path: jss-builder.tar
 
+      - name: Build jss-dist image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: jss-dist
+          target: jss-dist
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=jss-dist.tar
+
+      - name: Store jss-dist image
+        uses: actions/cache@v3
+        with:
+          key: jss-dist-${{ matrix.os }}-${{ github.sha }}
+          path: jss-dist.tar
+
       - name: Build jss-runner image
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,17 +29,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retrieve jss-builder image
+      - name: Retrieve jss-dist image
         uses: actions/cache@v3
         with:
-          key: jss-builder-${{ matrix.os }}-${{ github.sha }}
-          path: jss-builder.tar
+          key: jss-dist-${{ matrix.os }}-${{ github.sha }}
+          path: jss-dist.tar
 
-      - name: Publish jss-builder image
+      - name: Publish jss-dist image
         run: |
-          docker load --input jss-builder.tar
-          docker tag jss-builder ghcr.io/${{ github.repository_owner }}/jss-builder:latest
-          docker push ghcr.io/${{ github.repository_owner }}/jss-builder:latest
+          docker load --input jss-dist.tar
+          docker tag jss-dist ghcr.io/${{ github.repository_owner }}/jss-dist:latest
+          docker push ghcr.io/${{ github.repository_owner }}/jss-dist:latest
 
       - name: Retrieve jss-runner image
         uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,16 @@ COPY . /root/jss/
 RUN ./build.sh --work-dir=build rpm
 
 ################################################################################
+FROM alpine:latest AS jss-dist
+
+# Import JSS packages
+COPY --from=jss-builder /root/jss/build/RPMS /root/RPMS/
+
+################################################################################
 FROM jss-deps AS jss-runner
 
 # Import JSS packages
-COPY --from=jss-builder /root/jss/build/RPMS /tmp/RPMS/
+COPY --from=jss-dist /root/RPMS /tmp/RPMS/
 
 # Install JSS packages
 RUN dnf localinstall -y /tmp/RPMS/* \


### PR DESCRIPTION
The CI has been modified to store the RPMs in an Alpine-based image and publish it to GH Packages to reduce the size of the distribution.