### PR TITLE
Add IPs address to the session

### DIFF
--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -1262,9 +1262,10 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             }
         } while (this_src_write != 0 || this_dst_write != 0);
 
-        if (seen_exception == false && ssl_exception == null) {
-            ssl_exception = checkSSLAlerts();
-            seen_exception = (ssl_exception != null);
+        SSLException checkException = checkSSLAlerts();
+        if (checkException != null && !seen_exception) {
+            ssl_exception = checkException;
+            seen_exception = true;
         }
 
         // Before we return, check if an exception occurred and throw it if

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -968,7 +968,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             }
 
             debug("JSSEngine: Got inbound alert: " + event);
-
+            event.setEngine(this);
             // Fire inbound alert prior to raising any exception.
             fireAlertReceived(event);
 
@@ -991,7 +991,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             }
 
             debug("JSSEngine: Got outbound alert: " + event);
-
+            event.setEngine(this);
             // Fire outbound alert prior to raising any exception. Note that
             // this still triggers after this alert is written to the output
             // wire buffer.

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSession.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSession.java
@@ -1,16 +1,23 @@
 package org.mozilla.jss.ssl.javax;
 
-import java.lang.AutoCloseable;
-import java.security.cert.Certificate;
-import javax.security.cert.X509Certificate;
 import java.security.Principal;
+import java.security.cert.Certificate;
 import java.util.HashMap;
 
-import javax.net.ssl.*;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSessionBindingEvent;
+import javax.net.ssl.SSLSessionBindingListener;
+import javax.net.ssl.SSLSessionContext;
+import javax.security.cert.X509Certificate;
 
-import org.mozilla.jss.nss.*;
-import org.mozilla.jss.pkcs11.*;
-import org.mozilla.jss.ssl.*;
+import org.mozilla.jss.nss.SSL;
+import org.mozilla.jss.nss.SSLChannelInfo;
+import org.mozilla.jss.nss.SSLFDProxy;
+import org.mozilla.jss.nss.SSLPreliminaryChannelInfo;
+import org.mozilla.jss.pkcs11.PK11Cert;
+import org.mozilla.jss.ssl.SSLCipher;
+import org.mozilla.jss.ssl.SSLVersion;
 
 public class JSSSession implements SSLSession, AutoCloseable {
     private static final int MAX_TLS_RECORD_PAYLOAD = (1 << 14);
@@ -34,6 +41,9 @@ public class JSSSession implements SSLSession, AutoCloseable {
 
     private String peerHost;
     private int peerPort;
+
+    private String localAddr;
+    private String remoteAddr;
 
     private Principal peerPrincipal;
     private X509Certificate[] peerChain;
@@ -315,4 +325,21 @@ public class JSSSession implements SSLSession, AutoCloseable {
     public void setPeerPort(int port) {
         peerPort = port;
     }
+
+    public String getLocalAddr() {
+        return localAddr;
+    }
+
+    public void setLocalAddr(String localAddr) {
+        this.localAddr = localAddr;
+    }
+
+    public String getRemoteAddr() {
+        return remoteAddr;
+    }
+
+    public void setRemoteAddr(String remoteAddr) {
+        this.remoteAddr = remoteAddr;
+    }
+
 }


### PR DESCRIPTION
The SSLEngine session "JSSSession" has been extended to container the IP addresses of the client and the server. These are used for the audit and have not other use in the protocol. By design the SSLEngine should be unaware of the underlying communication but this is need to keep the original audit format required for the certification.