### PR TITLE
Update Java dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN if [ -n "$COPR_REPO" ]; then dnf copr enable -y $COPR_REPO; fi
 
 # Install JSS runtime dependencies
 RUN dnf install -y dogtag-jss \
-    && dnf remove -y dogtag-* --noautoremove \
+    && rpm -e --nodeps $(rpm -qa | grep -E "^java-|^dogtag-") \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 

--- a/jss.spec
+++ b/jss.spec
@@ -55,9 +55,27 @@ ExcludeArch: i686
 # Java
 ################################################################################
 
+%if 0%{?rhel}
+
 %define java_devel java-17-openjdk-devel
 %define java_headless java-17-openjdk-headless
 %define java_home %{_jvmdir}/jre-17-openjdk
+
+%else
+
+# Use Java 21 on Fedora 40+
+%global java_devel java-devel >= 1:17
+%global java_headless java-headless >= 1:17
+
+# Don't use find since it might not work well with local builds.
+#   find {_jvmdir} -maxdepth 1 | grep "jre-[0-9]\+$"
+%global java_home %(
+   source /usr/share/java-utils/java-functions;
+   _prefer_jre=true;
+   set_jvm;
+   echo $JAVA_HOME)
+
+%endif
 
 ################################################################################
 # Build Options


### PR DESCRIPTION
The RPM spec has been updated to use Java 21 on Fedora 40 or later and Java 17 on other platforms.

The `Dockerfile` has been modified to remove any Java packages pulled by the existing JSS package to ensure that the build will be done using the correct Java version.
