### PR TITLE
Hard-code version number in pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ src/*.a
 src/*.o
 target/
 .flattened-pom.xml
+*.versionsBackup
 
 # These files are automatically generated from their .in equivalents
 org/mozilla/jss/util/jssver.h

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
-        <version>${revision}</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jss-base</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
-        <version>${revision}</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jss-examples</artifactId>

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
-        <version>${revision}</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>libjss</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,10 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dogtagpki.jss</groupId>
     <artifactId>jss-parent</artifactId>
-    <version>${revision}</version>
+    <version>5.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
-        <revision>5.5.0-SNAPSHOT</revision>
         <sonar.organization>dogtagpki</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.c.file.suffixes>-</sonar.c.file.suffixes>

--- a/symkey/pom.xml
+++ b/symkey/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
-        <version>${revision}</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>libjss-symkey</artifactId>


### PR DESCRIPTION
Some build systems require hard-coding the version number in `pom.xml`, so the `revision` property has been replaced with the actual version number. Updating the version number can be done with the following commands:

```
$ mvn versions:set -DnewVersion=<version>
$ mvn versions:commit
```

The `.gitignore` has been updated to ignore the backup files created by this command.