### PR TITLE
Reintroduce SHA1 algorithm

### DIFF
--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/AlgorithmId.java
@@ -1070,10 +1070,10 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * Supported signing algorithms for a RSA key.
      */
     public static final String[] RSA_SIGNING_ALGORITHMS = new String[]
-    { "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA256withRSA/PSS", "SHA384withRSA/PSS", "SHA512withRSA/PSS" };
+    { "SHA256withRSA", "SHA384withRSA", "SHA512withRSA", "SHA1withRSA", "SHA256withRSA/PSS", "SHA384withRSA/PSS", "SHA512withRSA/PSS" };
 
     public static final String[] EC_SIGNING_ALGORITHMS = new String[]
-    { "SHA256withEC", "SHA384withEC", "SHA512withEC" };
+    { "SHA256withEC", "SHA384withEC", "SHA512withEC", "SHA1withEC" };
 
     /**
      * All supported signing algorithms.


### PR DESCRIPTION
SHA1 algorithms were removed with the commit
f9d83e27ff6d22c9cefe4a7d1f651498782bb8cb but this generate problem when dogtag is used on RHEL8 based systems. To solve the problem they are put back in place.

Fix Bug 2182085