### PR TITLE
git Make update_version script update jss_config_version

### DIFF
--- a/update_version.sh
+++ b/update_version.sh
@@ -70,10 +70,21 @@ change_spec_version() {
     fi
 }
 
+change_jss_config_version() {
+    if [ "$NEXT_PHASE" ] ; then
+        IS_BETA="1"
+    else
+        IS_BETA="0"
+    fi
+    JSS_CONFIG_VERSION="$NEXT_MAJOR $NEXT_MINOR $NEXT_UPDATE $IS_BETA"
+    echo "Updating jss_config_version to $JSS_CONFIG_VERSION"
+    sed -i "/ jss_config_version/c\    jss_config_version($JSS_CONFIG_VERSION)" cmake/JSSConfig.cmake
+}
+
 commit_version_change() {
-    git add jss.spec
+    git add jss.spec cmake/JSSConfig.cmake
     git commit -m "Updating version to v$NEXT_VERSION"
- }
+}
 
 create_tag() {
     git tag v"$NEXT_VERSION"
@@ -87,6 +98,7 @@ create_source_tarball() {
 
 verify_phase
 change_spec_version
+change_jss_config_version
 commit_version_change
 create_tag
 create_source_tarball


### PR DESCRIPTION
In JSS there is an extra step required for updating where the value of jss_config_version must be bumped in sync with the version and phase. Currently this does not happen, which will lead to irregularities in testing and potentially incompatible config.