### PR TITLE
Suppress warnings for deprecated algorithms

### DIFF
--- a/base/src/main/java/org/mozilla/jss/JSSProvider.java
+++ b/base/src/main/java/org/mozilla/jss/JSSProvider.java
@@ -108,7 +108,7 @@ public final class JSSProvider extends java.security.Provider {
                     int lineNumber = stackTrace[i + 1].getLineNumber();
                     String methodName = stackTrace[i + 1].getMethodName();
                     String className = stackTrace[i + 1].getClassName();
-                    logger.warn(
+                    logger.debug(
                             "The {} algorithm used in {}::{}:{} is deprecated. Use a more secure algorithm.",
                             algorithm,
                             className,


### PR DESCRIPTION
Algorithms such as SHA-1 and MD5 are deprecated but they still have valid uses and in certain cases cannot be replaced easily. The problem is currently code that uses these algorithms generates warnings that can undermine user's confidence in the code. To avoid the problem, the warnings have been converted into regular debug messages which will only appear in debug mode.