### PR TITLE
Removde printStackTrace()

### DIFF
--- a/base/src/main/java/org/mozilla/jss/netscape/security/extensions/ExtendedKeyUsageExtension.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/extensions/ExtendedKeyUsageExtension.java
@@ -30,6 +30,8 @@ import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
 import org.mozilla.jss.netscape.security.x509.CertAttrSet;
 import org.mozilla.jss.netscape.security.x509.Extension;
 import org.mozilla.jss.netscape.security.x509.OIDMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This represents the extended key usage extension.
@@ -40,6 +42,8 @@ public class ExtendedKeyUsageExtension extends Extension implements CertAttrSet 
      *
      */
     private static final long serialVersionUID = 765403075764697489L;
+    private static final Logger logger = LoggerFactory.getLogger(ExtendedKeyUsageExtension.class);
+
     public static final String OID = "2.5.29.37";
     public static final String NAME = OIDMap.EXT_KEY_USAGE_NAME;
     public static final String OID_OCSPSigning = "1.3.6.1.5.5.7.3.9";
@@ -221,7 +225,7 @@ public class ExtendedKeyUsageExtension extends Extension implements CertAttrSet 
                     temp.putOID(oidList.nextElement());
                 }
             } catch (IOException ex) {
-                ex.printStackTrace();
+                logger.error("Problem encoding", ex);
             }
         }
 

--- a/base/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS8Key.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS8Key.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -31,7 +32,6 @@ import java.security.Provider;
 import java.security.Security;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.lang.reflect.InvocationTargetException;
 
 import org.mozilla.jss.netscape.security.util.BigInt;
 import org.mozilla.jss.netscape.security.util.DerOutputStream;
@@ -326,7 +326,6 @@ public class PKCS8Key implements PrivateKey {
                 throw new InvalidKeyException("excess key data");
 
         } catch (IOException e) {
-            // e.printStackTrace ();
             throw new InvalidKeyException("IOException : " +
                       e.getMessage());
         }
@@ -352,7 +351,6 @@ public class PKCS8Key implements PrivateKey {
         try {
             decode(stream);
         } catch (InvalidKeyException e) {
-            e.printStackTrace();
             throw new IOException("deserialized key is invalid: " +
                     e.getMessage());
         }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/util/CertPrettyPrint.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/util/CertPrettyPrint.java
@@ -35,6 +35,8 @@ import org.mozilla.jss.netscape.security.x509.X509CertInfo;
 import org.mozilla.jss.netscape.security.x509.X509Key;
 import org.mozilla.jss.pkcs7.ContentInfo;
 import org.mozilla.jss.pkcs7.SignedData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class will display the certificate content in predefined
@@ -48,7 +50,9 @@ public class CertPrettyPrint {
     /*==========================================================
      * constants
      *==========================================================*/
-    private final static String CUSTOM_LOCALE = "Custom";
+    private static final String CUSTOM_LOCALE = "Custom";
+
+    private static final Logger logger = LoggerFactory.getLogger(CertPrettyPrint.class);
 
     /*==========================================================
      * variables
@@ -335,7 +339,7 @@ public class CertPrettyPrint {
 
             sb.append(certFingerprints.toString());
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Problem converting to string", e);
         }
 
         return sb.toString();

--- a/base/src/main/java/org/mozilla/jss/netscape/security/util/CrlPrettyPrint.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/util/CrlPrettyPrint.java
@@ -28,6 +28,8 @@ import org.mozilla.jss.netscape.security.x509.CRLExtensions;
 import org.mozilla.jss.netscape.security.x509.Extension;
 import org.mozilla.jss.netscape.security.x509.RevokedCertificate;
 import org.mozilla.jss.netscape.security.x509.X509CRLImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class will display the certificate content in predefined
@@ -41,7 +43,9 @@ public class CrlPrettyPrint {
     /*==========================================================
      * constants
      *==========================================================*/
-    private final static String CUSTOM_LOCALE = "Custom";
+    private static final String CUSTOM_LOCALE = "Custom";
+
+    private static final Logger logger = LoggerFactory.getLogger(CrlPrettyPrint.class);
 
     /*==========================================================
      * variables
@@ -263,7 +267,7 @@ public class CrlPrettyPrint {
         } catch (Exception e) {
             sb.append("\n\n" + pp.indent(4) + resource.getString(
                     PrettyPrintResources.TOKEN_DECODING_ERROR) + "\n\n");
-            e.printStackTrace();
+            logger.debug("Problem converting to string", e);
         }
 
         return sb.toString();

--- a/base/src/main/java/org/mozilla/jss/netscape/security/util/ExtPrettyPrint.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/util/ExtPrettyPrint.java
@@ -78,6 +78,8 @@ import org.mozilla.jss.netscape.security.x509.SubjectAlternativeNameExtension;
 import org.mozilla.jss.netscape.security.x509.SubjectDirAttributesExtension;
 import org.mozilla.jss.netscape.security.x509.SubjectKeyIdentifierExtension;
 import org.mozilla.jss.netscape.security.x509.UserNotice;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class will display the certificate content in predefined
@@ -87,6 +89,8 @@ import org.mozilla.jss.netscape.security.x509.UserNotice;
  * @version $Revision$, $Date$
  */
 public class ExtPrettyPrint {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExtPrettyPrint.class);
 
     /*==========================================================
      * variables
@@ -538,7 +542,7 @@ public class ExtPrettyPrint {
             }
             return sb.toString();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.debug("Problem getting key usage", e);
             return sb.toString();
         }
 
@@ -587,7 +591,7 @@ public class ExtPrettyPrint {
             }
             return sb.toString();
         } catch (CertificateException e) {
-            e.printStackTrace();
+            logger.debug("Problem getting certificate type", e);
             return "";
         }
 
@@ -618,7 +622,7 @@ public class ExtPrettyPrint {
             }
             return sb.toString();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.debug("Problem getting subject identifier", e);
             return "";
         }
     }
@@ -669,7 +673,7 @@ public class ExtPrettyPrint {
             }
             return sb.toString();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.debug("Problem getting authority key identifier", e);
             return "";
         }
     }
@@ -771,7 +775,7 @@ public class ExtPrettyPrint {
 
             return sb.toString();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.debug("Problem getting basic constraints", e);
             return "";
         }
     }
@@ -804,7 +808,7 @@ public class ExtPrettyPrint {
 
             return sb.toString();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.debug("Problem getting CRL number extensions", e);
             return "";
         }
     }
@@ -837,7 +841,7 @@ public class ExtPrettyPrint {
 
             return sb.toString();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.debug("Problem getting delta CRL extensions", e);
             return "";
         }
     }
@@ -921,7 +925,7 @@ public class ExtPrettyPrint {
 
             return sb.toString();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.debug("Problem getting subject alternative name", e);
             return "";
         }
     }
@@ -1319,7 +1323,7 @@ public class ExtPrettyPrint {
 
             return sb.toString();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.debug("Problem getting certificate issuer", e);
             return "";
         }
     }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/util/PubKeyPrettyPrint.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/util/PubKeyPrettyPrint.java
@@ -24,6 +24,8 @@ import java.util.ResourceBundle;
 
 import org.mozilla.jss.netscape.security.provider.RSAPublicKey;
 import org.mozilla.jss.netscape.security.x509.X509Key;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class will display the certificate content in predefined
@@ -34,6 +36,8 @@ import org.mozilla.jss.netscape.security.x509.X509Key;
  * @version $Revision$, $Date$
  */
 public class PubKeyPrettyPrint {
+
+    public static final Logger logger = LoggerFactory.getLogger(PubKeyPrettyPrint.class);
 
     /*==========================================================
      * variables
@@ -115,7 +119,7 @@ public class PubKeyPrettyPrint {
             }
 
         } catch(InvalidKeyException e){
-            e.printStackTrace();
+            logger.debug("Impossible convert public certificate to string", e);
         }
 
         return sb.toString();

--- a/base/src/main/java/org/mozilla/jss/netscape/security/util/Utils.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/util/Utils.java
@@ -37,7 +37,12 @@ import java.util.Date;
 import java.util.StringTokenizer;
 import java.util.Vector;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class Utils {
+
+    private static final Logger logger = LoggerFactory.getLogger(Utils.class);
     /**
      * Checks if this is NT.
      */
@@ -89,7 +94,7 @@ public class Utils {
                 return false;
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error("The command canot be executed: " + cmd, e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
@@ -226,31 +231,14 @@ public class Utils {
     }
 
     public static void copy(String orig, String dest) throws Exception {
-        BufferedReader in = null;
-        PrintWriter out = null;
-        try {
-            in = new BufferedReader(new FileReader(orig));
-            out = new PrintWriter(
-                    new BufferedWriter(new FileWriter(dest)));
+        try (BufferedReader in = new BufferedReader(new FileReader(orig));
+                PrintWriter out = new PrintWriter(
+                    new BufferedWriter(new FileWriter(dest)))) {
             String line = "";
             while (in.ready()) {
                 line = in.readLine();
                 if (line != null)
                     out.println(line);
-            }
-        } catch (Exception ee) {
-            ee.printStackTrace();
-            throw ee;
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-            if (out != null) {
-                out.close();
             }
         }
     }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/CRLDistributionPointsExtension.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/CRLDistributionPointsExtension.java
@@ -30,9 +30,10 @@ import java.util.Vector;
 import org.mozilla.jss.asn1.ASN1Util;
 import org.mozilla.jss.asn1.InvalidBERException;
 import org.mozilla.jss.asn1.SEQUENCE;
-
 import org.mozilla.jss.netscape.security.util.BitArray;
 import org.mozilla.jss.netscape.security.util.DerOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An extension that tells applications where to find the CRL for
@@ -67,6 +68,8 @@ public class CRLDistributionPointsExtension extends Extension
      *
      */
     private static final long serialVersionUID = 8551761833349709229L;
+
+    private static final Logger logger = LoggerFactory.getLogger(CRLDistributionPointsExtension.class);
     // vector of CRLDistributionPoint
     private SEQUENCE distributionPoints = new SEQUENCE();
 
@@ -98,9 +101,7 @@ public class CRLDistributionPointsExtension extends Extension
                 throw new IOException("Invalid BER-encoding: " + e, e);
             }
         } catch (IOException e) {
-            System.out.println("Big error");
-            System.out.println(e);
-            e.printStackTrace();
+            logger.error("Error decoding CRLDistributionPoints", e);
             //throw e;
         }
     }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/ExtensionsRequested.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/ExtensionsRequested.java
@@ -45,9 +45,8 @@ public class ExtensionsRequested implements CertAttrSet {
 
         try {
             decode(is);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new IOException(e.getMessage());
+        } catch (CertificateException | IOException e) {
+            throw new IOException("Error decoding extensions: " + e.getMessage());
         }
     }
 

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/FreshestCRLExtension.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/FreshestCRLExtension.java
@@ -30,9 +30,10 @@ import java.util.Vector;
 import org.mozilla.jss.asn1.ASN1Util;
 import org.mozilla.jss.asn1.InvalidBERException;
 import org.mozilla.jss.asn1.SEQUENCE;
-
 import org.mozilla.jss.netscape.security.util.BitArray;
 import org.mozilla.jss.netscape.security.util.DerOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An extension that tells applications where to find
@@ -69,6 +70,7 @@ public class FreshestCRLExtension extends Extension
      */
     private static final long serialVersionUID = -8040203589629281781L;
 
+    private static final Logger logger = LoggerFactory.getLogger(FreshestCRLExtension.class);
     // vector of CRLDistributionPoint
     private SEQUENCE distributionPoints = new SEQUENCE();
 
@@ -118,10 +120,7 @@ public class FreshestCRLExtension extends Extension
                 throw new IOException("Invalid BER-encoding: " + e, e);
             }
         } catch (IOException e) {
-            System.out.println("Big error");
-            System.out.println(e);
-            e.printStackTrace();
-            //throw e;
+            logger.error("Error decoding freshest CRL", e);
         }
     }
 

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/OIDMap.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/OIDMap.java
@@ -26,6 +26,8 @@ import java.util.Iterator;
 import java.util.Properties;
 
 import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class defines the mapping from OID and name to classes and vice
@@ -37,6 +39,8 @@ import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
  * @version 1.12
  */
 public class OIDMap {
+
+    private static final Logger logger = LoggerFactory.getLogger(OIDMap.class);
 
     /**
      * Location for where the OID/Classes maps are stored on
@@ -177,7 +181,7 @@ public class OIDMap {
                     try {
                         fis.close();
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        logger.debug("Error closing " + EXTENSIONS_OIDS, e);
                     }
                 }
             }
@@ -213,7 +217,7 @@ public class OIDMap {
                     try {
                         fis.close();
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        logger.debug("Error closing " + EXTENSIONS_CLASSES, e);
                     }
                 }
             }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/X509CertImpl.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/X509CertImpl.java
@@ -1073,7 +1073,7 @@ public class X509CertImpl extends X509Certificate
                 try {
                     out.close();
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    logger.debug("Error getting DER encoding", e);
                 }
             }
         }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/X509CertInfo.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/X509CertInfo.java
@@ -33,6 +33,8 @@ import java.util.Vector;
 import org.mozilla.jss.netscape.security.util.DerInputStream;
 import org.mozilla.jss.netscape.security.util.DerOutputStream;
 import org.mozilla.jss.netscape.security.util.DerValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The X509CertInfo class represents X.509 certificate information.
@@ -69,6 +71,8 @@ public class X509CertInfo implements CertAttrSet, Serializable {
      *
      */
     private static final long serialVersionUID = -5094073467876311577L;
+
+    private static final Logger logger = LoggerFactory.getLogger(X509CertInfo.class);
     /**
      * Identifier for this attribute, to be used with the
      * get, set, delete methods of Certificate, x509 type.
@@ -271,9 +275,7 @@ public class X509CertInfo implements CertAttrSet, Serializable {
             byte[] dup = new byte[rawCertInfo.length];
             System.arraycopy(rawCertInfo, 0, dup, 0, dup.length);
             return dup;
-        } catch (IOException e) {
-            throw new CertificateEncodingException(e);
-        } catch (CertificateException e) {
+        } catch (CertificateException | IOException e) {
             throw new CertificateEncodingException(e);
         }
     }
@@ -380,7 +382,7 @@ public class X509CertInfo implements CertAttrSet, Serializable {
                         try {
                             out.close();
                         } catch (IOException e) {
-                            e.printStackTrace();
+                            logger.debug("Error closing stream", e);
                         }
                     }
                 }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/X509Key.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/X509Key.java
@@ -376,7 +376,6 @@ public class X509Key implements PublicKey {
         try {
             decode(stream);
         } catch (InvalidKeyException e) {
-            e.printStackTrace();
             throw new IOException("deserialized key is invalid: " + e.getMessage());
         }
     }

--- a/base/src/main/java/org/mozilla/jss/pkcs12/PFX.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs12/PFX.java
@@ -165,7 +165,6 @@ public class PFX implements ASN1Value {
             }
 
         } catch (java.security.DigestException e) {
-            e.printStackTrace();
             reason.append("A DigestException occurred");
             return false;
 


### PR DESCRIPTION
The `printStackTrace()` output should not be used in production because it can leak information and cannot be disabled.

The method is deleted or converted to log.

Note: some tests and client code still use the method