### PR TITLE
Fix native filename

### DIFF
--- a/native/pom.xml
+++ b/native/pom.xml
@@ -11,7 +11,7 @@
         <version>${revision}</version>
     </parent>
 
-    <artifactId>jss-native</artifactId>
+    <artifactId>libjss</artifactId>
     <packaging>so</packaging>
 
     <dependencies>


### PR DESCRIPTION
Running `mvn install` generate error for messing package name. Investigating and checking the code the artificatId has to be the same of the library generated.

https://stackoverflow.com/questions/25138413/java-jni-maven-native-maven-plugin-how-to-set-shared-library-final-name https://github.com/mojohaus/maven-native/blob/master/native-maven-plugin/src/main/java/org/codehaus/mojo/natives/plugin/NativeInitializeMojo.java

The install phase is relevant to deploy in the artificat in the local database and use the artifact as dependency