### PR TITLE
Add Maven module for symkey

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -51,8 +51,24 @@ jobs:
 
     - name: Compare jss.jar
       run: |
-        jar tvf ~/build/jss/jss.jar | awk '{print $8;}' | sort | tee cmake.out
-        jar tvf base/target/jss-5.4.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        jar tvf ~/build/jss/jss.jar | awk '{print $8;}' | sort \
+            | grep -v '/$' \
+            | tee cmake.out
+        jar tvf base/target/jss-5.4.0-SNAPSHOT.jar | awk '{print $8;}' | sort \
+            | grep -v '/$' \
+            | grep -v '^META-INF/maven/' \
+            | tee maven.out
+        diff cmake.out maven.out
+
+    - name: Compare jss-symkey.jar
+      run: |
+        jar tvf ~/build/jss/symkey/jss-symkey.jar | awk '{print $8;}' | sort \
+            | grep -v '/$' \
+            | tee cmake.out
+        jar tvf symkey/target/jss-symkey-5.4.0-SNAPSHOT.jar | awk '{print $8;}' | sort \
+            | grep -v '/$' \
+            | grep -v '^META-INF/maven/' \
+            | tee maven.out
         diff cmake.out maven.out
 
     # TODO: Run examples

--- a/jss.spec
+++ b/jss.spec
@@ -85,13 +85,13 @@ BuildRequires:  unzip
 BuildRequires:  gcc-c++
 BuildRequires:  nss-devel >= 3.66
 BuildRequires:  nss-tools >= 3.66
-BuildRequires:  %{java_devel}
-BuildRequires:  jpackage-utils
-BuildRequires:  slf4j
-BuildRequires:  slf4j-jdk14
-BuildRequires:  apache-commons-lang3
 
-BuildRequires:  junit
+BuildRequires:  %{java_devel}
+BuildRequires:  maven-local
+BuildRequires:  mvn(org.apache.commons:commons-lang3)
+BuildRequires:  mvn(org.slf4j:slf4j-api)
+BuildRequires:  mvn(org.slf4j:slf4j-jdk14)
+BuildRequires:  mvn(junit:junit)
 
 %description
 Java Security Services (JSS) is a java native interface which provides a bridge
@@ -105,11 +105,11 @@ This only works with gcj. Other JREs require that JCE providers be signed.
 Summary:        Java Security Services (JSS)
 
 Requires:       nss >= 3.66
+
 Requires:       %{java_headless}
-Requires:       jpackage-utils
-Requires:       slf4j
-Requires:       slf4j-jdk14
-Requires:       apache-commons-lang3
+Requires:       mvn(org.apache.commons:commons-lang3)
+Requires:       mvn(org.slf4j:slf4j-api)
+Requires:       mvn(org.slf4j:slf4j-jdk14)
 
 Obsoletes:      jss < %{version}-%{release}
 Provides:       jss = %{version}-%{release}

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,16 @@
         <revision>5.4.0-SNAPSHOT</revision>
         <sonar.organization>dogtagpki</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.c.file.suffixes>-</sonar.c.file.suffixes>
+        <sonar.cpp.file.suffixes>-</sonar.cpp.file.suffixes>
+        <sonar.objc.file.suffixes>-</sonar.objc.file.suffixes>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>
         <module>base</module>
         <module>native</module>
+        <module>symkey</module>
         <module>examples</module>
     </modules>
 

--- a/symkey/pom.xml
+++ b/symkey/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>jss-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>jss-symkey</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jss</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <compilerArgs>
+                        <arg>-proc:none</arg>
+                        <arg>-h</arg><arg>${project.build.directory}/include/_jni</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
A `pom.xml` has been added to define Maven module for symkey. The build test has been added to compare the `jss-symkey.jar` created by CMake and by Maven to ensure that they contain the same files.

For now Maven will only build symkey Java code and SonarCloud will ignore symkey native code.

The `jss.spec` has been updated to use Maven dependencies.