### PR TITLE
Replace BASE64_MATRIX with BASE64_OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,6 @@ jobs:
     name: Building JSS
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -25,7 +23,7 @@ jobs:
         id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('jss.spec') }}
+          key: buildx-${{ hashFiles('jss.spec') }}
           path: /tmp/.buildx-cache
 
       - name: Build jss-deps image
@@ -33,7 +31,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: jss-deps
           target: jss-deps
@@ -45,7 +43,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: jss-builder-deps
           target: jss-builder-deps
@@ -57,7 +55,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: jss-builder
           target: jss-builder
@@ -67,7 +65,7 @@ jobs:
       - name: Store jss-builder image
         uses: actions/cache@v3
         with:
-          key: jss-builder-${{ matrix.os }}-${{ github.sha }}
+          key: jss-builder-${{ github.sha }}
           path: jss-builder.tar
 
       - name: Build jss-dist image
@@ -75,7 +73,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: jss-dist
           target: jss-dist
@@ -85,7 +83,7 @@ jobs:
       - name: Store jss-dist image
         uses: actions/cache@v3
         with:
-          key: jss-dist-${{ matrix.os }}-${{ github.sha }}
+          key: jss-dist-${{ github.sha }}
           path: jss-dist.tar
 
       - name: Build jss-runner image
@@ -93,7 +91,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: jss-runner
           target: jss-runner
@@ -103,5 +101,5 @@ jobs:
       - name: Store jss-runner image
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ matrix.os }}-${{ github.sha }}
+          key: jss-runner-${{ github.sha }}
           path: jss-runner.tar

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -2,15 +2,15 @@ name: Initialization
 on:
   workflow_call:
     secrets:
-      BASE64_MATRIX:
+      BASE64_OS:
         required: false
       BASE64_REPO:
         required: false
       BASE64_DATABASE:
         required: false
     outputs:
-      matrix:
-        value: ${{ jobs.init.outputs.matrix }}
+      base-image:
+        value: ${{ jobs.init.outputs.base-image }}
       repo:
         value: ${{ jobs.init.outputs.repo }}
       db-image:
@@ -21,7 +21,7 @@ jobs:
     name: Initializing workflow
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
+      base-image: ${{ steps.init.outputs.base-image }}
       repo: ${{ steps.init.outputs.repo }}
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
@@ -31,7 +31,7 @@ jobs:
       - name: Initialize workflow
         id: init
         env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
+          BASE64_OS: ${{ secrets.BASE64_OS }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
           BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |

--- a/.github/workflows/pkcs11-tests.yml
+++ b/.github/workflows/pkcs11-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building JSS (${{ matrix.os }})'
+          check-name: 'Building JSS'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building JSS (${{ matrix.os }})'
+          check-name: 'Building JSS'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -39,8 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/jss
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -48,7 +44,7 @@ jobs:
       - name: Retrieve jss-runner image
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ matrix.os }}-${{ github.sha }}
+          key: jss-runner-${{ github.sha }}
           path: jss-runner.tar
 
       - name: Load jss-runner image

--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building JSS (${{ matrix.os }})'
+          check-name: 'Building JSS'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building JSS (${{ matrix.os }})'
+          check-name: 'Building JSS'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -39,8 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/jss
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -48,7 +44,7 @@ jobs:
       - name: Retrieve jss-runner image
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ matrix.os }}-${{ github.sha }}
+          key: jss-runner-${{ github.sha }}
           path: jss-runner.tar
 
       - name: Load jss-runner image
@@ -94,8 +90,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/jss
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -103,7 +97,7 @@ jobs:
       - name: Retrieve jss-runner image
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ matrix.os }}-${{ github.sha }}
+          key: jss-runner-${{ github.sha }}
           path: jss-runner.tar
 
       - name: Load jss-runner image
@@ -191,6 +185,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-${{ matrix.os }}
+          name: ca
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,6 @@ jobs:
     name: Publishing JSS
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -32,7 +30,7 @@ jobs:
       - name: Retrieve jss-dist image
         uses: actions/cache@v3
         with:
-          key: jss-dist-${{ matrix.os }}-${{ github.sha }}
+          key: jss-dist-${{ github.sha }}
           path: jss-dist.tar
 
       - name: Publish jss-dist image
@@ -44,7 +42,7 @@ jobs:
       - name: Retrieve jss-runner image
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ matrix.os }}-${{ github.sha }}
+          key: jss-runner-${{ github.sha }}
           path: jss-runner.tar
 
       - name: Publish jss-runner image

--- a/.github/workflows/tomcat-tests.yml
+++ b/.github/workflows/tomcat-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building JSS (${{ matrix.os }})'
+          check-name: 'Building JSS'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building JSS (${{ matrix.os }})'
+          check-name: 'Building JSS'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -40,8 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -49,7 +45,7 @@ jobs:
       - name: Retrieve jss-runner image
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ matrix.os }}-${{ github.sha }}
+          key: jss-runner-${{ github.sha }}
           path: jss-runner.tar
 
       - name: Load jss-runner image
@@ -148,6 +144,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: https-nss-test-${{ matrix.os }}
+          name: https-nss-test
           path: |
             /tmp/artifacts/server

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -1,14 +1,15 @@
 #!/bin/bash -e
 
-if [ "$BASE64_MATRIX" == "" ]
+if [ "$BASE64_OS" != "" ]
 then
-    MATRIX="{\"os\":[\"latest\"]}"
+    OS_VERSION=$(echo "$BASE64_OS" | base64 -d)
 else
-    MATRIX=$(echo "$BASE64_MATRIX" | base64 -d)
+    OS_VERSION=latest
 fi
 
-echo "MATRIX: $MATRIX"
-echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+BASE_IMAGE=registry.fedoraproject.org/fedora:$OS_VERSION
+echo "BASE_IMAGE: $BASE_IMAGE"
+echo "base-image=$BASE_IMAGE" >> $GITHUB_OUTPUT
 
 if [ "$BASE64_REPO" == "" ]
 then


### PR DESCRIPTION
Previously the `BASE64_MATRIX` parameter provided a mechanism to test against multiple Fedora versions at once. However, since the test resources are limited and only one of the versions is eventually published, the parameter has been replaced with a new `BASE64_OS` parameter which only supports a single Fedora version.

https://github.com/dogtagpki/pki/wiki/Configuring-Test-OS