### PR TITLE
Add support for container registry configuration

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -15,6 +15,10 @@ on:
         value: ${{ jobs.init.outputs.repo }}
       db-image:
         value: ${{ jobs.init.outputs.db-image }}
+      registry:
+        value: ${{ jobs.init.outputs.registry }}
+      registry-namespace:
+        value: ${{ jobs.init.outputs.registry-namespace }}
 
 jobs:
   init:
@@ -24,6 +28,8 @@ jobs:
       base-image: ${{ steps.init.outputs.base-image }}
       repo: ${{ steps.init.outputs.repo }}
       db-image: ${{ steps.init.outputs.db-image }}
+      registry: ${{ steps.init.outputs.registry }}
+      registry-namespace: ${{ steps.init.outputs.registry-namespace }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -34,5 +40,7 @@ jobs:
           BASE64_OS: ${{ secrets.BASE64_OS }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
           BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
+          REGISTRY: ${{ vars.REGISTRY }}
+          REGISTRY_NAMESPACE: ${{ vars.REGISTRY_NAMESPACE }}
         run: |
           tests/bin/init-workflow.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     name: Initialization
     uses: ./.github/workflows/init.yml
     secrets: inherit
+    if: vars.REGISTRY != ''
 
   build:
     name: Waiting for build
@@ -29,12 +30,21 @@ jobs:
     needs: [init, build]
     runs-on: ubuntu-latest
     steps:
-      - name: Log in to the Container registry
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+        if: vars.REGISTRY == 'ghcr.io'
+
+      - name: Log in to other container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ vars.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+        if: vars.REGISTRY != 'ghcr.io'
 
       - name: Retrieve jss-dist image
         uses: actions/cache@v3
@@ -45,17 +55,5 @@ jobs:
       - name: Publish jss-dist image
         run: |
           docker load --input jss-dist.tar
-          docker tag jss-dist ghcr.io/${{ github.repository_owner }}/jss-dist:latest
-          docker push ghcr.io/${{ github.repository_owner }}/jss-dist:latest
-
-      - name: Retrieve jss-runner image
-        uses: actions/cache@v3
-        with:
-          key: jss-runner-${{ github.sha }}
-          path: jss-runner.tar
-
-      - name: Publish jss-runner image
-        run: |
-          docker load --input jss-runner.tar
-          docker tag jss-runner ghcr.io/${{ github.repository_owner }}/jss-runner:latest
-          docker push ghcr.io/${{ github.repository_owner }}/jss-runner:latest
+          docker tag jss-dist ${{ needs.init.outputs.registry }}/${{ needs.init.outputs.registry-namespace }}/jss-dist:latest
+          docker push ${{ needs.init.outputs.registry }}/${{ needs.init.outputs.registry-namespace }}/jss-dist:latest

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+################################################################################
+# Base image
+
 if [ "$BASE64_OS" != "" ]
 then
     OS_VERSION=$(echo "$BASE64_OS" | base64 -d)
@@ -11,6 +14,9 @@ BASE_IMAGE=registry.fedoraproject.org/fedora:$OS_VERSION
 echo "BASE_IMAGE: $BASE_IMAGE"
 echo "base-image=$BASE_IMAGE" >> $GITHUB_OUTPUT
 
+################################################################################
+# COPR repository
+
 if [ "$BASE64_REPO" == "" ]
 then
     REPO=""
@@ -20,3 +26,25 @@ fi
 
 echo "REPO: $REPO"
 echo "repo=$REPO" >> $GITHUB_OUTPUT
+
+################################################################################
+# Container registry
+
+if [ "$REGISTRY" == "" ]
+then
+    REGISTRY="ghcr.io"
+fi
+
+echo "REGISTRY: $REGISTRY"
+echo "registry=$REGISTRY" >> $GITHUB_OUTPUT
+
+################################################################################
+# Container registry namespace
+
+if [ "$REGISTRY_NAMESPACE" == "" ]
+then
+    REGISTRY_NAMESPACE=$GITHUB_REPOSITORY_OWNER
+fi
+
+echo "REGISTRY_NAMESPACE: $REGISTRY_NAMESPACE"
+echo "registry-namespace=$REGISTRY_NAMESPACE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The publish job has been modified to support container registry configuration and will only run if the registry is configured. The job will also no longer publish the runner image since it's only used internally.

https://github.com/dogtagpki/pki/wiki/Configuring-Container-Registry