### PR TITLE
Fix PKCS #11 constants test

### DIFF
--- a/.github/workflows/pkcs11-tests.yml
+++ b/.github/workflows/pkcs11-tests.yml
@@ -48,16 +48,19 @@ jobs:
         run: |
           tests/bin/runner-init.sh jss
         env:
+          IMAGE: jss-builder
           HOSTNAME: jss.example.com
 
-      - name: Install dependencies
-        run: docker exec jss dnf install -y nss-util-devel python3 java-devel
-
-      - name: Generate PKCS11 constants
+      - name: Check PKCS11 constants
         run: |
-          docker exec jss python3 $SHARED/tools/build_pkcs11_constants.py \
-                   --pkcs11t /usr/include/nss3/pkcs11t.h \
-                   --pkcs11n /usr/include/nss3/pkcs11n.h \
-                   -o PKCS11Constants.java \
-                   --verbose
-          docker exec jss diff PKCS11Constants.java $SHARED/base/src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java
+          # generate new PKCS11Constants.java from NSS header files
+          docker exec jss $SHARED/tools/build_pkcs11_constants.py \
+              --pkcs11t /usr/include/nss3/pkcs11t.h \
+              --pkcs11n /usr/include/nss3/pkcs11n.h \
+              -o PKCS11Constants.java \
+              --verbose
+
+          # compare existing PKCS11Constants.java with the new one
+          docker exec jss diff \
+              $SHARED/base/src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java \
+              PKCS11Constants.java

--- a/tools/build_pkcs11_constants.py
+++ b/tools/build_pkcs11_constants.py
@@ -21,13 +21,24 @@ import tempfile
 import argparse
 import textwrap
 
-BLACKLIST = [
+# Exclude new constants added in NSS 3.97 such that this script will
+# create a new PKCS11Constants.java that will match the existing
+# PKCS11Constants.java in base/src/main/java/org/mozilla/jss/pkcs11.
+#
+# https://github.com/dogtagpki/jss/issues/993
+EXCLUDED_CONSTANTS = [
     'CK_PTR',
     'CK_VOID',
     'CK_CALLBACK_FUNCTION',
     'CK_DECLARE_FUNCTION',
     'CK_DECLARE_FUNCTION_POINTER',
-    'CK_UNAVAILABLE_INFORMATION'
+    'CK_UNAVAILABLE_INFORMATION',
+    'CKK_NSS_KYBER',                  # added in NSS 3.97
+    'CKA_NSS_PARAMETER_SET',          # added in NSS 3.97
+    'CKM_NSS_KYBER_KEY_PAIR_GEN',     # added in NSS 3.97
+    'CKM_NSS_KYBER',                  # added in NSS 3.97
+    'CKP_NSS',                        # added in NSS 3.97
+    'CKP_NSS_KYBER_768_ROUND3',       # added in NSS 3.97
 ]
 
 logger = logging.getLogger(__name__)
@@ -465,8 +476,8 @@ def parse_header(header):
         line = file_contents[line_num-1].lstrip()
         if line.startswith('#define'):
             name, value = parse_define(line)
-            if name in BLACKLIST:
-                logger.info("Skipping blacklisted constant: %s", name)
+            if name in EXCLUDED_CONSTANTS:
+                logger.info("Skipping constant: %s", name)
                 continue
 
             logger.info("Found definition %s = %s", name, value)


### PR DESCRIPTION
The PKCS #11 constants test failed on Fedora 40 since it uses NSS 3.97 that provides some new PKCS #11 constants. As a workaround the new constants need to be excluded until NSS 3.97 becomes available on all supported platforms.

The test has also been modified to reuse the `jss-builder` image which already has the build dependencies.

Resolves: https://github.com/dogtagpki/jss/issues/993