### PR TITLE
Import Tomcat JSS project

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,6 +4,8 @@
 	<classpathentry kind="src" path="base/src/test/java"/>
 	<classpathentry kind="src" path="base/src/broken_test/java"/>
 	<classpathentry kind="src" path="examples/src/main/java"/>
+	<classpathentry kind="src" path="tomcat/src/main/java"/>
+	<classpathentry kind="src" path="tomcat-9.0/src/main/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="module" value="true"/>
@@ -12,6 +14,10 @@
 	<classpathentry kind="lib" path="/usr/share/java/slf4j/slf4j-api.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/slf4j/slf4j-simple.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/apache-commons-lang3.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/tomcat/catalina.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/tomcat/tomcat-coyote.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/tomcat/tomcat-juli.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/tomcat/tomcat-util.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/opentest4j/opentest4j.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-testkit.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-suite-commons.jar"/>

--- a/docs/changes/v5.5.0/Packaging-Changes.adoc
+++ b/docs/changes/v5.5.0/Packaging-Changes.adoc
@@ -1,0 +1,10 @@
+= Packaging Changes =
+
+== New jss-tomcat RPM package ==
+
+A new `jss-tomcat` RPM package has been added to provide a JSS Connector for Tomcat.
+This package will replace Tomcat JSS with the following changes:
+
+* All classes are moved into `org.dogtagpki.jss.tomcat` package.
+* Generic Tomcat classes are packaged into `jss-tomcat.jar`.
+* Tomcat 9.0 classes are packaged into `jss-tomcat-9.0.jar`.

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
         <module>native</module>
         <module>symkey</module>
         <module>examples</module>
+        <module>tomcat</module>
+        <module>tomcat-9.0</module>
     </modules>
 
     <build>

--- a/tomcat-9.0/pom.xml
+++ b/tomcat-9.0/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki.jss</groupId>
+        <artifactId>jss-parent</artifactId>
+        <version>5.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jss-tomcat-9.0</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-juli</artifactId>
+            <version>9.0.50</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jss-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jss-tomcat</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+        <finalName>jss-tomcat-9.0</finalName>
+    </build>
+
+</project>

--- a/tomcat-9.0/src/main/java/org/dogtagpki/jss/tomcat/JSSContext.java
+++ b/tomcat-9.0/src/main/java/org/dogtagpki/jss/tomcat/JSSContext.java
@@ -1,0 +1,123 @@
+package org.dogtagpki.jss.tomcat;
+
+import java.security.KeyManagementException;
+import java.security.SecureRandom;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.mozilla.jss.JSSProvider;
+import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
+import org.mozilla.jss.provider.javax.crypto.JSSTrustManager;
+import org.mozilla.jss.ssl.javax.JSSEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JSSContext implements org.apache.tomcat.util.net.SSLContext {
+    public static Logger logger = LoggerFactory.getLogger(JSSContext.class);
+
+    private javax.net.ssl.SSLContext ctx;
+    private String alias;
+
+    private JSSKeyManager jkm;
+    private JSSTrustManager jtm;
+
+    public JSSContext(String alias) {
+        logger.debug("JSSContext(" + alias + ")");
+        this.alias = alias;
+
+        /* These KeyManagers and TrustManagers aren't used with the SSLEngine;
+         * they're only used to implement certain function calls below. */
+        try {
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance("NssX509", "Mozilla-JSS");
+            jkm = (JSSKeyManager) kmf.getKeyManagers()[0];
+
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance("NssX509", "Mozilla-JSS");
+            jtm = (JSSTrustManager) tmf.getTrustManagers()[0];
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void init(KeyManager[] kms, TrustManager[] tms, SecureRandom sr) throws KeyManagementException {
+        logger.debug("JSSContext.init(...)");
+
+        try {
+            String provider = "SunJSSE";
+            if (JSSProvider.ENABLE_JSSENGINE) {
+                provider = "Mozilla-JSS";
+            }
+
+            ctx = javax.net.ssl.SSLContext.getInstance("TLS", provider);
+            ctx.init(kms, tms, sr);
+        } catch (Exception e) {
+            throw new KeyManagementException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public javax.net.ssl.SSLEngine createSSLEngine() {
+        logger.debug("JSSContext.createSSLEngine()");
+        javax.net.ssl.SSLEngine eng = ctx.createSSLEngine();
+
+	TomcatJSS instance = TomcatJSS.getInstance();
+
+        if (eng instanceof JSSEngine) {
+            JSSEngine j_eng = (JSSEngine) eng;
+            j_eng.setCertFromAlias(alias);
+            if(instance != null) {
+                j_eng.setListeners(instance.getSocketListeners());
+            }
+        }
+
+        return eng;
+    }
+
+    @Override
+    public javax.net.ssl.SSLSessionContext getServerSessionContext() {
+        logger.debug("JSSContext.getServerSessionContext()");
+        return ctx.getServerSessionContext();
+    }
+
+    @Override
+    public javax.net.ssl.SSLServerSocketFactory getServerSocketFactory() {
+        logger.debug("JSSContext.getServerSocketFactory()");
+        return ctx.getServerSocketFactory();
+    }
+
+    @Override
+    public javax.net.ssl.SSLParameters getSupportedSSLParameters() {
+        logger.debug("JSSContext.getSupportedSSLParameters()");
+        return ctx.getSupportedSSLParameters();
+    }
+
+    @Override
+    public java.security.cert.X509Certificate[] getCertificateChain(java.lang.String alias) {
+        logger.debug("JSSContext.getCertificateChain(" + alias + ")");
+
+        try {
+            return jkm.getCertificateChain(alias);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+        logger.debug("JSSContext.getAcceptedIssuers()");
+
+        try {
+            return jtm.getAcceptedIssuers();
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        logger.debug("JSSContext.destroy()");
+    }
+}

--- a/tomcat-9.0/src/main/java/org/dogtagpki/jss/tomcat/JSSImplementation.java
+++ b/tomcat-9.0/src/main/java/org/dogtagpki/jss/tomcat/JSSImplementation.java
@@ -1,0 +1,66 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2007 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.jss.tomcat;
+
+import javax.net.ssl.SSLSession;
+
+import org.apache.tomcat.util.net.SSLHostConfig;
+import org.apache.tomcat.util.net.SSLHostConfigCertificate;
+import org.apache.tomcat.util.net.SSLImplementation;
+import org.apache.tomcat.util.net.SSLSupport;
+import org.apache.tomcat.util.net.SSLUtil;
+import org.apache.tomcat.util.net.jsse.JSSESupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JSSImplementation extends SSLImplementation {
+
+    public static final Logger logger = LoggerFactory.getLogger(JSSImplementation.class);
+
+    public JSSImplementation() {
+        logger.debug("JSSImplementation: instance created");
+    }
+
+    @Override
+    public SSLSupport getSSLSupport(SSLSession session) {
+        logger.debug("JSSImplementation.getSSLSupport()");
+        return new JSSESupport(session, null);
+    }
+
+    @Override
+    public SSLUtil getSSLUtil(SSLHostConfigCertificate cert) {
+        logger.debug("JSSImplementation: getSSLUtil()");
+        logger.debug("JSSImplementation: key alias: {}", cert.getCertificateKeyAlias());
+        logger.debug("JSSImplementation: keystore provider: {}", cert.getCertificateKeystoreProvider());
+
+        SSLHostConfig hostConfig = cert.getSSLHostConfig();
+        logger.debug("JSSImplementation: key manager alg: {}", hostConfig.getKeyManagerAlgorithm());
+        logger.debug("JSSImplementation: truststore alg: {}", hostConfig.getTruststoreAlgorithm());
+        logger.debug("JSSImplementation: truststore provider: {}", hostConfig.getTruststoreProvider());
+
+        return new JSSUtil(cert);
+    }
+
+    @Override
+    public boolean isAlpnSupported() {
+        // NSS supports ALPN but JSS doesn't yet support ALPN.
+        return false;
+    }
+}

--- a/tomcat-9.0/src/main/java/org/dogtagpki/jss/tomcat/JSSUtil.java
+++ b/tomcat-9.0/src/main/java/org/dogtagpki/jss/tomcat/JSSUtil.java
@@ -1,0 +1,130 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.jss.tomcat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.net.SSLContext;
+import org.apache.tomcat.util.net.SSLHostConfigCertificate;
+import org.apache.tomcat.util.net.SSLUtilBase;
+import org.mozilla.jss.JSSProvider;
+import org.mozilla.jss.provider.javax.crypto.JSSNativeTrustManager;
+
+public class JSSUtil extends SSLUtilBase {
+    public static Log logger = LogFactory.getLog(JSSUtil.class);
+
+    private String keyAlias;
+
+    private SSLEngine engine;
+    private Set<String> protocols;
+    private Set<String> ciphers;
+
+    public JSSUtil(SSLHostConfigCertificate cert) {
+        super(cert);
+
+        keyAlias = certificate.getCertificateKeyAlias();
+        logger.debug("JSSUtil: instance created");
+    }
+
+    private void init() {
+        if (engine != null) {
+            return;
+        }
+
+        try {
+            JSSContext ctx = new JSSContext(null);
+            ctx.init(null, null, null);
+            engine = ctx.createSSLEngine();
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+
+        protocols = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(engine.getSupportedProtocols()))
+        );
+
+        ciphers = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(engine.getSupportedCipherSuites()))
+        );
+    }
+
+    @Override
+    public KeyManager[] getKeyManagers() throws Exception {
+        logger.debug("JSSUtil: getKeyManagers()");
+        KeyManagerFactory jkm = KeyManagerFactory.getInstance("NssX509", "Mozilla-JSS");
+        return jkm.getKeyManagers();
+    }
+
+    @Override
+    public TrustManager[] getTrustManagers() throws Exception {
+        logger.debug("JSSUtil: getTrustManagers()");
+        if (!JSSProvider.ENABLE_JSSENGINE) {
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance("NssX509");
+            return tmf.getTrustManagers();
+        }
+
+        return new TrustManager[] { new JSSNativeTrustManager() };
+    }
+
+    @Override
+    public SSLContext createSSLContextInternal(List<String> negotiableProtocols) throws Exception {
+        logger.debug("JSSUtil createSSLContextInternal(...) keyAlias=" + keyAlias);
+        return new JSSContext(keyAlias);
+    }
+
+    @Override
+    public boolean isTls13RenegAuthAvailable() {
+        logger.debug("JSSUtil: isTls13RenegAuthAvailable()");
+        return true;
+    }
+
+    @Override
+    public Log getLog() {
+        logger.debug("JSSUtil: getLog()");
+        return logger;
+    }
+
+    @Override
+    protected Set<String> getImplementedProtocols() {
+        logger.debug("JSSUtil: getImplementedProtocols()");
+        init();
+        return protocols;
+    }
+
+    @Override
+    protected Set<String> getImplementedCiphers() {
+        logger.debug("JSSUtil: getImplementedCiphers()");
+        init();
+
+        return ciphers;
+    }
+}

--- a/tomcat/pom.xml
+++ b/tomcat/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki.jss</groupId>
+        <artifactId>jss-parent</artifactId>
+        <version>5.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jss-tomcat</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <version>9.0.50</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-coyote</artifactId>
+            <version>9.0.50</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jss-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+        <finalName>jss-tomcat</finalName>
+    </build>
+
+</project>

--- a/tomcat/src/main/java/org/dogtagpki/jss/tomcat/Http11NioProtocol.java
+++ b/tomcat/src/main/java/org/dogtagpki/jss/tomcat/Http11NioProtocol.java
@@ -1,0 +1,126 @@
+package org.dogtagpki.jss.tomcat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Http11NioProtocol extends org.apache.coyote.http11.Http11NioProtocol {
+
+    public static Logger logger = LoggerFactory.getLogger(Http11NioProtocol.class);
+
+    TomcatJSS tomcatjss = TomcatJSS.getInstance();
+
+    public String getCertdbDir() {
+        return tomcatjss.getCertdbDir();
+    }
+
+    public void setCertdbDir(String certdbDir) {
+        tomcatjss.setCertdbDir(certdbDir);
+    }
+
+    public String getPasswordClass() {
+        return tomcatjss.getPasswordClass();
+    }
+
+    public void setPasswordClass(String passwordClass) {
+        tomcatjss.setPasswordClass(passwordClass);
+    }
+
+    public String getPasswordFile() {
+        return tomcatjss.getPasswordFile();
+    }
+
+    public void setPasswordFile(String passwordFile) {
+        tomcatjss.setPasswordFile(passwordFile);
+    }
+
+    public String getServerCertNickFile() {
+        return tomcatjss.getServerCertNickFile();
+    }
+
+    public void setServerCertNickFile(String serverCertNickFile) {
+        tomcatjss.setServerCertNickFile(serverCertNickFile);
+    }
+
+    public boolean getEnabledOCSP() {
+        return tomcatjss.getEnableOCSP();
+    }
+
+    public void setEnableOCSP(boolean enableOCSP) {
+        tomcatjss.setEnableOCSP(enableOCSP);
+    }
+
+    public String getOcspResponderURL() {
+        return tomcatjss.getOcspResponderURL();
+    }
+
+    public void setOcspResponderURL(String ocspResponderURL) {
+        tomcatjss.setOcspResponderURL(ocspResponderURL);
+    }
+
+    public String getOcspResponderCertNickname() {
+        return tomcatjss.getOcspResponderCertNickname();
+    }
+
+    public void setOcspResponderCertNickname(String ocspResponderCertNickname) {
+        tomcatjss.setOcspResponderCertNickname(ocspResponderCertNickname);
+    }
+
+    public int getOcspCacheSize() {
+        return tomcatjss.getOcspCacheSize();
+    }
+
+    public void setOcspCacheSize(int ocspCacheSize) {
+        tomcatjss.setOcspCacheSize(ocspCacheSize);
+    }
+
+    public int getOcspMinCacheEntryDuration() {
+        return tomcatjss.getOcspMinCacheEntryDuration();
+    }
+
+    public void setOcspMinCacheEntryDuration(int ocspMinCacheEntryDuration) {
+        tomcatjss.setOcspMinCacheEntryDuration(ocspMinCacheEntryDuration);
+    }
+
+    public int getOcspMaxCacheEntryDuration() {
+        return tomcatjss.getOcspMaxCacheEntryDuration();
+    }
+
+    public void setOcspMaxCacheEntryDuration(int ocspMaxCacheEntryDuration) {
+        tomcatjss.setOcspMaxCacheEntryDuration(ocspMaxCacheEntryDuration);
+    }
+
+    public int getOcspTimeout() {
+        return tomcatjss.getOcspTimeout();
+    }
+
+    public void setOcspTimeout(int ocspTimeout) {
+        tomcatjss.setOcspTimeout(ocspTimeout);
+    }
+
+    public void setKeystorePassFile(String keystorePassFile) {
+        try {
+            Path path = Paths.get(keystorePassFile);
+            String password = new String(Files.readAllBytes(path)).trim();
+            setKeystorePass(password);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void setTruststorePassFile(String truststorePassFile) {
+        try {
+            Path path = Paths.get(truststorePassFile);
+            String password = new String(Files.readAllBytes(path)).trim();
+            setTruststorePass(password);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tomcat/src/main/java/org/dogtagpki/jss/tomcat/IPasswordStore.java
+++ b/tomcat/src/main/java/org/dogtagpki/jss/tomcat/IPasswordStore.java
@@ -1,0 +1,38 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2007 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.jss.tomcat;
+
+import java.io.IOException;
+import java.util.Enumeration;
+
+public interface IPasswordStore {
+    public void init(String pwdPath) throws IOException;
+
+    public String getPassword(String tag, int iteration);
+
+    public String getPassword(String tag);
+
+    public Enumeration<String> getTags();
+
+    public Object putPassword(String tag, String password);
+
+    public void commit() throws IOException, ClassCastException,
+            NullPointerException;
+}

--- a/tomcat/src/main/java/org/dogtagpki/jss/tomcat/JSSListener.java
+++ b/tomcat/src/main/java/org/dogtagpki/jss/tomcat/JSSListener.java
@@ -1,0 +1,65 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.jss.tomcat;
+
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JSSListener implements LifecycleListener {
+
+    final static Logger logger = LoggerFactory.getLogger(JSSListener.class);
+
+    public String configFile;
+
+    public String getConfigFile() {
+        return configFile;
+    }
+
+    public void setConfigFile(String configFile) {
+        this.configFile = configFile;
+    }
+
+    @Override
+    public void lifecycleEvent(LifecycleEvent event) {
+
+        String type = event.getType();
+
+        if (type.equals(Lifecycle.BEFORE_INIT_EVENT)) {
+            initJSS();
+        }
+    }
+
+    public void initJSS() {
+
+        logger.info("JSSListener: Initializing JSS");
+
+        try {
+            TomcatJSS tomcatjss = TomcatJSS.getInstance();
+            tomcatjss.loadConfig();
+            tomcatjss.init();
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tomcat/src/main/java/org/dogtagpki/jss/tomcat/PlainPasswordFile.java
+++ b/tomcat/src/main/java/org/dogtagpki/jss/tomcat/PlainPasswordFile.java
@@ -1,0 +1,156 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2007 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.jss.tomcat;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Enumeration;
+import java.util.Properties;
+
+public class PlainPasswordFile implements IPasswordStore {
+    private String mPwdPath = "";
+    private Properties mPwdStore;
+    private static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PlainPasswordFile.class);
+
+    public PlainPasswordFile() {
+        mPwdStore = new Properties();
+    }
+
+    /**
+     * Initialization method to read passwords(key and element pairs) from a file.
+     * <p>
+     * Every property occupies one line of the input stream. Each line is terminated by a line terminator (
+     * <code>\n</code> or <code>\r</code> or <code>\r\n</code>). Lines are processed until end of
+     * file is reached.
+     * <p>
+     * A line that contains only whitespace or whose first non-whitespace character is an ASCII <code>#</code>
+     * is ignored (thus, <code>#</code> indicates comment line).
+     * <p>
+     * Every line other than a blank line or a comment line describes one property to be added to the table.
+     * The characters before the delimiter <code>=</code> forms the <code>key</code> and the characters after
+     * the <code>=</code> is assigned as <code>value</code> to the key.
+     * <p>
+     * As an example, each of the following lines specify the key <code>"Truth"</code> and the associated element
+     * value <code>"Beauty"</code>:
+     * <p>
+     *
+     * <pre>
+     * Truth = Beauty
+     * Truth= Beauty
+     * Truth                    =Beauty
+     * </pre>
+     *
+     * <p>
+     * Note that the space appearing before/after <code>=</code> is ignored. However, the space appearing in between are
+     * stored.
+     * <p>
+     * Example:
+     *
+     * <pre>
+     * Welcome Message  = Hello World
+     * </pre>
+     *
+     * assigns value <code>Hello World</code> to key <code>Welcome Message</code>
+     * <p>
+     *
+     * If the line doesn't have the delimiter <code>=</code>, the method throws an IOException
+     *
+     * @param pwdPath the input file path.
+     * @exception IOException if an error occurred when reading from the
+     *                input stream.
+     */
+    @Override
+    public void init(String pwdPath) throws IOException {
+        logger.debug("PlainPasswordFile: Initializing PlainPasswordFile");
+        // initialize mPwdStore
+        mPwdPath = pwdPath;
+
+        try (FileInputStream file = new FileInputStream(mPwdPath);
+                InputStreamReader isr = new InputStreamReader(file);
+                BufferedReader br = new BufferedReader(isr)) {
+
+            String line;
+            int index = 1;
+            while ((line = br.readLine()) != null) {
+                // Remove any leading or trailing spaces
+                line = line.trim();
+
+                if (line.startsWith("#") || line.isEmpty())
+                    continue;
+
+                String[] parts = line.split("=", 2);
+                if (parts.length < 2) {
+                    throw new IOException("Missing delimiter '=' in file " + mPwdPath + " in line " + index);
+                }
+
+                // Load key value into the password store
+                mPwdStore.put(parts[0].trim(), parts[1].trim());
+                index++;
+            }
+        }
+    }
+
+    @Override
+    public String getPassword(String tag) {
+        return getPassword(tag, 0);
+    }
+
+    @Override
+    public String getPassword(String tag, int iteration) {
+        return mPwdStore.getProperty(tag);
+    }
+
+    // return an array of String-based tag
+    @Override
+    @SuppressWarnings("unchecked")
+    public Enumeration<String> getTags() {
+        return (Enumeration<String>) mPwdStore.propertyNames();
+    }
+
+    @Override
+    public Object putPassword(String tag, String password) {
+        return mPwdStore.setProperty(tag, password);
+    }
+
+    @Override
+    public synchronized void commit()
+            throws IOException, ClassCastException, NullPointerException {
+        try (FileOutputStream file = new FileOutputStream(mPwdPath);
+                OutputStreamWriter osw = new OutputStreamWriter(file);
+                BufferedWriter bw = new BufferedWriter(osw)) {
+
+            for (Enumeration<?> e = mPwdStore.keys(); e.hasMoreElements();) {
+                String key = ((String) e.nextElement()).trim();
+                String val = ((String) mPwdStore.get(key)).trim();
+                bw.write(key + "=" + val);
+                bw.newLine();
+            }
+        }
+    }
+
+    public int getSize() {
+        return mPwdStore.size();
+    }
+}

--- a/tomcat/src/main/java/org/dogtagpki/jss/tomcat/TomcatJSS.java
+++ b/tomcat/src/main/java/org/dogtagpki/jss/tomcat/TomcatJSS.java
@@ -1,0 +1,615 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.jss.tomcat;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Properties;
+
+import javax.naming.ConfigurationException;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mozilla.jss.CertDatabaseException;
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.InitializationValues;
+import org.mozilla.jss.KeyDatabaseException;
+import org.mozilla.jss.NoSuchTokenException;
+import org.mozilla.jss.NotInitializedException;
+import org.mozilla.jss.crypto.AlreadyInitializedException;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.crypto.TokenException;
+import org.mozilla.jss.ssl.SSLAlertEvent;
+import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
+import org.mozilla.jss.ssl.SSLServerSocket;
+import org.mozilla.jss.ssl.SSLSocketListener;
+import org.mozilla.jss.util.IncorrectPasswordException;
+import org.mozilla.jss.util.Password;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+public class TomcatJSS implements SSLSocketListener {
+
+    public static final Logger logger = LoggerFactory.getLogger(TomcatJSS.class);
+
+    public static final TomcatJSS INSTANCE = new TomcatJSS();
+    public static final int MAX_LOGIN_ATTEMPTS = 3;
+    public static final String CATALINA_BASE = "catalina.base";
+
+    public static TomcatJSS getInstance() { return INSTANCE; }
+
+    Collection<SSLSocketListener> socketListeners = new ArrayList<>();
+
+    String certdbDir;
+    CryptoManager manager;
+
+    String passwordClass;
+    String passwordFile;
+    IPasswordStore passwordStore;
+
+    String serverCertNickFile;
+    String serverCertNick;
+
+    String clientAuth = "want";
+    boolean requireClientAuth;
+    boolean wantClientAuth;
+
+    boolean enableOCSP;
+    String ocspResponderURL;
+    String ocspResponderCertNickname;
+    int ocspCacheSize = 1000; // entries
+    int ocspMinCacheEntryDuration = 3600; // seconds (default: 1 hour)
+    int ocspMaxCacheEntryDuration = 86400; // seconds (default: 24 hours)
+    int ocspTimeout = 60; // seconds (default: 1 minute)
+
+    String strictCiphers;
+    boolean boolStrictCiphers;
+
+    String sslRangeCiphers;
+    String sslOptions;
+    String ssl2Ciphers;
+    String ssl3Ciphers;
+    String tlsCiphers;
+
+    boolean initialized;
+
+    public void addSocketListener(SSLSocketListener listener) {
+        socketListeners.add(listener);
+    }
+
+    public void removeSocketListener(SSLSocketListener listener) {
+        socketListeners.remove(listener);
+    }
+
+    public Collection<SSLSocketListener> getSocketListeners() {
+        return socketListeners;
+    }
+
+    public String getCertdbDir() {
+        return certdbDir;
+    }
+
+    public void setCertdbDir(String certdbDir) {
+        this.certdbDir = certdbDir;
+    }
+
+    public String getPasswordClass() {
+        return passwordClass;
+    }
+
+    public void setPasswordClass(String passwordClass) {
+        this.passwordClass = passwordClass;
+    }
+
+    public String getPasswordFile() {
+        return passwordFile;
+    }
+
+    public void setPasswordFile(String passwordFile) {
+        this.passwordFile = passwordFile;
+    }
+
+    public String getServerCertNickFile() {
+        return serverCertNickFile;
+    }
+
+    public IPasswordStore getPasswordStore() {
+        return passwordStore;
+    }
+
+    public void setPasswordStore(IPasswordStore passwordStore) {
+        this.passwordStore = passwordStore;
+    }
+
+    public void setServerCertNickFile(String serverCertNickFile) {
+        this.serverCertNickFile = serverCertNickFile;
+    }
+
+    public String getServerCertNick() {
+        return serverCertNick;
+    }
+
+    public void setServerCertNick(String serverCertNick) {
+        this.serverCertNick = serverCertNick;
+    }
+
+    public String getClientAuth() {
+        return clientAuth;
+    }
+
+    public void setClientAuth(String clientAuth) {
+        this.clientAuth = clientAuth;
+    }
+
+    public boolean getRequireClientAuth() {
+        return requireClientAuth;
+    }
+
+    public boolean getWantClientAuth() {
+        return wantClientAuth;
+    }
+
+    public boolean getEnableOCSP() {
+        return enableOCSP;
+    }
+
+    public void setEnableOCSP(boolean enableOCSP) {
+        this.enableOCSP = enableOCSP;
+    }
+
+    public String getOcspResponderURL() {
+        return ocspResponderURL;
+    }
+
+    public void setOcspResponderURL(String ocspResponderURL) {
+        this.ocspResponderURL = ocspResponderURL;
+    }
+
+    public String getOcspResponderCertNickname() {
+        return ocspResponderCertNickname;
+    }
+
+    public void setOcspResponderCertNickname(String ocspResponderCertNickname) {
+        this.ocspResponderCertNickname = ocspResponderCertNickname;
+    }
+
+    public int getOcspCacheSize() {
+        return ocspCacheSize;
+    }
+
+    public void setOcspCacheSize(int ocspCacheSize) {
+        this.ocspCacheSize = ocspCacheSize;
+    }
+
+    public int getOcspMinCacheEntryDuration() {
+        return ocspMinCacheEntryDuration;
+    }
+
+    public void setOcspMinCacheEntryDuration(int ocspMinCacheEntryDuration) {
+        this.ocspMinCacheEntryDuration = ocspMinCacheEntryDuration;
+    }
+
+    public int getOcspMaxCacheEntryDuration() {
+        return ocspMaxCacheEntryDuration;
+    }
+
+    public void setOcspMaxCacheEntryDuration(int ocspMaxCacheEntryDuration) {
+        this.ocspMaxCacheEntryDuration = ocspMaxCacheEntryDuration;
+    }
+
+    public int getOcspTimeout() {
+        return ocspTimeout;
+    }
+
+    public void setOcspTimeout(int ocspTimeout) {
+        this.ocspTimeout = ocspTimeout;
+    }
+
+    public void loadJSSConfig(String jssConf) throws IOException {
+        File configFile = new File(jssConf);
+        loadJSSConfig(configFile);
+    }
+
+    public void loadJSSConfig(File configFile) throws IOException {
+
+        Properties config = new Properties();
+        try (FileReader fr = new FileReader(configFile)) {
+            config.load(fr);
+            loadJSSConfig(config);
+        }
+    }
+
+    public void loadJSSConfig(Properties config) {
+
+        String certdbDirProp = config.getProperty("certdbDir");
+        if (certdbDirProp != null)
+            setCertdbDir(certdbDirProp);
+
+        String passwordClassProp = config.getProperty("passwordClass");
+        if (passwordClassProp != null)
+            setPasswordClass(passwordClassProp);
+
+        String passwordFileProp = config.getProperty("passwordFile");
+        if (passwordFileProp != null)
+            setPasswordFile(passwordFileProp);
+
+        String enableOCSPProp = config.getProperty("enableOCSP");
+        if (enableOCSPProp != null)
+            setEnableOCSP(Boolean.parseBoolean(enableOCSPProp));
+
+        String ocspResponderURLProp = config.getProperty("ocspResponderURL");
+        if (ocspResponderURLProp != null)
+            setOcspResponderURL(ocspResponderURLProp);
+
+        String ocspResponderCertNicknameProp = config.getProperty("ocspResponderCertNickname");
+        if (ocspResponderCertNicknameProp != null)
+            setOcspResponderCertNickname(ocspResponderCertNicknameProp);
+
+        String ocspCacheSizeProp = config.getProperty("ocspCacheSize");
+        if (StringUtils.isNotEmpty(ocspCacheSizeProp))
+            setOcspCacheSize(Integer.parseInt(ocspCacheSizeProp));
+
+        String ocspMinCacheEntryDurationProp = config.getProperty("ocspMinCacheEntryDuration");
+        if (StringUtils.isNotEmpty(ocspMinCacheEntryDurationProp))
+            setOcspMinCacheEntryDuration(Integer.parseInt(ocspMinCacheEntryDurationProp));
+
+        String ocspMaxCacheEntryDurationProp = config.getProperty("ocspMaxCacheEntryDuration");
+        if (StringUtils.isNotEmpty(ocspMaxCacheEntryDurationProp))
+            setOcspMaxCacheEntryDuration(Integer.parseInt(ocspMaxCacheEntryDurationProp));
+
+        String ocspTimeoutProp = config.getProperty("ocspTimeout");
+        if (StringUtils.isNotEmpty(ocspTimeoutProp))
+            setOcspTimeout(Integer.parseInt(ocspTimeoutProp));
+    }
+
+    public void loadTomcatConfig(String serverXml)
+            throws ParserConfigurationException, SAXException, IOException, XPathExpressionException {
+        File configFile = new File(serverXml);
+        loadTomcatConfig(configFile);
+    }
+
+    public void loadTomcatConfig(File configFile)
+            throws ParserConfigurationException, SAXException, IOException, XPathExpressionException {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.parse(configFile);
+
+        loadTomcatConfig(document);
+    }
+
+    public void loadTomcatConfig(Document document) throws XPathExpressionException {
+
+        XPathFactory xPathfactory = XPathFactory.newInstance();
+        XPath xpath = xPathfactory.newXPath();
+
+        Element connector = (Element) xpath.evaluate(
+                "/Server/Service[@name='Catalina']/Connector[@SSLEnabled='true']",
+                document, XPathConstants.NODE);
+
+        String certDbProp = connector.getAttribute("certdbDir");
+        if (certDbProp != null)
+            setCertdbDir(certDbProp);
+
+        String passwordClassProp = connector.getAttribute("passwordClass");
+        if (passwordClassProp != null)
+            setPasswordClass(passwordClassProp);
+
+        String passwordFileProp = connector.getAttribute("passwordFile");
+        if (passwordFileProp != null)
+            setPasswordFile(passwordFileProp);
+
+        String serverCertNickFileProp = connector.getAttribute("serverCertNickFile");
+        if (serverCertNickFileProp != null)
+            setServerCertNickFile(serverCertNickFileProp);
+
+        String enableOCSPProp = connector.getAttribute("enableOCSP");
+        if (enableOCSPProp != null)
+            setEnableOCSP(Boolean.parseBoolean(enableOCSPProp));
+
+        String ocspResponderURLProp = connector.getAttribute("ocspResponderURL");
+        if (ocspResponderURLProp != null)
+            setOcspResponderURL(ocspResponderURLProp);
+
+        String ocspResponderCertNicknameProp = connector.getAttribute("ocspResponderCertNickname");
+        if (ocspResponderCertNicknameProp != null)
+            setOcspResponderCertNickname(ocspResponderCertNicknameProp);
+
+        String ocspCacheSizeProp = connector.getAttribute("ocspCacheSize");
+        if (StringUtils.isNotEmpty(ocspCacheSizeProp))
+            setOcspCacheSize(Integer.parseInt(ocspCacheSizeProp));
+
+        String ocspMinCacheEntryDurationProp = connector.getAttribute("ocspMinCacheEntryDuration");
+        if (StringUtils.isNotEmpty(ocspMinCacheEntryDurationProp))
+            setOcspMinCacheEntryDuration(Integer.parseInt(ocspMinCacheEntryDurationProp));
+
+        String ocspMaxCacheEntryDurationProp = connector.getAttribute("ocspMaxCacheEntryDuration");
+        if (StringUtils.isNotEmpty(ocspMaxCacheEntryDurationProp))
+            setOcspMaxCacheEntryDuration(Integer.parseInt(ocspMaxCacheEntryDurationProp));
+
+        String ocspTimeoutProp = connector.getAttribute("ocspTimeout");
+        if (StringUtils.isNotEmpty(ocspTimeoutProp))
+            setOcspTimeout(Integer.parseInt(ocspTimeoutProp));
+    }
+
+    /**
+     * Load configuration from jss.conf (if available) or server.xml.
+     * @throws IOException
+     * @throws SAXException
+     * @throws ParserConfigurationException
+     * @throws XPathExpressionException
+     */
+    public void loadConfig() throws IOException, XPathExpressionException, ParserConfigurationException, SAXException {
+        String catalinaBase = System.getProperty(CATALINA_BASE);
+        String jssConf = catalinaBase + "/conf/jss.conf";
+        File configFile = new File(jssConf);
+
+        if (configFile.exists()) {
+            logger.info("TomcatJSS: Loading JSS configuration from {}", jssConf);
+            loadJSSConfig(configFile);
+
+        } else {
+            String serverXml = catalinaBase + "/conf/server.xml";
+            logger.info("TomcatJSS: Loading JSS configuration from {}", serverXml);
+            loadTomcatConfig(serverXml);
+        }
+    }
+
+    public void init() throws KeyDatabaseException, CertDatabaseException, GeneralSecurityException,
+            NotInitializedException, InstantiationException, IllegalAccessException, IllegalArgumentException,
+            InvocationTargetException, NoSuchMethodException, SecurityException, ClassNotFoundException, IOException,
+            NoSuchTokenException, TokenException, ConfigurationException {
+
+        if (initialized) {
+            return;
+        }
+
+        logger.info("TomcatJSS: initialization");
+
+        if (certdbDir == null) {
+            certdbDir = System.getProperty(CATALINA_BASE) + File.separator + "alias";
+        }
+
+        logger.debug("TomcatJSS: certdbDir: {}", certdbDir);
+
+        if (passwordClass == null) {
+            passwordClass = PlainPasswordFile.class.getName();
+        }
+
+        logger.debug("TomcatJSS: passwordClass: {}", passwordClass);
+
+        if (passwordFile == null) {
+            passwordFile = System.getProperty(CATALINA_BASE) + File.separator +
+                    "conf" + File.separator + "password.conf";
+        }
+
+        logger.debug("TomcatJSS: passwordFile: {}", passwordFile);
+
+        if (StringUtils.isNotEmpty(serverCertNickFile)) {
+            logger.debug("TomcatJSS: serverCertNickFile: {}", serverCertNickFile);
+        }
+
+        InitializationValues vals = new InitializationValues(certdbDir);
+
+        vals.removeSunProvider = false;
+        vals.installJSSProvider = true;
+
+        try {
+            CryptoManager.initialize(vals);
+
+        } catch (AlreadyInitializedException e) {
+            logger.warn("TomcatJSS: {}", e, e);
+        }
+
+        manager = CryptoManager.getInstance();
+
+        passwordStore = (IPasswordStore) Class.forName(passwordClass).getDeclaredConstructor().newInstance();
+        passwordStore.init(passwordFile);
+
+        login();
+
+        if (StringUtils.isNotEmpty(serverCertNickFile)) {
+            serverCertNick = new String(Files.readAllBytes(Paths.get(serverCertNickFile))).trim();
+            logger.debug("serverCertNick: {}", serverCertNick);
+        }
+
+        logger.debug("clientAuth: {}", clientAuth);
+        if (clientAuth.equalsIgnoreCase("true")) {
+            requireClientAuth = true;
+
+        } else if (clientAuth.equalsIgnoreCase("yes")) {
+            requireClientAuth = true;
+            logger.warn("The \"yes\" value for clientAuth has been deprecated. Use \"true\" instead.");
+
+        } else if (clientAuth.equalsIgnoreCase("want")) {
+            wantClientAuth = true;
+        }
+
+        logger.debug("requireClientAuth: {}", requireClientAuth);
+        logger.debug("wantClientAuth: {}", wantClientAuth);
+
+        if (requireClientAuth || wantClientAuth) {
+            configureOCSP();
+        }
+
+        // 12 hours = 43200 seconds
+        SSLServerSocket.configServerSessionIDCache(0, 43200, 43200, null);
+
+        logger.info("TomcatJSS: initialization complete");
+
+        initialized = true;
+    }
+
+    public void login() throws NoSuchTokenException, TokenException {
+
+        logger.debug("TomcatJSS: logging into tokens");
+
+        Enumeration<String> tags = passwordStore.getTags();
+
+        while (tags.hasMoreElements()) {
+
+            String tag = tags.nextElement();
+            if (!tag.equals("internal") && !tag.startsWith("hardware-")) {
+                continue;
+            }
+
+            login(tag);
+        }
+    }
+
+    public void login(String tag) throws NoSuchTokenException, TokenException {
+
+        CryptoToken token = getToken(tag);
+
+        if (token.isLoggedIn()) {
+            logger.debug("TomcatJSS: already logged into {}", tag);
+            return;
+        }
+
+        logger.debug("TomcatJSS: logging into {}", tag);
+
+        int iteration = 0;
+        do {
+            String strPassword = passwordStore.getPassword(tag, iteration);
+
+            if (strPassword == null) {
+                logger.debug("TomcatJSS: no password for {}", tag);
+                return;
+            }
+
+            Password password = new Password(strPassword.toCharArray());
+
+            try {
+                token.login(password);
+                return; //NOSONAR - Not a redundant return, break will print the final error message even on success.
+            } catch (IncorrectPasswordException e) {
+                logger.warn("TomcatJSS: incorrect password");
+                iteration ++;
+            } finally {
+                password.clear();
+            }
+
+        } while (iteration < MAX_LOGIN_ATTEMPTS);
+
+        logger.error("TomcatJSS: failed to log into {}", tag);
+    }
+
+    public CryptoToken getToken(String tag) throws NoSuchTokenException {
+
+        if (tag.equals("internal")) {
+            return manager.getInternalKeyStorageToken();
+        }
+
+        if (tag.startsWith("hardware-")) {
+            String tokenName = tag.substring(9);
+            return manager.getTokenByName(tokenName);
+        }
+
+        // non-token password entry
+        return null;
+    }
+
+    public void configureOCSP() throws GeneralSecurityException, ConfigurationException {
+
+        logger.info("configuring OCSP");
+
+        logger.debug("enableOCSP: {}", enableOCSP);
+        if (!enableOCSP) {
+            return;
+        }
+
+        logger.debug("ocspResponderURL: {}", ocspResponderURL);
+
+        if (StringUtils.isEmpty(ocspResponderURL)) {
+            ocspResponderURL = null;
+        }
+
+        logger.debug("ocspResponderCertNickname: {}", ocspResponderCertNickname);
+        if (StringUtils.isEmpty(ocspResponderCertNickname)) {
+            ocspResponderCertNickname = null;
+        }
+
+        // Check to see if the ocsp url and nickname are both set or not set
+
+        if (ocspResponderURL == null && ocspResponderCertNickname != null) {
+            throw new ConfigurationException("Missing OCSP responder URL");
+        }
+
+        if (ocspResponderURL != null && ocspResponderCertNickname == null) {
+            throw new ConfigurationException("Missing OCSP responder certificate nickname");
+        }
+
+        manager.configureOCSP(
+                true,
+                ocspResponderURL,
+                ocspResponderCertNickname);
+
+        logger.debug("ocspCacheSize: {}", ocspCacheSize);
+        logger.debug("ocspMinCacheEntryDuration: {}", ocspMinCacheEntryDuration);
+        logger.debug("ocspMaxCacheEntryDuration: {}", ocspMaxCacheEntryDuration);
+
+        manager.OCSPCacheSettings(ocspCacheSize,
+                ocspMinCacheEntryDuration,
+                ocspMaxCacheEntryDuration);
+
+        logger.debug("ocspTimeout: {}", ocspTimeout);
+
+        manager.setOCSPTimeout(ocspTimeout);
+    }
+
+    @Override
+    public void alertReceived(SSLAlertEvent event) {
+        for (SSLSocketListener listener : socketListeners) {
+            listener.alertReceived(event);
+        }
+    }
+
+    @Override
+    public void alertSent(SSLAlertEvent event) {
+        for (SSLSocketListener listener : socketListeners) {
+            listener.alertSent(event);
+        }
+    }
+
+    @Override
+    public void handshakeCompleted(SSLHandshakeCompletedEvent event) {
+        for (SSLSocketListener listener : socketListeners) {
+            listener.handshakeCompleted(event);
+        }
+    }
+}


### PR DESCRIPTION
To simplify package maintenance, the code from Tomcat JSS master branch has been imported into `tomcat` and `tomcat-9.0` modules which will be distributed as `jss-tomcat` RPM package:
https://github.com/edewata/jss/blob/tomcatjss/docs/changes/v5.5.0/Packaging-Changes.adoc

Later PKI will need to be updated to depend on `jss-tomcat` instead of `tomcatjss`, then `tomcatjss` can be deprecated.