### PR TITLE
[v4.9.x] Fix AIA externsion print

### DIFF
--- a/src/main/java/org/mozilla/jss/netscape/security/x509/OIDMap.java
+++ b/src/main/java/org/mozilla/jss/netscape/security/x509/OIDMap.java
@@ -25,6 +25,7 @@ import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Properties;
 
+import org.mozilla.jss.netscape.security.extensions.AuthInfoAccessExtension;
 import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
 
 /**
@@ -61,6 +62,8 @@ public class OIDMap {
                                           AuthorityKeyIdentifierExtension.NAME;
     private static final String SUB_KEY_IDENTIFIER = ROOT + "." +
                                           SubjectKeyIdentifierExtension.NAME;
+    private static final String AUTHORITY_INFORMATION_ACCESS_IDENTIFIER = ROOT + "." +
+                                          AuthInfoAccessExtension.NAME;
     private static final String KEY_USAGE = ROOT + "." +
                                           KeyUsageExtension.NAME;
     private static final String PRIVATE_KEY_USAGE = ROOT + "." +
@@ -81,6 +84,7 @@ public class OIDMap {
             CertificatePoliciesExtension.NAME;
     private static final String SUBJ_DIR_ATTR = ROOT + "." +
             SubjectDirAttributesExtension.NAME;
+
     public static final String EXT_KEY_USAGE_NAME = "ExtendedKeyUsageExtension";
     public static final String EXT_INHIBIT_ANY_POLICY_NAME = "InhibitAnyPolicyExtension";
     private static final String EXT_KEY_USAGE = ROOT + "." +
@@ -105,6 +109,7 @@ public class OIDMap {
     // Load the default name to oid map (EXTENSIONS_OIDS)
     private static void loadNamesDefault(Properties props) {
         props.put(SUB_KEY_IDENTIFIER, "2.5.29.14");
+        props.put(AUTHORITY_INFORMATION_ACCESS_IDENTIFIER, "1.3.6.1.5.5.7.1.1");
         props.put(KEY_USAGE, "2.5.29.15");
         props.put(PRIVATE_KEY_USAGE, "2.5.29.16");
         props.put(SUB_ALT_NAME, "2.5.29.17");
@@ -127,6 +132,8 @@ public class OIDMap {
                    "org.mozilla.jss.netscape.security.x509.AuthorityKeyIdentifierExtension");
         props.put(SUB_KEY_IDENTIFIER,
                   "org.mozilla.jss.netscape.security.x509.SubjectKeyIdentifierExtension");
+        props.put(AUTHORITY_INFORMATION_ACCESS_IDENTIFIER,
+                 "org.mozilla.jss.netscape.security.extensions.AuthInfoAccessExtension");
         props.put(KEY_USAGE,
                   "org.mozilla.jss.netscape.security.x509.KeyUsageExtension");
         props.put(PRIVATE_KEY_USAGE,


### PR DESCRIPTION
The "Authority Info Access" extension was not included in the oid
extension  map so it was not correctly printed.

This add AIA extension to the oid map.