### PR TITLE
Fix some bugs in org.mozilla.jss.pkix

### DIFF
--- a/base/src/main/java/org/mozilla/jss/pkix/cert/Certificate.java
+++ b/base/src/main/java/org/mozilla/jss/pkix/cert/Certificate.java
@@ -53,7 +53,7 @@ public class Certificate implements ASN1Value
     SEQUENCE sequence;
 
     Certificate(CertificateInfo info, byte[] infoEncoding,
-            AlgorithmIdentifier algId, byte[] signature) throws IOException
+            AlgorithmIdentifier algId, byte[] signature)
     {
         this.info = info;
         this.infoEncoding = infoEncoding;
@@ -118,7 +118,6 @@ public class Certificate implements ASN1Value
         infoEncoding = ASN1Util.encode(info);
 
         // sign the info encoding
-        CryptoManager cm = CryptoManager.getInstance();
         CryptoToken token = priv.getOwningToken();
         Signature sig = token.getSignatureContext(signingAlg);
         sig.initSign(priv);
@@ -137,9 +136,8 @@ public class Certificate implements ASN1Value
      * that the certificate is valid at any specific time.
      */
     public void verify()
-        throws InvalidKeyException, NotInitializedException,
-        NoSuchAlgorithmException, CertificateException,
-        SignatureException, InvalidKeyFormatException
+        throws InvalidKeyException, NoSuchAlgorithmException,
+        CertificateException, SignatureException, InvalidKeyFormatException
     {
         verify( info.getSubjectPublicKeyInfo().toPublicKey() );
     }
@@ -221,7 +219,6 @@ public class Certificate implements ASN1Value
 
         public Template() {
             seqt = new SEQUENCE.Template();
-            //seqt.addElement( CertificateInfo.getTemplate() );
             seqt.addElement( new ANY.Template() );
             seqt.addElement( AlgorithmIdentifier.getTemplate() );
             seqt.addElement( BIT_STRING.getTemplate() );
@@ -267,7 +264,7 @@ public class Certificate implements ASN1Value
         }
     }
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
 
       try {
 

--- a/base/src/main/java/org/mozilla/jss/pkix/cert/CertificateInfo.java
+++ b/base/src/main/java/org/mozilla/jss/pkix/cert/CertificateInfo.java
@@ -52,10 +52,15 @@ public class CertificateInfo implements ASN1Value {
 
         @Override
         public boolean equals(Object obj) {
-            if(obj == null || !(obj instanceof Version)) {
+            if(!(obj instanceof Version)) {
                 return false;
             }
             return ((Version)obj).versionNumber == versionNumber;
+        }
+
+        @Override
+        public int hashCode() {
+            return versionNumber;
         }
 
         public int getNumber() {
@@ -391,7 +396,7 @@ public class CertificateInfo implements ASN1Value {
         return templateInstance;
     }
 
-    public void print(PrintStream ps) throws IOException, InvalidBERException {
+    public void print(PrintStream ps) throws InvalidBERException {
         ps.println("CertificateInfo:");
         ps.println("Version: "+version);
         ps.println("Serial Number: "+serialNumber);

--- a/base/src/main/java/org/mozilla/jss/pkix/cmmf/CertRepContent.java
+++ b/base/src/main/java/org/mozilla/jss/pkix/cmmf/CertRepContent.java
@@ -120,7 +120,7 @@ public class CertRepContent implements ASN1Value {
         encoding.encode(implicitTag, ostream);
     }
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
 
         if(argv.length != 2) {
             System.out.println("Usage: CertRepContent <certfile> <outputfile>");
@@ -134,24 +134,26 @@ public class CertRepContent implements ASN1Value {
 
         byte[][] certs = new byte[2][];
         certs[0] = new byte[ certfile.available() ];
-        certfile.read(certs[0]);
-        certs[1] = certs[0];
+        while(certfile.read(certs[0]) > 0)
+        {
+            certs[1] = certs[0];
 
-        PKIStatusInfo status = new PKIStatusInfo(PKIStatusInfo.rejection,
-                    PKIStatusInfo.badRequest | PKIStatusInfo.badTime );
+            PKIStatusInfo status = new PKIStatusInfo(PKIStatusInfo.rejection,
+                        PKIStatusInfo.badRequest | PKIStatusInfo.badTime );
 
-        status.addFreeText("And your mother dresses you funny");
-        status.addFreeText("so there");
+            status.addFreeText("And your mother dresses you funny");
+            status.addFreeText("so there");
 
-        CertifiedKeyPair ckp = new CertifiedKeyPair(
-                                new CertOrEncCert( certs[0] ) );
-        CertResponse resp = new CertResponse( new INTEGER(54), status, ckp);
+            CertifiedKeyPair ckp = new CertifiedKeyPair(
+                                    new CertOrEncCert( certs[0] ) );
+            CertResponse resp = new CertResponse( new INTEGER(54), status, ckp);
 
-        CertRepContent content = new CertRepContent(certs);
-        content.addCertResponse(resp);
+            CertRepContent content = new CertRepContent(certs);
+            content.addCertResponse(resp);
 
-        content.encode(fos);
-        System.out.println("Success!");
+            content.encode(fos);
+            System.out.println("Success!");
+        }
 
       } catch( Exception e ) {
         e.printStackTrace();

--- a/base/src/main/java/org/mozilla/jss/pkix/cms/DigestInfo.java
+++ b/base/src/main/java/org/mozilla/jss/pkix/cms/DigestInfo.java
@@ -7,6 +7,7 @@ package org.mozilla.jss.pkix.cms;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 
 import org.mozilla.jss.asn1.ASN1Template;
 import org.mozilla.jss.asn1.ASN1Value;
@@ -51,7 +52,7 @@ public class DigestInfo implements ASN1Value {
 
     @Override
     public boolean equals(Object obj) {
-        if( obj==null || !(obj instanceof DigestInfo)) {
+        if(!(obj instanceof DigestInfo)) {
             return false;
         }
         DigestInfo di = (DigestInfo)obj;
@@ -59,6 +60,10 @@ public class DigestInfo implements ASN1Value {
         return byteArraysAreSame(di.digest.toByteArray(), digest.toByteArray());
     }
 
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(digest.toByteArray());
+    }
     /**
      * Compares two non-null byte arrays.  Returns true if they are identical,
      * false otherwise.

--- a/base/src/main/java/org/mozilla/jss/pkix/crmf/CertReqMsg.java
+++ b/base/src/main/java/org/mozilla/jss/pkix/crmf/CertReqMsg.java
@@ -120,7 +120,7 @@ public class CertReqMsg implements ASN1Value {
 		if (type == ProofOfPossession.SIGNATURE) {
 			POPOSigningKey sigkey = pop.getSignature();
 			AlgorithmIdentifier alg = sigkey.getAlgorithmIdentifier();
-			BIT_STRING sig_from = sigkey.getSignature();
+			BIT_STRING sigFrom = sigkey.getSignature();
 			ByteArrayOutputStream bo = new ByteArrayOutputStream();
 			certReq.encode(bo);
 			byte[] toBeVerified = bo.toByteArray();
@@ -137,7 +137,7 @@ public class CertReqMsg implements ASN1Value {
 			Signature sig = token.getSignatureContext(sigAlg);
 			sig.initVerify(pubkey);
 			sig.update(toBeVerified);
-			if( !sig.verify(sig_from.getBits()) ) {
+			if( !sig.verify(sigFrom.getBits()) ) {
 				throw new SignatureException(
 					"Signed request information does not "+
 					"match signature in POP");
@@ -240,7 +240,7 @@ public class CertReqMsg implements ASN1Value {
         }
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
 
       try {
         if( args.length < 1 ) {
@@ -256,7 +256,7 @@ public class CertReqMsg implements ASN1Value {
 
         try (FileInputStream fis = new FileInputStream(args[0])) {
             bytes = new byte[fis.available()];
-            fis.read(bytes);
+            while(fis.read(bytes)>0);
         }
 
         seq = (SEQUENCE) seqt.decode(new ByteArrayInputStream(bytes));

--- a/base/src/main/java/org/mozilla/jss/pkix/primitive/SubjectPublicKeyInfo.java
+++ b/base/src/main/java/org/mozilla/jss/pkix/primitive/SubjectPublicKeyInfo.java
@@ -3,14 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.jss.pkix.primitive;
 
-import org.mozilla.jss.asn1.*;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.IOException;
-import java.security.PublicKey;
 import java.security.NoSuchAlgorithmException;
-import org.mozilla.jss.crypto.PrivateKey;
+import java.security.PublicKey;
+
+import org.mozilla.jss.asn1.ASN1Template;
+import org.mozilla.jss.asn1.ASN1Util;
+import org.mozilla.jss.asn1.ASN1Value;
+import org.mozilla.jss.asn1.BIT_STRING;
+import org.mozilla.jss.asn1.InvalidBERException;
+import org.mozilla.jss.asn1.SEQUENCE;
+import org.mozilla.jss.asn1.Tag;
 import org.mozilla.jss.crypto.InvalidKeyFormatException;
+import org.mozilla.jss.crypto.PrivateKey;
 import org.mozilla.jss.pkcs11.PK11PubKey;
 
 /**
@@ -38,7 +45,7 @@ public class SubjectPublicKeyInfo extends java.security.spec.X509EncodedKeySpec
     public byte[] getEncoded() {
         return ASN1Util.encode(this);
     }
-        
+
 
     public AlgorithmIdentifier getAlgorithmIdentifier() {
         return algorithm;
@@ -59,7 +66,7 @@ public class SubjectPublicKeyInfo extends java.security.spec.X509EncodedKeySpec
     }
 
     public SubjectPublicKeyInfo(PublicKey pubk)
-            throws InvalidBERException, IOException
+            throws InvalidBERException
     {
         super( new byte[] {0});
         SubjectPublicKeyInfo spki = (SubjectPublicKeyInfo)


### PR DESCRIPTION
The main issuees fixed are:

- override of equals and and hash code, (they should be done both)
- check byde read from stream
- removed not possible exceptions
- syntax compliant to Java best practice