### PR TITLE
Convert tests to JUnit5 (PrintableConverterTest)

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,14 +4,28 @@
 	<classpathentry kind="src" path="base/src/test/java"/>
 	<classpathentry kind="src" path="base/src/broken_test/java"/>
 	<classpathentry kind="src" path="examples/src/main/java"/>
-	<classpathentry kind="lib" path="/usr/share/java/slf4j/slf4j-api.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/apache-commons-lang3.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/junit.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/slf4j/slf4j-simple.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="lib" path="/usr/share/java/slf4j/slf4j-api.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/apache-commons-lang3.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/slf4j/slf4j-simple.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-vintage-engine.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-testkit.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-suite-commons.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-suite-api.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-runner.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-reporting.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-launcher.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-engine.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-commons.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-jupiter-params.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-jupiter-migrationsupport.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-jupiter-engine.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-jupiter-api.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-jupiter.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -41,7 +41,7 @@ jobs:
             cmake zip unzip \
             g++ libnss3-dev libnss3-tools \
             openjdk-17-jdk libcommons-lang3-java libslf4j-java junit4 \
-            maven
+            junit5 libopentest4j-java maven
 
     - name: Build JSS with CMake
       run: ./build.sh --with-tests
@@ -132,6 +132,7 @@ jobs:
       run: |
         dnf install -y dnf-plugins-core
         dnf builddep -y nspr nss jss
+        dnf builddep -y jss.spec
         dnf install -y mercurial \
             python-unversioned-command \
             gyp \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,8 @@ jobs:
       docker exec -u 0 runner apt-get install -y \
           cmake zip unzip \
           g++ libnss3-dev libnss3-tools \
-          openjdk-17-jdk libcommons-lang3-java libslf4j-java junit4
+          openjdk-17-jdk libcommons-lang3-java libslf4j-java junit4 \
+          junit5 libopentest4j-java
     displayName: Install build dependencies
 
   - script: ./build.sh --with-tests

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -36,9 +36,16 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -37,8 +37,15 @@
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>5.9.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.9.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -49,6 +56,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.opentest4j</groupId>
+            <artifactId>opentest4j</artifactId>
+            <version>1.2.0</version>
+        </dependency> 
     </dependencies>
 
     <build>

--- a/base/src/test/java/org/mozilla/jss/tests/PrintableConverterTest.java
+++ b/base/src/test/java/org/mozilla/jss/tests/PrintableConverterTest.java
@@ -1,7 +1,7 @@
 package org.mozilla.jss.tests;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mozilla.jss.netscape.security.util.DerValue;
 import org.mozilla.jss.netscape.security.x509.PrintableConverter;
 
@@ -19,7 +19,7 @@ public class PrintableConverterTest {
         byte[] actual = ConverterTestUtil.convert(new PrintableConverter(), string);
         System.out.println(" - actual  : " + StringTestUtil.toString(actual));
 
-        Assert.assertArrayEquals(expected, actual);
+        Assertions.assertArrayEquals(expected, actual);
     }
 
     @Test
@@ -34,11 +34,11 @@ public class PrintableConverterTest {
             byte[] actual = ConverterTestUtil.convert(new PrintableConverter(), string);
             System.out.println(" - actual  : " + StringTestUtil.toString(actual));
 
-            Assert.fail();
+            Assertions.fail();
 
         } catch (Exception e) {
             System.out.println(" - actual  : " + e.getClass().getSimpleName());
-            Assert.assertTrue(e instanceof IllegalArgumentException);
+            Assertions.assertTrue(e instanceof IllegalArgumentException);
         }
     }
 
@@ -54,7 +54,7 @@ public class PrintableConverterTest {
         byte[] actual = ConverterTestUtil.convert(new PrintableConverter(), string);
         System.out.println(" - actual  : " + StringTestUtil.toString(actual));
 
-        Assert.assertArrayEquals(expected, actual);
+        Assertions.assertArrayEquals(expected, actual);
     }
 
     @Test
@@ -69,11 +69,11 @@ public class PrintableConverterTest {
             byte[] actual = ConverterTestUtil.convert(new PrintableConverter(), string);
             System.out.println(" - actual  : " + StringTestUtil.toString(actual));
 
-            Assert.fail();
+            Assertions.fail();
 
         } catch (Exception e) {
             System.out.println(" - actual  : " + e.getClass().getSimpleName());
-            Assert.assertTrue(e instanceof IllegalArgumentException);
+            Assertions.assertTrue(e instanceof IllegalArgumentException);
         }
     }
 
@@ -89,11 +89,11 @@ public class PrintableConverterTest {
             byte[] actual = ConverterTestUtil.convert(new PrintableConverter(), string);
             System.out.println(" - actual  : " + StringTestUtil.toString(actual));
 
-            Assert.fail();
+            Assertions.fail();
 
         } catch (Exception e) {
             System.out.println(" - actual  : " + e.getClass().getSimpleName());
-            Assert.assertTrue(e instanceof IllegalArgumentException);
+            Assertions.assertTrue(e instanceof IllegalArgumentException);
         }
     }
 }

--- a/base/src/test/java/org/mozilla/jss/tests/TestRunner.java
+++ b/base/src/test/java/org/mozilla/jss/tests/TestRunner.java
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.jss.tests;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+
+public class TestRunner {
+
+    SummaryGeneratingListener listener = new SummaryGeneratingListener();
+    public void test(String className) throws FileNotFoundException {
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(selectClass(className))
+                .build();
+              Launcher launcher = LauncherFactory.create();
+              launcher.registerTestExecutionListeners(listener);
+              launcher.execute(request);
+    }
+    public static void main(String[] args)  throws FileNotFoundException {
+        TestRunner runner = new TestRunner();
+        runner.test(args[0]);
+
+        TestExecutionSummary summary = runner.listener.getSummary();
+        summary.printTo(new PrintWriter(System.out));
+        summary.printFailuresTo(new PrintWriter(System.out));
+
+        if(summary.getTotalFailureCount() > 0)
+            System.exit(1);
+    }
+}

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -232,6 +232,30 @@ macro(jss_config_java)
         NAMES junit4 junit
     )
     find_jar(
+        JUNIT5_API_JAR
+        NAMES junit-jupiter-api junit5/junit-jupiter-api
+    )
+    find_jar(
+	    JUNIT5_ENGINE_JAR
+        NAMES junit-jupiter-engine junit5/junit-jupiter-engine
+    )
+    find_jar(
+	    JUNIT5_PLATFORM_COMMONS_JAR
+        NAMES junit-platform-commons junit5/junit-platform-commons
+    )
+    find_jar(
+	    JUNIT5_PLATFORM_ENGINE_JAR
+        NAMES junit-platform-engine junit5/junit-platform-engine
+    )
+    find_jar(
+	    JUNIT5_PLATFORM_LAUNCHER_JAR
+        NAMES junit-platform-launcher junit5/junit-platform-launcher
+    )
+    find_jar(
+	    OPENTEST4J_JAR
+        NAMES opentest4j opentest4j/opentest4j
+    )
+    find_jar(
         HAMCREST_JAR
         NAMES hamcrest/core hamcrest-core hamcrest/hamcrest
     )
@@ -253,13 +277,37 @@ macro(jss_config_java)
         message(FATAL_ERROR "Test dependency junit4.jar not found by find_jar! Tests will not compile.")
     endif()
 
+    if(JUNIT5_API_JAR STREQUAL "JUNIT5_API_JAR-NOTFOUND")
+        message(FATAL_ERROR "Test dependency JUnit 5 API not found by find_jar! Tests will not compile.")
+    endif()
+
+    if(JUNIT5_ENGINE_JAR STREQUAL "JUNIT5_ENGINE_JAR-NOTFOUND")
+        message(WARNING "Test dependency JUnit 5 engine not found by find_jar! Tests could not execute.")
+    endif()
+
+    if(JUNIT5_PLATFORM_COMMONS_JAR STREQUAL "JUNIT5_PLATFORM_COMMONS_JAR-NOTFOUND")
+        message(WARNING "Test dependency JUnit 5 platform commons not found by find_jar! Tests could not execute.")
+    endif()
+
+    if(JUNIT5_PLATFORM_ENGINE_JAR STREQUAL "JUNIT5_PLATFORM_ENGINE_JAR-NOTFOUND")
+        message(WARNING "Test dependency JUnit 5 platform engine not found by find_jar! Tests could not execute.")
+    endif()
+
+    if(JUNIT5_PLATFORM_LAUNCHER_JAR STREQUAL "JUNIT5_PLATFORM_LAUNCHER_JAR-NOTFOUND")
+        message(WARNING "Test dependency JUnit 5 platform launcher not found by find_jar! Tests could not execute.")
+    endif()
+
+    if(OPENTEST4J_JAR STREQUAL "OPENTEST4J_JAR-NOTFOUND")
+        message(WARNING "Test dependency opentest4j not found by find_jar! Tests could not execute.")
+    endif()
+
     if(HAMCREST_JAR STREQUAL "HAMCREST_JAR-NOTFOUND")
         message(WARNING "Test dependency hamcrest/core.jar not found by find_jar! Tests might not run properly.")
     endif()
 
     # Set class paths
     set(JAVAC_CLASSPATH "${SLF4J_API_JAR}:${LANG_JAR}")
-    set(TEST_CLASSPATH "${JSS_JAR_PATH}:${JSS_TESTS_JAR_PATH}:${JAVAC_CLASSPATH}:${SLF4J_JDK14_JAR}:${JUNIT4_JAR}:${HAMCREST_JAR}")
+    set(TEST_CLASSPATH "${JSS_JAR_PATH}:${JSS_TESTS_JAR_PATH}:${JAVAC_CLASSPATH}:${SLF4J_JDK14_JAR}:${JUNIT4_JAR}:${JUNIT5_API_JAR}:${JUNIT5_ENGINE_JAR}:${JUNIT5_PLATFORM_COMMONS_JAR}:${JUNIT5_PLATFORM_ENGINE_JAR}:${JUNIT5_PLATFORM_LAUNCHER_JAR}:${OPENTEST4J_JAR}:${HAMCREST_JAR}")
 
     message(STATUS "javac classpath: ${JAVAC_CLASSPATH}")
     message(STATUS "tests classpath: ${TEST_CLASSPATH}")
@@ -291,7 +339,7 @@ macro(jss_config_java)
 
     # Set compile flags for JSS test suite
     list(APPEND JSS_TEST_JAVAC_FLAGS "-classpath")
-    list(APPEND JSS_TEST_JAVAC_FLAGS "${JAVAC_CLASSPATH}:${JUNIT4_JAR}:${CLASSES_OUTPUT_DIR}")
+    list(APPEND JSS_TEST_JAVAC_FLAGS "${JAVAC_CLASSPATH}:${JUNIT4_JAR}:${JUNIT5_API_JAR}:${JUNIT5_PLATFORM_COMMONS_JAR}:${JUNIT5_PLATFORM_ENGINE_JAR}:${JUNIT5_PLATFORM_LAUNCHER_JAR}:${CLASSES_OUTPUT_DIR}")
     list(APPEND JSS_TEST_JAVAC_FLAGS "-sourcepath")
     list(APPEND JSS_TEST_JAVAC_FLAGS "${PROJECT_SOURCE_DIR}/base/src/main/java:${PROJECT_SOURCE_DIR}/base/src/test/java")
 

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -439,7 +439,7 @@ macro(jss_tests)
     )
     jss_test_java(
         NAME "JUnit_PrintableConverterTest"
-        COMMAND "org.junit.runner.JUnitCore" "org.mozilla.jss.tests.PrintableConverterTest"
+        COMMAND "org.mozilla.jss.tests.TestRunner" "org.mozilla.jss.tests.PrintableConverterTest"
     )
 
     if(TEST_WITH_INTERNET)

--- a/jss.spec
+++ b/jss.spec
@@ -91,7 +91,8 @@ BuildRequires:  maven-local
 BuildRequires:  mvn(org.apache.commons:commons-lang3)
 BuildRequires:  mvn(org.slf4j:slf4j-api)
 BuildRequires:  mvn(org.slf4j:slf4j-jdk14)
-BuildRequires:  mvn(junit:junit)
+BuildRequires:  mvn(org.junit.jupiter:junit-jupiter-engine)
+BuildRequires:  mvn(org.junit.vintage:junit-vintage-engine)
 
 %description
 Java Security Services (JSS) is a java native interface which provides a bridge

--- a/jss.spec
+++ b/jss.spec
@@ -91,8 +91,9 @@ BuildRequires:  maven-local
 BuildRequires:  mvn(org.apache.commons:commons-lang3)
 BuildRequires:  mvn(org.slf4j:slf4j-api)
 BuildRequires:  mvn(org.slf4j:slf4j-jdk14)
-BuildRequires:  mvn(org.junit.jupiter:junit-jupiter-engine)
+BuildRequires:  mvn(org.junit.jupiter:junit-jupiter)
 BuildRequires:  mvn(org.junit.vintage:junit-vintage-engine)
+BuildRequires:  mvn(org.opentest4j:opentest4j)
 
 %description
 Java Security Services (JSS) is a java native interface which provides a bridge


### PR DESCRIPTION
This is the first junit test converted to junit 5.

In order to run the test also a new runner class is introduced. 

Here the migration documentation: https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4

The remaining tests make use of junit 4 or makes use of a custom  approach. All of them could be converted to junit 5.

At compile time there is a warning with `org.apiguardian.api.API$Status` which seems related to a library problem in junit 5 but it can be ignored according to many post (e.g. https://stackoverflow.com/questions/46702273/warning-unknown-enum-constant-status-stable).