### PR TITLE
Bug_2233740 Fix wrong port number in log and audit

### DIFF
--- a/src/main/java/org/mozilla/jss/ssl/javasock.c
+++ b/src/main/java/org/mozilla/jss/ssl/javasock.c
@@ -365,11 +365,11 @@ getInetAddress(PRFileDesc *fd, PRNetAddr *addr, LocalOrPeer localOrPeer)
         if (addrBALen == 4) {
             memcpy( (void*) &addr->inet.ip, addrBytes, 4);
             addr->inet.family = PR_AF_INET;
-            addr->inet.port = port;
+            addr->inet.port = PR_htons(port);
         } else {
             memcpy( (void*) &addr->ipv6.ip,addrBytes, 16);
             addr->inet.family = PR_AF_INET6;
-            addr->inet.port = port;
+            addr->inet.port = PR_htons(port);
         }
 
         JSS_DerefByteArray(env, addrByteArray, addrBytes, JNI_ABORT);


### PR DESCRIPTION
If the connection is created from a java socket the port number was reported incorrectly because a conversion from host to network format was missed.