### PR TITLE
Update kea_alg_defs to match NSS 3.97

### DIFF
--- a/native/src/main/native/org/mozilla/jss/ssl/SSLCipher.c
+++ b/native/src/main/native/org/mozilla/jss/ssl/SSLCipher.c
@@ -23,7 +23,7 @@ static const CK_MECHANISM_TYPE auth_alg_defs[] = {
 };
 PR_STATIC_ASSERT(PR_ARRAY_SIZE(auth_alg_defs) == ssl_auth_size);
 
-/* Copied from NSS's ssl3con.c. */
+/* Copied from NSS 3.97's ssl3con.c. */
 static const CK_MECHANISM_TYPE kea_alg_defs[] = {
     CKM_INVALID_MECHANISM, /* ssl_kea_null */
     CKM_RSA_PKCS,          /* ssl_kea_rsa */
@@ -33,8 +33,9 @@ static const CK_MECHANISM_TYPE kea_alg_defs[] = {
     CKM_ECDH1_DERIVE,      /* ssl_kea_ecdh_psk */
     CKM_DH_PKCS_DERIVE,    /* ssl_kea_dh_psk */
     CKM_INVALID_MECHANISM, /* ssl_kea_tls13_any */
+    CKM_INVALID_MECHANISM, /* ssl_kea_ecdh_hybrid */
+    CKM_INVALID_MECHANISM, /* ssl_kea_ecdh_hybrid_psk */
 };
-PR_STATIC_ASSERT(PR_ARRAY_SIZE(kea_alg_defs) == ssl_kea_size);
 
 #ifdef HAVE_NSS_CIPHER_SUITE_INFO_KDFHASH
 /* Not present in ssl3con.c. */


### PR DESCRIPTION
The `kea_alg_defs` array in `SSLCipher.c` has been updated to match the one defined in NSS 3.97. The assertion that compares the size of the array with `ssl_kea_size` has also been removed. These changes will allow JSS to work with the newer NSS 3.97 on Fedora Rawhide as well as the older NSS versions on other platforms.

Resolves: https://github.com/dogtagpki/jss/issues/991

Note: With these changes the build now works on Rawhide and most tests pass too. There are some failures, but they don't seem to be related so they need to be investigated separately:

* https://github.com/edewata/jss/actions/runs/7821129758/job/21337674464#step:11:559
* https://github.com/edewata/jss/actions/runs/7821129726/job/21337673840#step:7:2220