### PR TITLE
Add build.sh --without-java and --without-native

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ if (DEFINED ENV{WITH_INTERNET})
 endif()
 option(TEST_WITH_INTERNET "When enabled, runs various tests which require an internet connection. " ${TEST_WITH_INTERNET_ENV})
 
+option(WITH_JAVA "Build Java binaries." TRUE)
+option(WITH_NATIVE "Build native binaries." TRUE)
 option(WITH_JAVADOC "Build Javadoc package." TRUE)
 
 # Find NSPR and NSS Libraries.
@@ -94,34 +96,38 @@ add_custom_target(
     DEPENDS generate_c generate_so symkey_library
 )
 
-install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/jss.jar
-    DESTINATION
-        ${JNI_DIR}
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/jss.jar
+        DESTINATION
+            ${JNI_DIR}
+    )
 
-install(
-    CODE "
-        MESSAGE(
-            \"-- Installing: \$ENV{DESTDIR}${LIB_DIR}/jss/jss.jar\"
-        )
-        execute_process(
-            COMMAND ln -sf ../../../${JNI_DIR}/jss.jar \$ENV{DESTDIR}${LIB_DIR}/jss/jss.jar
-        )
-    "
-)
+    install(
+        CODE "
+            MESSAGE(
+                \"-- Installing: \$ENV{DESTDIR}${LIB_DIR}/jss/jss.jar\"
+            )
+            execute_process(
+                COMMAND ln -sf ../../../${JNI_DIR}/jss.jar \$ENV{DESTDIR}${LIB_DIR}/jss/jss.jar
+            )
+        "
+    )
+endif(WITH_JAVA)
 
-install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/libjss.so
-    DESTINATION
-        ${LIB_DIR}/jss
-    PERMISSIONS
-        OWNER_READ OWNER_WRITE OWNER_EXECUTE
-        GROUP_READ GROUP_EXECUTE
-        WORLD_READ WORLD_EXECUTE
-)
+if(WITH_NATIVE)
+    install(
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/libjss.so
+        DESTINATION
+            ${LIB_DIR}/jss
+        PERMISSIONS
+            OWNER_READ OWNER_WRITE OWNER_EXECUTE
+            GROUP_READ GROUP_EXECUTE
+            WORLD_READ WORLD_EXECUTE
+    )
+endif(WITH_NATIVE)
 
 if(WITH_JAVADOC)
     install(

--- a/build.sh
+++ b/build.sh
@@ -40,6 +40,8 @@ WITH_TIMESTAMP=
 WITH_COMMIT_ID=
 DIST=
 
+WITH_JAVA=true
+WITH_NATIVE=true
 WITH_JAVADOC=true
 WITH_TESTS=
 
@@ -68,6 +70,8 @@ usage() {
     echo "    --with-timestamp       Append timestamp to release number."
     echo "    --with-commit-id       Append commit ID to release number."
     echo "    --dist=<name>          Distribution name (e.g. fc28)."
+    echo "    --without-java         Do not build Java binaries."
+    echo "    --without-native       Do not build native binaries."
     echo "    --without-javadoc      Do not build Javadoc package."
     echo "    --with-tests           Run unit tests."
     echo " -v,--verbose              Run in verbose mode."
@@ -253,6 +257,12 @@ while getopts v-: arg ; do
         dist=?*)
             DIST="$LONG_OPTARG"
             ;;
+        without-java)
+            WITH_JAVA=false
+            ;;
+        without-native)
+            WITH_NATIVE=false
+            ;;
         without-javadoc)
             WITH_JAVADOC=false
             ;;
@@ -382,6 +392,14 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
 
     OPTIONS+=(-DVERSION="$VERSION")
 
+    if [ "$WITH_JAVA" = false ] ; then
+        OPTIONS+=(-DWITH_JAVA=FALSE)
+    fi
+
+    if [ "$WITH_NATIVE" = false ] ; then
+        OPTIONS+=(-DWITH_NATIVE=FALSE)
+    fi
+
     if [ "$WITH_JAVADOC" = false ] ; then
         OPTIONS+=(-DWITH_JAVADOC=FALSE)
     fi
@@ -397,7 +415,13 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
     OPTIONS+=(CMAKE_NO_VERBOSE=1)
     OPTIONS+=(--no-print-directory)
 
-    make "${OPTIONS[@]}" all
+    if [ "$WITH_JAVA" = true ] ; then
+        make "${OPTIONS[@]}" java
+    fi
+
+    if [ "$WITH_NATIVE" = true ] ; then
+        make "${OPTIONS[@]}" native
+    fi
 
     if [ "$WITH_JAVADOC" = true ] ; then
         make "${OPTIONS[@]}" javadoc
@@ -409,11 +433,17 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
 
     echo
     echo "Build artifacts:"
-    echo "- Java archives:"
-    echo "    $WORK_DIR/jss.jar"
-    echo "- shared libraries:"
-    echo "    $WORK_DIR/libjss.so"
-    echo "    $WORK_DIR/symkey/libjss-symkey.so"
+
+    if [ "$WITH_JAVA" = true ] ; then
+        echo "- Java binaries:"
+        echo "    $WORK_DIR/jss.jar"
+    fi
+
+    if [ "$WITH_NATIVE" = true ] ; then
+        echo "- native binaries:"
+        echo "    $WORK_DIR/libjss.so"
+        echo "    $WORK_DIR/symkey/libjss-symkey.so"
+    fi
 
     if [ "$WITH_JAVADOC" = true ] ; then
         echo "- documentation:"

--- a/symkey/CMakeLists.txt
+++ b/symkey/CMakeLists.txt
@@ -39,13 +39,15 @@ set_target_properties(${SYMKEY_SHARED_LIBRARY}
 target_link_libraries(${SYMKEY_SHARED_LIBRARY}
     smime3 ssl3 nss3 nssutil3 plc4 plds4 nspr4 pthread dl)
 
-install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/libjss-symkey.so
-    DESTINATION
-        ${LIB_DIR}/jss
-    PERMISSIONS
-        OWNER_READ OWNER_WRITE OWNER_EXECUTE
-        GROUP_READ GROUP_EXECUTE
-        WORLD_READ WORLD_EXECUTE
-)
+if(WITH_NATIVE)
+    install(
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/libjss-symkey.so
+        DESTINATION
+            ${LIB_DIR}/jss
+        PERMISSIONS
+            OWNER_READ OWNER_WRITE OWNER_EXECUTE
+            GROUP_READ GROUP_EXECUTE
+            WORLD_READ WORLD_EXECUTE
+    )
+endif(WITH_NATIVE)


### PR DESCRIPTION
New options have been added into `build.sh` to support building Java and native binaries separately.