### PR TITLE
Fix warning for accessing `-Werror=maybe-uninitialized`

### DIFF
--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.c
@@ -152,8 +152,8 @@ JSS_PK11_generateKeyPairWithOpFlags(JNIEnv *env, CK_MECHANISM_TYPE mechanism,
 
     if( *privk == NULL ) {
         int errLength;
-        char *errBuf;
-        char *msgBuf;
+        char *errBuf = NULL;
+        char *msgBuf = NULL;
 
         errLength = PR_GetErrorTextLength();
         if(errLength > 0) {


### PR DESCRIPTION
The error stop the building only with debug enabled and all warning enabled. This is not a problem but it blocks the `sandbox-test` which exit with error.

The error is arise only in fedora rawhide and not in fedora 37.

The current logic of the application does not change.