### PR TITLE
Make maven artifcat usabale

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,36 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.1.0</version>
+          <configuration>
+            <updatePomFile>true</updatePomFile>
+            <flattenMode>resolveCiFriendliesOnly</flattenMode>
+          </configuration>
+          <executions>
+            <execution>
+              <id>flatten</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>flatten</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>flatten.clean</id>
+              <phase>clean</phase>
+              <goals>
+                <goal>clean</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+
     <modules>
         <module>base</module>
         <module>native</module>


### PR DESCRIPTION
When parent version is managed with a `revision` property in the submodules the generated artificats will have the `version` field not updated do they cannot be consumed by other projects. The solution is to add a plugin transforming the `pom.xml` for the artifact.

References:

- https://maven.apache.org/maven-ci-friendly.html#install-deploy
- https://jeanchristophegay.com/en/posts/maven-unique-version-multi-modules-build/