### PR TITLE
Add jss-tests package

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -44,7 +44,7 @@ jobs:
             junit5 libopentest4j-java maven
 
     - name: Build JSS with CMake
-      run: ./build.sh --with-tests
+      run: ./build.sh
 
     - name: Build JSS with Maven
       run: mvn package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ option(TEST_WITH_INTERNET "When enabled, runs various tests which require an int
 option(WITH_JAVA "Build Java binaries." TRUE)
 option(WITH_NATIVE "Build native binaries." TRUE)
 option(WITH_JAVADOC "Build Javadoc package." TRUE)
-option(WITH_TESTS "Run unit tests." TRUE)
+option(WITH_TESTS "Build tests package." TRUE)
 
 # Find NSPR and NSS Libraries.
 find_package(NSPR REQUIRED)
@@ -83,9 +83,16 @@ include(JSSTests)
 
 jss_config()
 jss_build()
-jss_tests()
+
+if(WITH_TESTS)
+    jss_tests()
+endif(WITH_TESTS)
 
 add_subdirectory(symkey)
+
+if(WITH_TESTS)
+    add_subdirectory(tests)
+endif(WITH_TESTS)
 
 add_custom_target(
     java ALL

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
       docker exec -w /root/src runner dnf builddep -y --spec jss.spec
     displayName: Install build dependencies
 
-  - script: docker exec -w /root/src runner ./build.sh --with-tests
+  - script: docker exec -w /root/src runner ./build.sh
     displayName: Build JSS binaries, Javadoc, and run tests
 
 - job: BuildTest_apt
@@ -79,7 +79,7 @@ jobs:
           junit5 libopentest4j-java
     displayName: Install build dependencies
 
-  - script: ./build.sh --with-tests
+  - script: ./build.sh
     displayName: Build JSS binaries, Javadoc, and run tests
     env:
       JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64

--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ DIST=
 WITH_JAVA=true
 WITH_NATIVE=true
 WITH_JAVADOC=true
-WITH_TESTS=false
+WITH_TESTS=true
 
 VERBOSE=
 DEBUG=
@@ -73,7 +73,7 @@ usage() {
     echo "    --without-java         Do not build Java binaries."
     echo "    --without-native       Do not build native binaries."
     echo "    --without-javadoc      Do not build Javadoc package."
-    echo "    --with-tests           Run unit tests."
+    echo "    --without-tests        Do not build tests package."
     echo " -v,--verbose              Run in verbose mode."
     echo "    --debug                Run in debug mode."
     echo "    --help                 Show help message."
@@ -130,7 +130,6 @@ generate_rpm_sources() {
     tar czf "$WORK_DIR/SOURCES/$TARBALL" \
         --transform "s,^./,$PREFIX/," \
         --exclude .git \
-        --exclude bin \
         --exclude build \
         -C "$SRC_DIR" \
         .
@@ -185,10 +184,10 @@ generate_rpm_spec() {
         sed -i "s/%\(bcond_without *javadoc\)\$/# \1\n%bcond_with javadoc/g" "$SPEC_FILE"
     fi
 
-    # hard-code test option
-    if [ "$WITH_TESTS" = true ] ; then
-        # convert bcond_with into bcond_without such that it runs unit tests by default
-        sed -i "s/%\(bcond_with *tests\)\$/# \1\n%bcond_without tests/g" "$SPEC_FILE"
+    # hard-code tests option
+    if [ "$WITH_TESTS" = false ] ; then
+        # convert bcond_without into bcond_with such that tests package is not built by default
+        sed -i "s/%\(bcond_without *tests\)\$/# \1\n%bcond_with tests/g" "$SPEC_FILE"
     fi
 
     # rpmlint "$SPEC_FILE"
@@ -266,8 +265,8 @@ while getopts v-: arg ; do
         without-javadoc)
             WITH_JAVADOC=false
             ;;
-        with-tests)
-            WITH_TESTS=true
+        without-tests)
+            WITH_TESTS=false
             ;;
         verbose)
             VERBOSE=true
@@ -468,7 +467,6 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
     fi
 
     echo
-    echo "To run the tests: $0 --with-tests"
     echo "To install the build: $0 install"
     echo "To create RPM packages: $0 rpm"
     echo

--- a/docs/changes/v5.5.0/Packaging-Changes.adoc
+++ b/docs/changes/v5.5.0/Packaging-Changes.adoc
@@ -8,3 +8,7 @@ This package will replace Tomcat JSS with the following changes:
 * All classes are moved into `org.dogtagpki.jss.tomcat` package.
 * Generic Tomcat classes are packaged into `jss-tomcat.jar`.
 * Tomcat 9.0 classes are packaged into `jss-tomcat-9.0.jar`.
+
+== New jss-tests RPM package ==
+
+A new `jss-tests` RPM package has been added to provide JSS test scripts and binaries.

--- a/jss.spec
+++ b/jss.spec
@@ -68,10 +68,10 @@ ExcludeArch: i686
 
 %bcond_without javadoc
 
-# By default the build will not execute unit tests unless --with tests
-# option is specified.
+# By default the tests package will be built and the tests will executed
+# unless --without tests option is specified.
 
-%bcond_with tests
+%bcond_without tests
 
 ################################################################################
 # Build Dependencies
@@ -91,8 +91,6 @@ BuildRequires:  maven-local
 BuildRequires:  mvn(org.apache.commons:commons-lang3)
 BuildRequires:  mvn(org.slf4j:slf4j-api)
 BuildRequires:  mvn(org.slf4j:slf4j-jdk14)
-BuildRequires:  mvn(org.junit.jupiter:junit-jupiter)
-BuildRequires:  mvn(org.opentest4j:opentest4j)
 
 %description
 Java Security Services (JSS) is a java native interface which provides a bridge
@@ -173,6 +171,22 @@ Provides:       %{product_id}-javadoc = %{major_version}.%{minor_version}
 
 %description -n %{product_id}-javadoc
 This package contains the API documentation for JSS.
+%endif
+
+%if %{with tests}
+################################################################################
+%package -n %{product_id}-tests
+################################################################################
+
+Summary:        Java Security Services (JSS) Tests
+
+BuildRequires:  mvn(org.junit.jupiter:junit-jupiter)
+BuildRequires:  mvn(org.opentest4j:opentest4j)
+
+%description -n %{product_id}-tests
+This package provides test suite for JSS.
+
+# with tests
 %endif
 
 ################################################################################
@@ -261,7 +275,7 @@ touch %{_vpath_builddir}/.targets/finished_generate_javadocs
     --version=%{version} \
     --without-java \
     --without-javadoc \
-    %{?with_tests:--with-tests} \
+    %{!?with_tests:--without-tests} \
     dist
 
 ################################################################################
@@ -290,6 +304,12 @@ ln -sf ../../..%{_javadir}/jss/jss.jar %{buildroot}%{_libdir}/jss/jss.jar
     --without-java \
     install
 
+# install tests binaries
+%if %{with tests}
+mkdir -p %{buildroot}%{_datadir}/jss/tests/lib
+cp base/target/jss-tests.jar %{buildroot}%{_datadir}/jss/tests/lib
+%endif
+
 ################################################################################
 %files -n %{product_id} -f .mfiles-jss-base
 ################################################################################
@@ -310,6 +330,16 @@ ln -sf ../../..%{_javadir}/jss/jss.jar %{buildroot}%{_libdir}/jss/jss.jar
 ################################################################################
 %files -n %{product_id}-javadoc -f .mfiles-javadoc
 ################################################################################
+%endif
+
+%if %{with tests}
+################################################################################
+%files -n %{product_id}-tests
+################################################################################
+
+%{_datadir}/jss/tests/
+
+# with tests
 %endif
 
 ################################################################################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(tests)
+
+install(
+    DIRECTORY
+        bin/
+    DESTINATION
+        ${SHARE_INSTALL_PREFIX}/jss/tests/bin
+    FILE_PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+)


### PR DESCRIPTION
A new package has been added for distributing test scripts and binaries.

https://github.com/edewata/jss/blob/build/docs/changes/v5.5.0/Packaging-Changes.adoc