### PR TITLE
Fix BASE_IMAGE param

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -3,19 +3,36 @@ name: Build Tests
 on: [push, pull_request]
 
 jobs:
+  wait-for-build:
+    name: Waiting for build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Building JSS'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
+
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building JSS'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
+
   build-test:
     name: Build Test
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       matrix:
         os:
-          - 'fedora:latest'
           - 'debian:testing'
           - 'ubuntu:rolling'
-          # Disable CentOS due to missing dependencies
-          # - 'centos:7'
-          # - 'centos:8'
     container: ${{ matrix.os }}
     steps:
     - name: Clone repository
@@ -27,14 +44,7 @@ jobs:
         java-version: '17'
         distribution: 'adopt'
 
-    - name: Install Fedora/CentOS dependencies
-      if: ${{ startsWith(matrix.os, 'fedora:') || startsWith(matrix.os, 'centos:') }}
-      run: |
-        dnf install -y dnf-plugins-core rpm-build maven
-        dnf builddep -y --spec jss.spec
-
-    - name: Install Debian/Ubuntu dependencies
-      if: ${{ startsWith(matrix.os, 'debian:') || startsWith(matrix.os, 'ubuntu:') }}
+    - name: Install build dependencies
       run: |
         apt-get update
         apt-get install -y \
@@ -51,10 +61,67 @@ jobs:
 
     - name: Compare jss.jar
       run: |
-        jar tvf ~/build/jss/jss.jar | awk '{print $8;}' | sort \
+        jar tvf ~/build/jss/jss.jar \
+            | awk '{print $8;}' \
+            | sort \
             | grep -v '/$' \
             | tee cmake.out
-        jar tvf base/target/jss.jar | awk '{print $8;}' | sort \
+        jar tvf base/target/jss.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | grep -v '^META-INF/maven/' \
+            | tee maven.out
+        diff cmake.out maven.out
+
+    # TODO: Run examples
+
+  fedora-test:
+    name: Fedora Build Test
+    needs: wait-for-build
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v3
+
+    - name: Retrieve JSS images
+      uses: actions/cache@v3
+      with:
+        key: jss-images-${{ github.sha }}
+        path: jss-images.tar
+
+    - name: Load JSS images
+      run: docker load --input jss-images.tar
+
+    - name: Set up JSS container
+      run: |
+        tests/bin/runner-init.sh jss
+      env:
+        IMAGE: jss-builder
+        HOSTNAME: jss.example.com
+
+    - name: Build JSS with CMake
+      run: |
+        docker exec jss ./build.sh
+
+    - name: Build JSS with Maven
+      run: |
+        docker exec jss mvn package
+
+    - name: Compare jss.jar
+      run: |
+        docker exec jss \
+            jar tvf /root/build/jss/jss.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | tee cmake.out
+        docker exec jss \
+            jar tvf base/target/jss.jar \
+            | awk '{print $8;}' \
+            | sort \
             | grep -v '/$' \
             | grep -v '^META-INF/maven/' \
             | tee maven.out
@@ -91,108 +158,138 @@ jobs:
 
   rpm-test:
     name: RPM Test
+    needs: wait-for-build
     runs-on: ubuntu-latest
-    container: 'fedora:latest'
+    env:
+      SHARED: /tmp/workdir/pki
     steps:
     - name: Clone repository
       uses: actions/checkout@v3
 
-    - name: Set up Java
-      uses: actions/setup-java@v3
+    - name: Retrieve JSS images
+      uses: actions/cache@v3
       with:
-        java-version: '17'
-        distribution: 'adopt'
+        key: jss-images-${{ github.sha }}
+        path: jss-images.tar
 
-    - name: Install Fedora dependencies
+    - name: Load jss-images image
+      run: docker load --input jss-images.tar
+
+    - name: Set up JSS container
       run: |
-        dnf install -y dnf-plugins-core rpm-build maven
-        dnf builddep -y --spec jss.spec
-
-    - name: Build JSS RPMs with XMvn and CMake
-      run: ./build.sh --work-dir=build rpm
+        tests/bin/runner-init.sh jss
+      env:
+        IMAGE: jss-builder
+        HOSTNAME: jss.example.com
 
     - name: Install RPMInspect
       run: |
-        dnf install -y dnf-plugins-core
-        dnf copr enable -y copr.fedorainfracloud.org/dcantrell/rpminspect
-        dnf install -y rpminspect rpminspect-data-fedora
+        docker exec jss dnf copr enable -y copr.fedorainfracloud.org/dcantrell/rpminspect
+        docker exec jss dnf install -y rpminspect rpminspect-data-fedora
 
     - name: Run RPMInspect on SRPM and RPMs
-      run: ./tests/bin/rpminspect.sh
+      run: |
+        docker exec jss ./tests/bin/rpminspect.sh
 
     - name: Install RPMs
-      run: dnf localinstall -y build/RPMS/*.rpm
+      run: |
+        docker exec jss bash -c "dnf localinstall -y build/RPMS/*.rpm"
 
     - name: Build JSS with Maven
-      run: mvn -pl '!native,!symkey,!examples' package
+      run: |
+        docker exec jss mvn -pl '!native,!symkey,!examples' package
 
     - name: Compare jss.jar
       run: |
-        jar tvf /usr/share/java/jss/jss.jar | awk '{print $8;}' | sort \
+        docker exec jss jar tvf /usr/share/java/jss/jss.jar \
+            | awk '{print $8;}' \
+            | sort \
             | grep -v '/$' \
             | tee jss.jar.rpm
-        jar tvf base/target/jss.jar | awk '{print $8;}' | sort \
+        docker exec jss jar tvf base/target/jss.jar \
+            | awk '{print $8;}' \
+            | sort \
             | grep -v '/$' \
             | tee jss.jar.maven
         diff jss.jar.rpm jss.jar.maven
 
     - name: Compare jss-tomcat.jar
       run: |
-        jar tvf /usr/share/java/jss/jss-tomcat.jar | awk '{print $8;}' | sort \
+        docker exec jss jar tvf /usr/share/java/jss/jss-tomcat.jar \
+            | awk '{print $8;}' \
+            | sort \
             | grep -v '/$' \
             | tee jss-tomcat.jar.rpm
-        jar tvf tomcat/target/jss-tomcat.jar | awk '{print $8;}' | sort \
+        docker exec jss jar tvf tomcat/target/jss-tomcat.jar \
+            | awk '{print $8;}' \
+            | sort \
             | grep -v '/$' \
             | tee jss-tomcat.jar.maven
         diff jss-tomcat.jar.rpm jss-tomcat.jar.maven
 
     - name: Compare jss-tomcat-9.0.jar
       run: |
-        jar tvf /usr/share/java/jss/jss-tomcat-9.0.jar | awk '{print $8;}' | sort \
+        docker exec jss jar tvf /usr/share/java/jss/jss-tomcat-9.0.jar \
+            | awk '{print $8;}' \
+            | sort \
             | grep -v '/$' \
             | tee jss-tomcat-9.0.jar.rpm
-        jar tvf tomcat-9.0/target/jss-tomcat-9.0.jar | awk '{print $8;}' | sort \
+        docker exec jss jar tvf tomcat-9.0/target/jss-tomcat-9.0.jar \
+            | awk '{print $8;}' \
+            | sort \
             | grep -v '/$' \
             | tee jss-tomcat-9.0.jar.maven
         diff jss-tomcat-9.0.jar.rpm jss-tomcat-9.0.jar.maven
 
   sandbox-test:
     name: Sandbox Test
+    needs: wait-for-build
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/fedora/fedora:rawhide
+    env:
+      SHARED: /tmp/workdir/jss
     steps:
     - name: Clone repository
       uses: actions/checkout@v3
 
+    - name: Retrieve JSS images
+      uses: actions/cache@v3
+      with:
+        key: jss-images-${{ github.sha }}
+        path: jss-images.tar
+
+    - name: Load jss-images image
+      run: docker load --input jss-images.tar
+
+    - name: Set up JSS container
+      run: |
+        tests/bin/runner-init.sh jss
+      env:
+        IMAGE: jss-builder
+        HOSTNAME: jss.example.com
+
     - name: Install build dependencies
       run: |
-        dnf install -y dnf-plugins-core
-        dnf builddep -y nspr nss jss
-        dnf builddep -y jss.spec
-        dnf install -y mercurial \
+        docker exec jss dnf builddep -y nspr nss
+        docker exec jss dnf install -y mercurial \
             python-unversioned-command \
             gyp \
             ninja-build
 
     - name: Build NSPR and NSS
       run: |
-        cd ..
-        hg clone https://hg.mozilla.org/projects/nspr
-        hg clone https://hg.mozilla.org/projects/nss
-        cd nss
-        ./build.sh --enable-fips --enable-libpkix
+        docker exec jss hg clone https://hg.mozilla.org/projects/nspr
+        docker exec jss hg clone https://hg.mozilla.org/projects/nss
+        docker exec -w /root/jss/nss jss \
+            bash build.sh --enable-fips --enable-libpkix
 
     - name: Build JSS
       run: |
-        cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug ..
-        make all
+        docker exec -w /root/jss/build jss cmake -DCMAKE_BUILD_TYPE=Debug ..
+        docker exec -w /root/jss/build jss make all
       env:
         SANDBOX: 1
         CFLAGS: -Wall -Wextra -Werror -Og -ggdb
 
     - name: Run JSS tests
       run: |
-        cd build
-        ctest --output-on-failure
+        docker exec -w /root/jss/build jss ctest --output-on-failure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,13 +58,7 @@ jobs:
           tags: jss-builder
           target: jss-builder
           cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=jss-builder.tar
-
-      - name: Store jss-builder image
-        uses: actions/cache@v3
-        with:
-          key: jss-builder-${{ github.sha }}
-          path: jss-builder.tar
+          outputs: type=docker
 
       - name: Build jss-dist image
         uses: docker/build-push-action@v3
@@ -76,13 +70,7 @@ jobs:
           tags: jss-dist
           target: jss-dist
           cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=jss-dist.tar
-
-      - name: Store jss-dist image
-        uses: actions/cache@v3
-        with:
-          key: jss-dist-${{ github.sha }}
-          path: jss-dist.tar
+          outputs: type=docker
 
       - name: Build jss-runner image
         uses: docker/build-push-action@v3
@@ -94,10 +82,15 @@ jobs:
           tags: jss-runner
           target: jss-runner
           cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=jss-runner.tar
+          outputs: type=docker
 
-      - name: Store jss-runner image
+      - name: Save JSS images
+        run: |
+          docker images
+          docker save -o jss-images.tar jss-builder jss-dist jss-runner
+
+      - name: Store JSS images
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ github.sha }}
-          path: jss-runner.tar
+          key: jss-images-${{ github.sha }}
+          path: jss-images.tar

--- a/.github/workflows/external-application-connection-tests.yml
+++ b/.github/workflows/external-application-connection-tests.yml
@@ -36,24 +36,23 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve jss-builder image
+      - name: Retrieve JSS images
         uses: actions/cache@v3
         with:
-          key: jss-builder-${{ github.sha }}
-          path: jss-builder.tar
+          key: jss-images-${{ github.sha }}
+          path: jss-images.tar
 
-      - name: Load jss-builder image
-        run: docker load --input jss-builder.tar
+      - name: Load JSS images
+        run: docker load --input jss-images.tar
 
       - name: Create network
         run: docker network create example
 
-      - name: Run container
+      - name: Set up JSS container
         run: |
-          tests/bin/runner-init.sh
+          tests/bin/runner-init.sh jss
         env:
           IMAGE: jss-builder
-          NAME: jss
           HOSTNAME: jss.example.com
   
       - name: Connect JSS container to network

--- a/.github/workflows/pkcs11-tests.yml
+++ b/.github/workflows/pkcs11-tests.yml
@@ -35,21 +35,20 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve jss-runner image
+      - name: Retrieve JSS images
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ github.sha }}
-          path: jss-runner.tar
+          key: jss-images-${{ github.sha }}
+          path: jss-images.tar
 
-      - name: Load jss-runner image
-        run: docker load --input jss-runner.tar
+      - name: Load JSS images
+        run: docker load --input jss-images.tar
 
-      - name: Run container
+      - name: Set up JSS container
         run: |
-          IMAGE=jss-runner \
-          NAME=jss \
-          HOSTNAME=jss.example.com \
-          tests/bin/runner-init.sh
+          tests/bin/runner-init.sh jss
+        env:
+          HOSTNAME: jss.example.com
 
       - name: Install dependencies
         run: docker exec jss dnf install -y nss-util-devel python3 java-devel

--- a/.github/workflows/pki-build-test.yml
+++ b/.github/workflows/pki-build-test.yml
@@ -12,21 +12,20 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve jss-runner image
+      - name: Retrieve JSS images
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ github.sha }}
-          path: jss-runner.tar
+          key: jss-images-${{ github.sha }}
+          path: jss-images.tar
 
-      - name: Load jss-runner image
-        run: docker load --input jss-runner.tar
+      - name: Load JSS images
+        run: docker load --input jss-images.tar
 
-      - name: Run JSS container
+      - name: Set up JSS container
         run: |
-          IMAGE=jss-runner \
-          NAME=pki \
-          HOSTNAME=pki.example.com \
-          tests/bin/runner-init.sh
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
 
       - name: Import LDAP SDK packages
         run: |

--- a/.github/workflows/pki-ca-test.yml
+++ b/.github/workflows/pki-ca-test.yml
@@ -12,21 +12,20 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve jss-runner image
+      - name: Retrieve JSS images
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ github.sha }}
-          path: jss-runner.tar
+          key: jss-images-${{ github.sha }}
+          path: jss-images.tar
 
-      - name: Load jss-runner image
-        run: docker load --input jss-runner.tar
+      - name: Load JSS images
+        run: docker load --input jss-images.tar
 
-      - name: Run container
+      - name: Set up JSS container
         run: |
-          IMAGE=jss-runner \
-          NAME=pki \
-          HOSTNAME=pki.example.com \
-          tests/bin/runner-init.sh
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
 
       - name: Import LDAP SDK packages
         run: |

--- a/.github/workflows/pki-tools-test.yml
+++ b/.github/workflows/pki-tools-test.yml
@@ -12,21 +12,20 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve jss-runner image
+      - name: Retrieve JSS images
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ github.sha }}
-          path: jss-runner.tar
+          key: jss-images-${{ github.sha }}
+          path: jss-images.tar
 
-      - name: Load jss-runner image
-        run: docker load --input jss-runner.tar
+      - name: Load JSS images
+        run: docker load --input jss-images.tar
 
-      - name: Run container
+      - name: Set up JSS container
         run: |
-          IMAGE=jss-runner \
-          NAME=pki \
-          HOSTNAME=pki.example.com \
-          tests/bin/runner-init.sh
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
 
       - name: Import LDAP SDK packages
         run: |

--- a/.github/workflows/pki-tps-test.yml
+++ b/.github/workflows/pki-tps-test.yml
@@ -12,24 +12,20 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve jss-runner image
+      - name: Retrieve JSS images
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ github.sha }}
-          path: jss-runner.tar
+          key: jss-images-${{ github.sha }}
+          path: jss-images.tar
 
-      - name: Load jss-runner image
-        run: docker load --input jss-runner.tar
+      - name: Load JSS images
+        run: docker load --input jss-images.tar
 
-      - name: Create network
-        run: docker network create example
-
-      - name: Run container
+      - name: Set up JSS container
         run: |
-          IMAGE=jss-runner \
-          NAME=pki \
-          HOSTNAME=pki.example.com \
-          tests/bin/runner-init.sh
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
 
       - name: Import LDAP SDK packages
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,14 +80,16 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
         if: vars.REGISTRY != 'ghcr.io'
 
-      - name: Retrieve jss-dist image
+      - name: Retrieve JSS images
         uses: actions/cache@v3
         with:
-          key: jss-dist-${{ github.sha }}
-          path: jss-dist.tar
+          key: jss-images-${{ github.sha }}
+          path: jss-images.tar
+
+      - name: Load JSS images
+        run: docker load --input jss-images.tar
 
       - name: Publish jss-dist image
         run: |
-          docker load --input jss-dist.tar
           docker tag jss-dist ${{ vars.REGISTRY }}/$NAMESPACE/jss-dist:latest
           docker push ${{ vars.REGISTRY }}/$NAMESPACE/jss-dist:latest

--- a/.github/workflows/tomcat-tests.yml
+++ b/.github/workflows/tomcat-tests.yml
@@ -41,24 +41,23 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve jss-runner image
+      - name: Retrieve JSS images
         uses: actions/cache@v3
         with:
-          key: jss-runner-${{ github.sha }}
-          path: jss-runner.tar
+          key: jss-images-${{ github.sha }}
+          path: jss-images.tar
 
-      - name: Load jss-runner image
-        run: docker load --input jss-runner.tar
+      - name: Load JSS images
+        run: docker load --input jss-images.tar
 
       - name: Create network
         run: docker network create example
 
-      - name: Set up server container
+      - name: Set up JSS container
         run: |
-          IMAGE=jss-runner \
-          NAME=server \
-          HOSTNAME=server.example.com \
-          tests/bin/runner-init.sh
+          tests/bin/runner-init.sh server
+        env:
+          HOSTNAME: server.example.com
 
       - name: Connect server container to network
         run: docker network connect example server --alias server.example.com
@@ -113,10 +112,9 @@ jobs:
 
       - name: Set up client container
         run: |
-          IMAGE=jss-runner \
-          NAME=client \
-          HOSTNAME=client.example.com \
-          tests/bin/runner-init.sh
+          tests/bin/runner-init.sh client
+        env:
+          HOSTNAME: client.example.com
 
       - name: Connect client container to network
         run: docker network connect example client --alias client.example.com

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,19 +17,21 @@ jobs:
 - job: BuildTest_dnf
   pool:
     vmImage: ubuntu-latest
-  strategy:
-    matrix:
-      fedora_latest:
-        image: registry.fedoraproject.org/fedora:latest
-      # Disable CentOS due to missing dependencies
-      # centos_7:
-      #   image: centos:7
-      # centos_8:
-      #   image: centos:8
   steps:
+  - task: PythonScript@0
+    displayName: Set environment variables
+    inputs:
+      scriptSource: inline
+      script: |
+       import os
+
+       value = os.getenv('BASE_IMAGE', 'registry.fedoraproject.org/fedora:latest')
+       print('BASE_IMAGE: {value}'.format(value=value))
+       print('##vso[task.setvariable variable=BASE_IMAGE]{value}'.format(value=value))
+
   - script: |
       docker build \
-          --build-arg BASE_IMAGE=$(image) \
+          --build-arg BASE_IMAGE=$BASE_IMAGE \
           --target jss-base \
           --tag jss-base:latest \
           .

--- a/tests/bin/runner-init.sh
+++ b/tests/bin/runner-init.sh
@@ -1,5 +1,18 @@
 #!/bin/bash -ex
 
+NAME=$1
+
+if [ "$NAME" == "" ]
+then
+    echo "Usage: runner-init.sh <name>"
+    exit 1
+fi
+
+if [ "$IMAGE" == "" ]
+then
+    IMAGE=jss-runner
+fi
+
 docker run \
     --name=${NAME} \
     --hostname=${HOSTNAME} \

--- a/tools/Dockerfiles/stylecheck
+++ b/tools/Dockerfiles/stylecheck
@@ -1,4 +1,6 @@
-FROM registry.fedoraproject.org/fedora:latest
+ARG BASE_IMAGE="registry.fedoraproject.org/fedora:latest"
+
+FROM $BASE_IMAGE
 
 # Install generic dependencies to check style
 RUN true \


### PR DESCRIPTION
The tests in GitHub and Azure DevOps have been modified to run using the latest Fedora by default, but it can be changed using the `BASE_IMAGE` param.

The GitHub tests have also been updated to reuse the images created by the build workflow. The build workflow has also been modified to store the images in a single cache instead of separate caches.

The `runner-init.sh` has been modified to use a positional argument to specify the container name and use `jss-runner` image by default.

https://github.com/dogtagpki/pki/wiki/Configuring-Test-OS