### PR TITLE
Publish to GitHub Maven registry

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -54,7 +54,7 @@ jobs:
         jar tvf ~/build/jss/jss.jar | awk '{print $8;}' | sort \
             | grep -v '/$' \
             | tee cmake.out
-        jar tvf base/target/jss-5.4.0-SNAPSHOT.jar | awk '{print $8;}' | sort \
+        jar tvf base/target/jss-base-5.4.0-SNAPSHOT.jar | awk '{print $8;}' | sort \
             | grep -v '/$' \
             | grep -v '^META-INF/maven/' \
             | tee maven.out

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,49 @@ jobs:
     secrets: inherit
     if: vars.REGISTRY != ''
 
-  build:
-    name: Waiting for build
+  publish-maven:
+    name: Publishing Maven artifacts
     needs: init
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for build
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Check settings.xml
+        run: |
+          cat ~/.m2/settings.xml
+
+      - name: Update pom.xml
+        run: |
+          sed -i \
+              -e "s/OWNER/$NAMESPACE/g" \
+              -e "s/REPOSITORY/jss/g" \
+              pom.xml
+          cat pom.xml
+
+      - name: Publish Maven artifacts
+        run: |
+          # TODO: Fix build issue in native and symkey modules.
+          mvn \
+              --batch-mode \
+              --update-snapshots \
+              -pl '!native,!symkey' \
+              deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  wait-for-images:
+    name: Waiting for container images
+    needs: init
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for container images
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
@@ -28,9 +65,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
 
-  publish:
-    name: Publishing JSS
-    needs: [init, build]
+  publish-images:
+    name: Publishing container images
+    needs: [init, wait-for-images]
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Container Registry

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -6,12 +6,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
+        <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
         <version>${revision}</version>
     </parent>
 
-    <artifactId>jss</artifactId>
+    <artifactId>jss-base</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
+        <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
         <version>${revision}</version>
     </parent>
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jss</artifactId>
+            <artifactId>jss-base</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
+        <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
         <version>${revision}</version>
     </parent>
@@ -18,7 +18,7 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jss</artifactId>
+            <artifactId>jss-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
+    <groupId>org.dogtagpki.jss</groupId>
     <artifactId>jss-parent</artifactId>
     <version>${revision}</version>
     <packaging>pom</packaging>
@@ -18,6 +18,13 @@
         <sonar.objc.file.suffixes>-</sonar.objc.file.suffixes>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <modules>
+        <module>base</module>
+        <module>native</module>
+        <module>symkey</module>
+        <module>examples</module>
+    </modules>
 
     <build>
       <plugins>
@@ -49,11 +56,22 @@
       </plugins>
     </build>
 
-    <modules>
-        <module>base</module>
-        <module>native</module>
-        <module>symkey</module>
-        <module>examples</module>
-    </modules>
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/OWNER/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/OWNER/REPOSITORY</url>
+        </repository>
+    </distributionManagement>
 
 </project>

--- a/symkey/pom.xml
+++ b/symkey/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
+        <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
         <version>${revision}</version>
     </parent>
@@ -18,7 +18,7 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jss</artifactId>
+            <artifactId>jss-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
A new job has been added to build JSS with Maven and publish the artifacts to GitHub Maven registry. Currently the native and symkey modules have to be disabled due to a build issue. The group ID and artifact ID have been renamed to follow a more commonly used pattern.

Once merged, the packages will look like the following:
https://github.com/edewata?tab=packages&repo_name=jss
