### PR TITLE
Fix missing OID mappings

### DIFF
--- a/base/src/main/java/org/mozilla/jss/netscape/security/extensions/ExtendedKeyUsageExtension.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/extensions/ExtendedKeyUsageExtension.java
@@ -46,18 +46,48 @@ public class ExtendedKeyUsageExtension extends Extension implements CertAttrSet 
 
     public static final String OID = "2.5.29.37";
     public static final String NAME = OIDMap.EXT_KEY_USAGE_NAME;
+    public static final String OID_IKEIntermediate = "1.3.6.1.5.5.8.2.2";
+    public static final String OID_IpsecIKE = "1.3.6.1.5.5.7.3.17";
     public static final String OID_OCSPSigning = "1.3.6.1.5.5.7.3.9";
+    public static final String OID_EMailProtection = "1.3.6.1.5.5.7.3.4";
     public static final String OID_CODESigning = "1.3.6.1.5.5.7.3.3";
+    public static final String OID_ClientAuth = "1.3.6.1.5.5.7.3.2";
+    public static final String OID_ServerAuth = "1.3.6.1.5.5.7.3.1";
+
+    public static final int OID_IKE_INTERMEDIATE_STR[] =
+        { 1, 3, 6, 1, 5, 5, 8, 2, 2 };
+    public static final ObjectIdentifier OID_IKE_INTERMEDIATE = new
+            ObjectIdentifier(OID_IKE_INTERMEDIATE_STR);
+
+    public static final int OID_ID_KP_IPSEC_IKE_STR[] =
+        { 1, 3, 6, 1, 5, 5, 7, 3, 17 };
+    public static final ObjectIdentifier OID_ID_KP_IPSEC_IKE = new
+            ObjectIdentifier(OID_ID_KP_IPSEC_IKE_STR);
 
     public static final int OID_OCSP_SIGNING_STR[] =
         { 1, 3, 6, 1, 5, 5, 7, 3, 9 };
     public static final ObjectIdentifier OID_OCSP_SIGNING = new
             ObjectIdentifier(OID_OCSP_SIGNING_STR);
 
+    public static final int OID_EMAIL_PROTECTION_STR[] =
+        { 1, 3, 6, 1, 5, 5, 7, 3, 4 };
+    public static final ObjectIdentifier OID_EMAIL_PROTECTION = new
+            ObjectIdentifier(OID_EMAIL_PROTECTION_STR);
+
     public static final int OID_CODE_SIGNING_STR[] =
         { 1, 3, 6, 1, 5, 5, 7, 3, 3 };
     public static final ObjectIdentifier OID_CODE_SIGNING = new
-            ObjectIdentifier(OID_OCSP_SIGNING_STR);
+            ObjectIdentifier(OID_CODE_SIGNING_STR);
+
+    public static final int OID_CLIENT_AUTH_STR[] =
+        { 1, 3, 6, 1, 5, 5, 7, 3, 2 };
+    public static final ObjectIdentifier OID_CLIENT_AUTH = new
+            ObjectIdentifier(OID_CLIENT_AUTH_STR);
+
+    public static final int OID_SERVER_AUTH_STR[] =
+        { 1, 3, 6, 1, 5, 5, 7, 3, 1 };
+    public static final ObjectIdentifier OID_SERVER_AUTH = new
+            ObjectIdentifier(OID_SERVER_AUTH_STR);
 
     private Vector<ObjectIdentifier> oidSet = null;
     private byte mCached[] = null;

--- a/base/src/main/java/org/mozilla/jss/netscape/security/extensions/ExtendedKeyUsageExtension.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/extensions/ExtendedKeyUsageExtension.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Vector;
 
@@ -29,7 +31,6 @@ import org.mozilla.jss.netscape.security.util.DerValue;
 import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
 import org.mozilla.jss.netscape.security.x509.CertAttrSet;
 import org.mozilla.jss.netscape.security.x509.Extension;
-import org.mozilla.jss.netscape.security.x509.OIDMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,60 +46,54 @@ public class ExtendedKeyUsageExtension extends Extension implements CertAttrSet 
     private static final Logger logger = LoggerFactory.getLogger(ExtendedKeyUsageExtension.class);
 
     public static final String OID = "2.5.29.37";
-    public static final String NAME = OIDMap.EXT_KEY_USAGE_NAME;
-    public static final String OID_IKEIntermediate = "1.3.6.1.5.5.8.2.2";
-    public static final String OID_IpsecIKE = "1.3.6.1.5.5.7.3.17";
+    public static final String NAME = "ExtendedKeyUsageExtension";
+
+    /**
+     * @deprecated This will be removed to avoid duplications
+     */
+    @Deprecated(since = "5.6.0", forRemoval = true)
     public static final String OID_OCSPSigning = "1.3.6.1.5.5.7.3.9";
-    public static final String OID_EMailProtection = "1.3.6.1.5.5.7.3.4";
+    /**
+     * @deprecated This will be removed to avoid duplications
+     */
+    @Deprecated(since = "5.6.0", forRemoval = true)
     public static final String OID_CODESigning = "1.3.6.1.5.5.7.3.3";
-    public static final String OID_ClientAuth = "1.3.6.1.5.5.7.3.2";
-    public static final String OID_ServerAuth = "1.3.6.1.5.5.7.3.1";
 
-    public static final int OID_IKE_INTERMEDIATE_STR[] =
-        { 1, 3, 6, 1, 5, 5, 8, 2, 2 };
     public static final ObjectIdentifier OID_IKE_INTERMEDIATE = new
-            ObjectIdentifier(OID_IKE_INTERMEDIATE_STR);
+            ObjectIdentifier("1.3.6.1.5.5.8.2.2");
 
-    public static final int OID_ID_KP_IPSEC_IKE_STR[] =
-        { 1, 3, 6, 1, 5, 5, 7, 3, 17 };
     public static final ObjectIdentifier OID_ID_KP_IPSEC_IKE = new
-            ObjectIdentifier(OID_ID_KP_IPSEC_IKE_STR);
+            ObjectIdentifier("1.3.6.1.5.5.7.3.17");
 
-    public static final int OID_OCSP_SIGNING_STR[] =
+    /**
+     * @deprecated This will be removed to avoid duplications
+     */
+    @Deprecated(since = "5.6.0", forRemoval = true)
+    public static final int[] OID_OCSP_SIGNING_STR =
         { 1, 3, 6, 1, 5, 5, 7, 3, 9 };
     public static final ObjectIdentifier OID_OCSP_SIGNING = new
-            ObjectIdentifier(OID_OCSP_SIGNING_STR);
+            ObjectIdentifier("1.3.6.1.5.5.7.3.9");
 
-    public static final int OID_EMAIL_PROTECTION_STR[] =
-        { 1, 3, 6, 1, 5, 5, 7, 3, 4 };
     public static final ObjectIdentifier OID_EMAIL_PROTECTION = new
-            ObjectIdentifier(OID_EMAIL_PROTECTION_STR);
+            ObjectIdentifier("1.3.6.1.5.5.7.3.4");
 
-    public static final int OID_CODE_SIGNING_STR[] =
+    /**
+     * @deprecated This will be removed to avoid duplications
+     */
+    @Deprecated(since = "5.6.0", forRemoval = true)
+    public static final int[] OID_CODE_SIGNING_STR =
         { 1, 3, 6, 1, 5, 5, 7, 3, 3 };
     public static final ObjectIdentifier OID_CODE_SIGNING = new
-            ObjectIdentifier(OID_CODE_SIGNING_STR);
+            ObjectIdentifier("1.3.6.1.5.5.7.3.3");
 
-    public static final int OID_CLIENT_AUTH_STR[] =
-        { 1, 3, 6, 1, 5, 5, 7, 3, 2 };
     public static final ObjectIdentifier OID_CLIENT_AUTH = new
-            ObjectIdentifier(OID_CLIENT_AUTH_STR);
+            ObjectIdentifier("1.3.6.1.5.5.7.3.2");
 
-    public static final int OID_SERVER_AUTH_STR[] =
-        { 1, 3, 6, 1, 5, 5, 7, 3, 1 };
     public static final ObjectIdentifier OID_SERVER_AUTH = new
-            ObjectIdentifier(OID_SERVER_AUTH_STR);
+            ObjectIdentifier("1.3.6.1.5.5.7.3.1");
 
-    private Vector<ObjectIdentifier> oidSet = null;
-    private byte mCached[] = null;
-
-    static {
-        try {
-            OIDMap.addAttribute(ExtendedKeyUsageExtension.class.getName(),
-                    OID, ExtendedKeyUsageExtension.NAME);
-        } catch (CertificateException e) {
-        }
-    }
+    private ArrayList<ObjectIdentifier> oidSet = null;
+    private byte[] mCached = null;
 
     public ExtendedKeyUsageExtension() throws IOException {
         this(false, null);
@@ -112,9 +107,9 @@ public class ExtendedKeyUsageExtension extends Extension implements CertAttrSet 
         }
         critical = crit;
         if (oids != null) {
-            oidSet = new Vector<>(oids);
+            oidSet = new ArrayList<>(oids);
         } else {
-            oidSet = new Vector<>();
+            oidSet = new ArrayList<>();
         }
         encodeExtValue();
     }
@@ -138,7 +133,7 @@ public class ExtendedKeyUsageExtension extends Extension implements CertAttrSet 
     public Enumeration<ObjectIdentifier> getOIDs() {
         if (oidSet == null)
             return null;
-        return oidSet.elements();
+        return Collections.enumeration(oidSet);
     }
 
     public void deleteAllOIDs() {
@@ -149,12 +144,12 @@ public class ExtendedKeyUsageExtension extends Extension implements CertAttrSet 
 
     public void addOID(ObjectIdentifier oid) {
         if (oidSet == null) {
-            oidSet = new Vector<>();
+            oidSet = new ArrayList<>();
         }
 
         if (oidSet.contains(oid))
             return;
-        oidSet.addElement(oid);
+        oidSet.add(oid);
         mCached = null;
     }
 
@@ -235,11 +230,11 @@ public class ExtendedKeyUsageExtension extends Extension implements CertAttrSet 
             throw new IOException("Invalid encoding of AuthInfoAccess extension");
         }
         if (oidSet == null)
-            oidSet = new Vector<>();
+            oidSet = new ArrayList<>();
         while (val.data.available() != 0) {
             DerValue oidVal = val.data.getDerValue();
 
-            oidSet.addElement(oidVal.getOID());
+            oidSet.add(oidVal.getOID());
         }
     }
 
@@ -248,7 +243,7 @@ public class ExtendedKeyUsageExtension extends Extension implements CertAttrSet 
         DerOutputStream temp = new DerOutputStream();
 
         if (!oidSet.isEmpty()) {
-            Enumeration<ObjectIdentifier> oidList = oidSet.elements();
+            Enumeration<ObjectIdentifier> oidList = Collections.enumeration(oidSet);
 
             try {
                 while (oidList.hasMoreElements()) {

--- a/base/src/main/java/org/mozilla/jss/netscape/security/extensions/InhibitAnyPolicyExtension.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/extensions/InhibitAnyPolicyExtension.java
@@ -30,7 +30,6 @@ import org.mozilla.jss.netscape.security.util.DerValue;
 import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
 import org.mozilla.jss.netscape.security.x509.CertAttrSet;
 import org.mozilla.jss.netscape.security.x509.Extension;
-import org.mozilla.jss.netscape.security.x509.OIDMap;
 
 /**
  * RFC3280:
@@ -49,17 +48,9 @@ public class InhibitAnyPolicyExtension
      */
     private static final long serialVersionUID = -8963439897419343166L;
     public static final String OID = "2.5.29.54";
-    public static final String NAME = OIDMap.EXT_INHIBIT_ANY_POLICY_NAME;
+    public static final String NAME = "InhibitAnyPolicyExtension";
 
     private BigInt mSkipCerts = new BigInt(-1);
-
-    static {
-        try {
-            OIDMap.addAttribute(InhibitAnyPolicyExtension.class.getName(),
-                    OID, NAME);
-        } catch (CertificateException e) {
-        }
-    }
 
     public InhibitAnyPolicyExtension() throws IOException {
         this(false, null);

--- a/base/src/main/java/org/mozilla/jss/netscape/security/extensions/OCSPNoCheckExtension.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/extensions/OCSPNoCheckExtension.java
@@ -27,7 +27,6 @@ import org.mozilla.jss.netscape.security.util.DerOutputStream;
 import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
 import org.mozilla.jss.netscape.security.x509.CertAttrSet;
 import org.mozilla.jss.netscape.security.x509.Extension;
-import org.mozilla.jss.netscape.security.x509.OIDMap;
 
 /**
  * This represents the OCSPNoCheck extension.
@@ -42,14 +41,6 @@ public class OCSPNoCheckExtension extends Extension implements CertAttrSet {
     public static final String NAME = "OCSPNoCheckExtension";
 
     private byte mCached[] = null;
-
-    static {
-        try {
-            OIDMap.addAttribute(OCSPNoCheckExtension.class.getName(),
-                    OID, NAME);
-        } catch (CertificateException e) {
-        }
-    }
 
     public OCSPNoCheckExtension() throws IOException {
         this(Boolean.FALSE);

--- a/base/src/main/java/org/mozilla/jss/netscape/security/util/ExtPrettyPrint.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/util/ExtPrettyPrint.java
@@ -479,8 +479,20 @@ public class ExtPrettyPrint {
             while (e.hasMoreElements()) {
                 ObjectIdentifier oid = e.nextElement();
 
-                if (oid.equals(ExtendedKeyUsageExtension.OID_OCSP_SIGNING)) {
+                if (oid.equals(ExtendedKeyUsageExtension.OID_IKE_INTERMEDIATE)) {
+                    sb.append(pp.indent(mIndentSize + 8) + "ipsec Intermediate System Usage" + "\n");
+                } else if (oid.equals(ExtendedKeyUsageExtension.OID_ID_KP_IPSEC_IKE)) {
+                    sb.append(pp.indent(mIndentSize + 8) + "ipsec Internet Key Exchange" + "\n");
+                } else if (oid.equals(ExtendedKeyUsageExtension.OID_OCSP_SIGNING)) {
                     sb.append(pp.indent(mIndentSize + 8) + "OCSPSigning" + "\n");
+                } else if (oid.equals(ExtendedKeyUsageExtension.OID_EMAIL_PROTECTION)) {
+                    sb.append(pp.indent(mIndentSize + 8) + "emailProtection" + "\n");
+                } else if (oid.equals(ExtendedKeyUsageExtension.OID_CODE_SIGNING)) {
+                    sb.append(pp.indent(mIndentSize + 8) + "codeSigning" + "\n");
+                } else if (oid.equals(ExtendedKeyUsageExtension.OID_CLIENT_AUTH)) {
+                    sb.append(pp.indent(mIndentSize + 8) + "clientAuth" + "\n");
+                } else if (oid.equals(ExtendedKeyUsageExtension.OID_SERVER_AUTH)) {
+                    sb.append(pp.indent(mIndentSize + 8) + "serverAuth" + "\n");
                 } else {
                     sb.append(pp.indent(mIndentSize + 8) + oid.toString() + "\n");
                 }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/util/ExtPrettyPrint.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/util/ExtPrettyPrint.java
@@ -480,21 +480,28 @@ public class ExtPrettyPrint {
                 ObjectIdentifier oid = e.nextElement();
 
                 if (oid.equals(ExtendedKeyUsageExtension.OID_IKE_INTERMEDIATE)) {
-                    sb.append(pp.indent(mIndentSize + 8) + "ipsec Intermediate System Usage" + "\n");
+                    sb.append(pp.indent(mIndentSize + 8) + "ipsec Intermediate System Usage" +
+                            " - " + oid + "\n");
                 } else if (oid.equals(ExtendedKeyUsageExtension.OID_ID_KP_IPSEC_IKE)) {
-                    sb.append(pp.indent(mIndentSize + 8) + "ipsec Internet Key Exchange" + "\n");
+                    sb.append(pp.indent(mIndentSize + 8) + "ipsec Internet Key Exchange" +
+                            " - " + oid + "\n");
                 } else if (oid.equals(ExtendedKeyUsageExtension.OID_OCSP_SIGNING)) {
-                    sb.append(pp.indent(mIndentSize + 8) + "OCSPSigning" + "\n");
+                    sb.append(pp.indent(mIndentSize + 8) + "OCSPSigning" +
+                            " - " + oid + "\n");
                 } else if (oid.equals(ExtendedKeyUsageExtension.OID_EMAIL_PROTECTION)) {
-                    sb.append(pp.indent(mIndentSize + 8) + "emailProtection" + "\n");
+                    sb.append(pp.indent(mIndentSize + 8) + "emailProtection" +
+                            " - " + oid + "\n");
                 } else if (oid.equals(ExtendedKeyUsageExtension.OID_CODE_SIGNING)) {
-                    sb.append(pp.indent(mIndentSize + 8) + "codeSigning" + "\n");
+                    sb.append(pp.indent(mIndentSize + 8) + "codeSigning" +
+                            " - " + oid + "\n");
                 } else if (oid.equals(ExtendedKeyUsageExtension.OID_CLIENT_AUTH)) {
-                    sb.append(pp.indent(mIndentSize + 8) + "clientAuth" + "\n");
+                    sb.append(pp.indent(mIndentSize + 8) + "clientAuth" +
+                            " - " + oid + "\n");
                 } else if (oid.equals(ExtendedKeyUsageExtension.OID_SERVER_AUTH)) {
-                    sb.append(pp.indent(mIndentSize + 8) + "serverAuth" + "\n");
+                    sb.append(pp.indent(mIndentSize + 8) + "serverAuth" +
+                            " - " + oid + "\n");
                 } else {
-                    sb.append(pp.indent(mIndentSize + 8) + oid.toString() + "\n");
+                    sb.append(pp.indent(mIndentSize + 8) + oid + "\n");
                 }
             }
         }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/OIDMap.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/OIDMap.java
@@ -26,6 +26,8 @@ import java.util.Iterator;
 import java.util.Properties;
 
 import org.mozilla.jss.netscape.security.extensions.AuthInfoAccessExtension;
+import org.mozilla.jss.netscape.security.extensions.InhibitAnyPolicyExtension;
+import org.mozilla.jss.netscape.security.extensions.OCSPNoCheckExtension;
 import org.mozilla.jss.netscape.security.extensions.SubjectInfoAccessExtension;
 import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
 import org.slf4j.Logger;
@@ -94,8 +96,11 @@ public class OIDMap {
 
     public static final String EXT_KEY_USAGE_NAME = "ExtendedKeyUsageExtension";
     public static final String EXT_INHIBIT_ANY_POLICY_NAME = "InhibitAnyPolicyExtension";
+    private static final String EXT_INHIBIT_ANY_POLICY = ROOT + "." + InhibitAnyPolicyExtension.NAME;
     private static final String EXT_KEY_USAGE = ROOT + "." +
             EXT_KEY_USAGE_NAME;
+
+    private static final String OCSP_NO_CHECK = ROOT + "." + OCSPNoCheckExtension.NAME;
 
     private static final String CRL_NUMBER = ROOT + "." +
                                           CRLNumberExtension.NAME;
@@ -132,6 +137,8 @@ public class OIDMap {
         props.put(AUTH_KEY_IDENTIFIER, "2.5.29.35");
         props.put(SUBJ_DIR_ATTR, "2.5.29.9");
         props.put(EXT_KEY_USAGE, "2.5.29.37");
+        props.put(EXT_INHIBIT_ANY_POLICY, "2.5.29.54");
+        props.put(OCSP_NO_CHECK, "1.3.6.1.5.5.7.48.1.5");
     }
 
     // Load the default name to class map (EXTENSIONS_CLASSES)
@@ -166,6 +173,10 @@ public class OIDMap {
                   "org.mozilla.jss.netscape.security.x509.SubjectDirAttributesExtension");
         props.put(EXT_KEY_USAGE,
                   "org.mozilla.jss.netscape.security.extensions.ExtendedKeyUsageExtension");
+        props.put(EXT_INHIBIT_ANY_POLICY,
+                "org.mozilla.jss.netscape.security.extensions.InhibitAnyPolicyExtension");
+        props.put(OCSP_NO_CHECK,
+                "org.mozilla.jss.netscape.security.extensions.OCSPNoCheckExtension");
         props.put(CRL_NUMBER, "org.mozilla.jss.netscape.security.x509.CRLNumberExtension");
         props.put(CRL_REASON, "org.mozilla.jss.netscape.security.x509.CRLReasonExtension");
     }

--- a/base/src/main/java/org/mozilla/jss/netscape/security/x509/OIDMap.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/x509/OIDMap.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.Properties;
 
 import org.mozilla.jss.netscape.security.extensions.AuthInfoAccessExtension;
+import org.mozilla.jss.netscape.security.extensions.ExtendedKeyUsageExtension;
 import org.mozilla.jss.netscape.security.extensions.InhibitAnyPolicyExtension;
 import org.mozilla.jss.netscape.security.extensions.OCSPNoCheckExtension;
 import org.mozilla.jss.netscape.security.extensions.SubjectInfoAccessExtension;
@@ -94,13 +95,16 @@ public class OIDMap {
     private static final String SUBJ_DIR_ATTR = ROOT + "." +
             SubjectDirAttributesExtension.NAME;
 
+    /**
+     * @deprecated This will be removed to avoid duplications
+     */
+    @Deprecated(since = "5.6.0", forRemoval = true)
     public static final String EXT_KEY_USAGE_NAME = "ExtendedKeyUsageExtension";
+    /**
+     * @deprecated This will be removed to avoid duplications
+     */
+    @Deprecated(since = "5.6.0", forRemoval = true)
     public static final String EXT_INHIBIT_ANY_POLICY_NAME = "InhibitAnyPolicyExtension";
-    private static final String EXT_INHIBIT_ANY_POLICY = ROOT + "." + InhibitAnyPolicyExtension.NAME;
-    private static final String EXT_KEY_USAGE = ROOT + "." +
-            EXT_KEY_USAGE_NAME;
-
-    private static final String OCSP_NO_CHECK = ROOT + "." + OCSPNoCheckExtension.NAME;
 
     private static final String CRL_NUMBER = ROOT + "." +
                                           CRLNumberExtension.NAME;
@@ -116,6 +120,9 @@ public class OIDMap {
         loadNames();
         loadClasses();
         addClass(CRLDistributionPointsExtension.class);
+        addClass(ExtendedKeyUsageExtension.class);
+        addClass(OCSPNoCheckExtension.class);
+        addClass(InhibitAnyPolicyExtension.class);
     }
 
     // Load the default name to oid map (EXTENSIONS_OIDS)
@@ -136,49 +143,28 @@ public class OIDMap {
         props.put(CERT_POLICIES, "2.5.29.32");
         props.put(AUTH_KEY_IDENTIFIER, "2.5.29.35");
         props.put(SUBJ_DIR_ATTR, "2.5.29.9");
-        props.put(EXT_KEY_USAGE, "2.5.29.37");
-        props.put(EXT_INHIBIT_ANY_POLICY, "2.5.29.54");
-        props.put(OCSP_NO_CHECK, "1.3.6.1.5.5.7.48.1.5");
     }
 
     // Load the default name to class map (EXTENSIONS_CLASSES)
     private static void loadClassDefault(Properties props) {
-        props.put(AUTH_KEY_IDENTIFIER,
-                   "org.mozilla.jss.netscape.security.x509.AuthorityKeyIdentifierExtension");
-        props.put(SUB_KEY_IDENTIFIER,
-                  "org.mozilla.jss.netscape.security.x509.SubjectKeyIdentifierExtension");
+        props.put(AUTH_KEY_IDENTIFIER, AuthorityKeyIdentifierExtension.class.getName());
+        props.put(SUB_KEY_IDENTIFIER, SubjectKeyIdentifierExtension.class.getName());
         props.put(AUTHORITY_INFORMATION_ACCESS_IDENTIFIER,
-                 "org.mozilla.jss.netscape.security.extensions.AuthInfoAccessExtension");
+                AuthInfoAccessExtension.class.getName());
         props.put(SUBJECT_INFORMATION_ACCESS_IDENTIFIER,
-                "org.mozilla.jss.netscape.security.extensions.SubjectInfoAccessExtension");
-        props.put(KEY_USAGE,
-                  "org.mozilla.jss.netscape.security.x509.KeyUsageExtension");
-        props.put(PRIVATE_KEY_USAGE,
-                  "org.mozilla.jss.netscape.security.x509.PrivateKeyUsageExtension");
-        props.put(POLICY_MAPPINGS,
-                  "org.mozilla.jss.netscape.security.x509.PolicyMappingsExtension");
-        props.put(SUB_ALT_NAME,
-                  "org.mozilla.jss.netscape.security.x509.SubjectAlternativeNameExtension");
-        props.put(ISSUER_ALT_NAME,
-                  "org.mozilla.jss.netscape.security.x509.IssuerAlternativeNameExtension");
-        props.put(BASIC_CONSTRAINTS,
-                  "org.mozilla.jss.netscape.security.x509.BasicConstraintsExtension");
-        props.put(NAME_CONSTRAINTS,
-                  "org.mozilla.jss.netscape.security.x509.NameConstraintsExtension");
-        props.put(POLICY_CONSTRAINTS,
-                  "org.mozilla.jss.netscape.security.x509.PolicyConstraintsExtension");
-        props.put(CERT_POLICIES,
-                  "org.mozilla.jss.netscape.security.x509.CertificatePoliciesExtension");
-        props.put(SUBJ_DIR_ATTR,
-                  "org.mozilla.jss.netscape.security.x509.SubjectDirAttributesExtension");
-        props.put(EXT_KEY_USAGE,
-                  "org.mozilla.jss.netscape.security.extensions.ExtendedKeyUsageExtension");
-        props.put(EXT_INHIBIT_ANY_POLICY,
-                "org.mozilla.jss.netscape.security.extensions.InhibitAnyPolicyExtension");
-        props.put(OCSP_NO_CHECK,
-                "org.mozilla.jss.netscape.security.extensions.OCSPNoCheckExtension");
-        props.put(CRL_NUMBER, "org.mozilla.jss.netscape.security.x509.CRLNumberExtension");
-        props.put(CRL_REASON, "org.mozilla.jss.netscape.security.x509.CRLReasonExtension");
+                SubjectInfoAccessExtension.class.getName());
+        props.put(KEY_USAGE, KeyUsageExtension.class.getName());
+        props.put(PRIVATE_KEY_USAGE, PrivateKeyUsageExtension.class.getName());
+        props.put(POLICY_MAPPINGS, PolicyMappingsExtension.class.getName());
+        props.put(SUB_ALT_NAME, SubjectAlternativeNameExtension.class.getName());
+        props.put(ISSUER_ALT_NAME, IssuerAlternativeNameExtension.class.getName());
+        props.put(BASIC_CONSTRAINTS, BasicConstraintsExtension.class.getName());
+        props.put(NAME_CONSTRAINTS, NameConstraintsExtension.class.getName());
+        props.put(POLICY_CONSTRAINTS, PolicyConstraintsExtension.class.getName());
+        props.put(CERT_POLICIES, CertificatePoliciesExtension.class.getName());
+        props.put(SUBJ_DIR_ATTR, SubjectDirAttributesExtension.class.getName());
+        props.put(CRL_NUMBER, CRLNumberExtension.class.getName());
+        props.put(CRL_REASON, CRLReasonExtension.class.getName());
     }
 
     // Return the file along with location
@@ -194,20 +180,10 @@ public class OIDMap {
         if (!namesMap.exists()) {
             loadNamesDefault(props);
         } else {
-            FileInputStream fis = null;
-            try {
-                fis = new FileInputStream(namesMap);
+            try (FileInputStream fis = new FileInputStream(namesMap)){
                 props.load(fis);
             } catch (IOException e) {
                 loadNamesDefault(props);
-            } finally {
-                if (fis != null) {
-                    try {
-                        fis.close();
-                    } catch (IOException e) {
-                        logger.debug("Error closing " + EXTENSIONS_OIDS, e);
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
Pretty print some additional OID:

OCSP No Check - id-pkix-ocsp-nocheck { 1.3.6.1.5.5.7.48.1.5} Inhibit Any Policy {2.5.29.54}
Extended Key Usage:
- serverAuth {1 3 6 1 5 5 7 3 1}
- clientAuth {1 3 6 1 5 5 7 3 2}
- codeSigning {1 3 6 1 5 5 7 3 3}
- emailProtection {1 3 6 1 5 5 7 3 4}