### PR TITLE
Update javac() to support HEADER_DIR

### DIFF
--- a/cmake/Java.cmake
+++ b/cmake/Java.cmake
@@ -24,7 +24,7 @@ function(javac target)
 
     foreach (arg ${ARGN})
 
-        if (arg MATCHES "(SOURCE_DIR|SOURCES|EXCLUDE|CLASSPATH|OUTPUT_DIR|DEPENDS)")
+        if (arg MATCHES "(SOURCE_DIR|SOURCES|EXCLUDE|CLASSPATH|OUTPUT_DIR|HEADER_DIR|DEPENDS)")
             set(param ${arg})
 
         else ()
@@ -44,12 +44,15 @@ function(javac target)
             elseif (param STREQUAL "OUTPUT_DIR")
                 set(output_dir ${arg})
 
+            elseif (param STREQUAL "HEADER_DIR")
+                set(header_dir ${arg})
+
             elseif (param STREQUAL "DEPENDS")
                 list(APPEND depends ${arg})
 
             endif(param STREQUAL "SOURCE_DIR")
 
-        endif(arg MATCHES "(SOURCE_DIR|SOURCES|EXCLUDE|CLASSPATH|OUTPUT_DIR|DEPENDS)")
+        endif(arg MATCHES "(SOURCE_DIR|SOURCES|EXCLUDE|CLASSPATH|OUTPUT_DIR|HEADER_DIR|DEPENDS)")
 
     endforeach(arg)
 
@@ -72,6 +75,19 @@ function(javac target)
 
     file(MAKE_DIRECTORY ${output_dir})
 
+    set(javac_options ${CMAKE_JAVA_COMPILE_FLAGS})
+    list(APPEND javac_options -encoding UTF-8)
+    list(APPEND javac_options -cp ${native_classpath})
+    list(APPEND javac_options -d ${output_dir})
+
+    if (DEFINED header_dir)
+        list(APPEND javac_options -h ${header_dir})
+    endif()
+
+    list(APPEND javac_options -source 17)
+    list(APPEND javac_options -target 17)
+    list(APPEND javac_options @${file_list})
+
     add_custom_command(
         TARGET ${target}
         COMMAND ${CMAKE_COMMAND}
@@ -80,14 +96,9 @@ function(javac target)
             -Dfiles="${sources}"
             -Dexclude="${exclude}"
             -P ${CMAKE_MODULE_PATH}/JavaFileList.cmake
-        COMMAND ${Java_JAVAC_EXECUTABLE}
-            ${CMAKE_JAVA_COMPILE_FLAGS}
-            -encoding UTF-8
-            -cp ${native_classpath}
-            -d ${output_dir}
-            -source 17
-            -target 17
-            @${file_list}
+        COMMAND
+            ${Java_JAVAC_EXECUTABLE}
+            ${javac_options}
         WORKING_DIRECTORY
             ${source_dir}
     )

--- a/symkey/CMakeLists.txt
+++ b/symkey/CMakeLists.txt
@@ -8,6 +8,8 @@ javac(symkey-classes
         ${CLASSES_OUTPUT_DIR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
+    HEADER_DIR
+        ${CMAKE_CURRENT_BINARY_DIR}/include
     DEPENDS
         generate_java
 )
@@ -38,17 +40,13 @@ set(SYMKEY_PUBLIC_INCLUDE_DIRS
 )
 
 set(SYMKEY_PRIVATE_INCLUDE_DIRS
-    ${CMAKE_BINARY_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}/include
     ${JNI_INCLUDE_DIRS}
     ${NSPR_INCLUDE_DIRS}
     ${NSS_INCLUDE_DIRS}
 )
 
 set(SYMKEY_SHARED_LIBRARY symkey_library CACHE INTERNAL "symkey shared library")
-
-set(symkey_library_HDRS
-    src/main/java/org/mozilla/jss/symkey/SessionKey.h
-)
 
 set(symkey_library_SRCS
     src/main/java/org/mozilla/jss/symkey/Buffer.cpp
@@ -60,20 +58,7 @@ set(symkey_library_SRCS
 
 include_directories(${SYMKEY_PRIVATE_INCLUDE_DIRS})
 
-# TODO: merge into javac() above
-add_custom_command(
-    OUTPUT
-        ${symkey_library_HDRS}
-    COMMAND
-        ${Java_JAVAC_EXECUTABLE}
-            -classpath ${JAVAC_CLASSPATH}:${CLASSES_OUTPUT_DIR}
-            -h ${CMAKE_CURRENT_BINARY_DIR}
-            -d ${CMAKE_CURRENT_BINARY_DIR}/classes
-            ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java/org/mozilla/jss/symkey/SessionKey.java
-)
-
 add_library(${SYMKEY_SHARED_LIBRARY} SHARED
-    ${symkey_library_HDRS}
     ${symkey_library_SRCS})
 
 add_dependencies(${SYMKEY_SHARED_LIBRARY} symkey-jar)


### PR DESCRIPTION
The `javac()` function in CMake has been modified to provide an option to specify where to generate the native header files. The `symkey` module has been modified to use this option.