### PR TITLE
Fix some Sonar Cloud issues

### DIFF
--- a/base/src/main/java/org/mozilla/jss/asn1/OBJECT_IDENTIFIER.java
+++ b/base/src/main/java/org/mozilla/jss/asn1/OBJECT_IDENTIFIER.java
@@ -142,7 +142,7 @@ public class OBJECT_IDENTIFIER implements ASN1Value {
     /**
      * Creates an OBJECT_IDENTIFIER from an array of longs, which constitute
      * the numbers that make up the OBJECT IDENTIFIER.
-     * 
+     *
      * @param numbers Numbers.
      */
     public OBJECT_IDENTIFIER(long[] numbers) {
@@ -157,7 +157,6 @@ public class OBJECT_IDENTIFIER implements ASN1Value {
      * off, it just checks for null.
      */
     private static void checkLongArray(long[] numbers) {
-        assert (numbers != null);
         if (numbers == null) {
             throw new NullPointerException();
         }
@@ -224,7 +223,7 @@ public class OBJECT_IDENTIFIER implements ASN1Value {
      * { 1 3 5 6 },
      * then calling <code>oid.subBranch(4)</code> would return a new
      * OBJECT_IDENTIFIER with the value { 1 3 5 6 4 }.
-     * 
+     *
      * @param num Number.
      * @return New sub-branch.
      */
@@ -242,7 +241,7 @@ public class OBJECT_IDENTIFIER implements ASN1Value {
      * then calling <code>oid.subBranch(new long[]{ 4, 3})</code>
      * would return a new
      * OBJECT_IDENTIFIER with the value { 1 3 5 6 4 3}.
-     * 
+     *
      * @param newNums New numbers.
      * @return New sub-branch.
      */

--- a/base/src/main/java/org/mozilla/jss/netscape/security/extensions/GenericASN1Extension.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/extensions/GenericASN1Extension.java
@@ -280,7 +280,7 @@ public class GenericASN1Extension extends Extension
      */
     @Override
     public String toString() {
-        return (null);
+        return "";
     }
 
     /**

--- a/base/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS10Attributes.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS10Attributes.java
@@ -155,7 +155,7 @@ public class PKCS10Attributes extends Vector<PKCS10Attribute> implements DerEnco
     }
 
     @Override
-    public int hashCode() {
+    public synchronized int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
         result = prime * result + ((map == null) ? 0 : map.hashCode());
@@ -163,7 +163,7 @@ public class PKCS10Attributes extends Vector<PKCS10Attribute> implements DerEnco
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public synchronized boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (!super.equals(obj))

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/AVA.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/AVA.java
@@ -285,7 +285,7 @@ public final class AVA implements DerEncoder {
             // (before Ldap escaping) here.
             s = toLdapDNString();
         } catch (IOException e) {
-            return null;
+            return "";
         }
         return s;
     }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/CRLExtensions.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/CRLExtensions.java
@@ -227,7 +227,7 @@ public class CRLExtensions extends Vector<Extension> {
     }
 
     @Override
-    public int hashCode() {
+    public synchronized int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
         result = prime * result + ((map == null) ? 0 : map.hashCode());
@@ -235,7 +235,7 @@ public class CRLExtensions extends Vector<Extension> {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public synchronized boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (!super.equals(obj))

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/CertificateExtensions.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/CertificateExtensions.java
@@ -283,7 +283,7 @@ public class CertificateExtensions extends Vector<Extension>
     }
 
     @Override
-    public int hashCode() {
+    public synchronized int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
         result = prime * result + ((map == null) ? 0 : map.hashCode());
@@ -291,7 +291,7 @@ public class CertificateExtensions extends Vector<Extension>
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public synchronized boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (!super.equals(obj))

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/Extensions.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/Extensions.java
@@ -232,7 +232,7 @@ public class Extensions extends Vector<Extension>
     }
 
     @Override
-    public int hashCode() {
+    public synchronized int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
         result = prime * result + ((map == null) ? 0 : map.hashCode());
@@ -240,7 +240,7 @@ public class Extensions extends Vector<Extension>
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public synchronized boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (!super.equals(obj))

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/RDN.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/RDN.java
@@ -299,7 +299,7 @@ public class RDN {
         try {
             s = toLdapDNString();
         } catch (IOException e) {
-            return null;
+            return "";
         }
         return s;
     }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/X500Name.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/X500Name.java
@@ -503,7 +503,7 @@ public class X500Name implements Principal, GeneralNameInterface {
         try {
             s = toLdapDNString();
         } catch (IOException e) {
-            return null;
+            return "";
         }
         return s;
     }

--- a/base/src/main/java/org/mozilla/jss/provider/java/security/KeyFactorySpi1_2.java
+++ b/base/src/main/java/org/mozilla/jss/provider/java/security/KeyFactorySpi1_2.java
@@ -185,7 +185,7 @@ public class KeyFactorySpi1_2 extends java.security.KeyFactorySpi
             // we need to chop off a leading zero byte
             if( y.bitLength() % 8 == 0 ) {
                 byte[] newBA = new byte[yBA.length-1];
-                assert(newBA.length >= 0);
+                assert(newBA.length > 0);
                 System.arraycopy(yBA, 1, newBA, 0, newBA.length);
                 yBA = newBA;
             }

--- a/base/src/main/java/org/mozilla/jss/util/Base64InputStream.java
+++ b/base/src/main/java/org/mozilla/jss/util/Base64InputStream.java
@@ -206,7 +206,7 @@ public class Base64InputStream extends FilterInputStream {
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         in.mark(readlimit);
         savedPrev = prev;
         savedState = state;
@@ -218,7 +218,7 @@ public class Base64InputStream extends FilterInputStream {
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         in.reset();
         prev = savedPrev;
         state = savedState;


### PR DESCRIPTION
The method `toString()` does never return `null` and the subclasses should maintain its original behaviour. Similarly, some syncronized methods were overrided without the `syncronize` modifier.

Finally, some conditions were not possible.