### PR TITLE
Drop legacy CSR header/footer

### DIFF
--- a/base/src/main/java/org/mozilla/jss/pkcs11/PK11Token.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs11/PK11Token.java
@@ -28,6 +28,7 @@ import org.mozilla.jss.crypto.PQGParams;
 import org.mozilla.jss.crypto.SignatureAlgorithm;
 import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.TokenException;
+import org.mozilla.jss.netscape.security.util.Cert;
 import org.mozilla.jss.util.IncorrectPasswordException;
 import org.mozilla.jss.util.NotImplementedException;
 import org.mozilla.jss.util.NullPasswordCallback;
@@ -526,9 +527,7 @@ public final class PK11Token implements CryptoToken {
 						throw e;
 					}
 
-					return ("-----BEGIN NEW CERTIFICATE REQUEST-----\n"+
-							pk10String +
-							"\n-----END NEW CERTIFICATE REQUEST-----");
+					return Cert.REQUEST_HEADER + "\n"+ pk10String + "\n" + Cert.REQUEST_FOOTER;
 				} else if ((P == null) || (Q == null) || (G == null)) {
 					throw new InvalidParameterException("need all P, Q, and G");
 				}
@@ -545,9 +544,7 @@ public final class PK11Token implements CryptoToken {
 				throw e;
 			}
 
-			return ("-----BEGIN NEW CERTIFICATE REQUEST-----\n"+
-					pk10String +
-					"\n-----END NEW CERTIFICATE REQUEST-----");
+			return Cert.REQUEST_HEADER + "\n"+  pk10String + "\n" + Cert.REQUEST_FOOTER;
 	}
 
 	protected native String generatePK10(String subject, int keysize,


### PR DESCRIPTION
The `PK11Token.generateCertRequest()` has been modified to generate a CSR with the header and footer described in RFC 7468.

See also:

* https://datatracker.ietf.org/doc/html/rfc7468#section-7
* https://github.com/dogtagpki/pki/issues/3843