### PR TITLE
Add PK11Store.importCert()

### DIFF
--- a/base/src/main/java/org/mozilla/jss/crypto/CryptoStore.java
+++ b/base/src/main/java/org/mozilla/jss/crypto/CryptoStore.java
@@ -166,6 +166,17 @@ public interface CryptoStore {
     public X509Certificate[] getCertificates() throws TokenException;
 
     /**
+     * Imports a certificate into this token.
+     *
+     * @param certBytes Certificate binaries
+     * @param nickname Certificate nickname
+     * @return X509Certificate object of the imported certificate
+     * @throws TokenException
+     */
+    public X509Certificate importCert(byte[] certBytes, String nickname)
+            throws TokenException;
+
+    /**
      * Deletes a certificate and the corresponding keys.
      *
      * @param cert A certificate to be deleted from this token. The cert

--- a/base/src/main/java/org/mozilla/jss/pkcs11/PK11Store.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs11/PK11Store.java
@@ -194,6 +194,10 @@ public final class PK11Store implements CryptoStore {
     }
     protected native void putCertsInVector(Vector<X509Certificate> certs) throws TokenException;
 
+    @Override
+    public native X509Certificate importCert(byte[] certBytes, String nickname)
+            throws TokenException;
+
     /**
      * Deletes the specified certificate and its associated private
      * key from the store.

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -512,3 +512,9 @@ Java_org_mozilla_jss_CryptoManager_initializeAllNativeWithContext;
     local:
         *;
 };
+JSS_5.5.0 {
+    global:
+Java_org_mozilla_jss_pkcs11_PK11Store_importCert;
+    local:
+        *;
+};


### PR DESCRIPTION
Currently none of the cert import methods provided by JSS works like `certutil -A` since they call different NSS functions so in some cases it's necessary to call this external command from Java which could be problematic and does not work well with HSM.

To address the problem the `PK11Store.importCert()` has been added to call the same NSS functions used by `certutil -A` so it's no longer necessary to call this external command from Java.

https://github.com/dogtagpki/nss/blob/master/cmd/certutil/certutil.c#L102-L182
