### PR TITLE
Enabling certificate verification using CRL-DP extension

### DIFF
--- a/docs/changes/v5.6.0/Parameter-Changes.adoc
+++ b/docs/changes/v5.6.0/Parameter-Changes.adoc
@@ -1,0 +1,5 @@
+= Paramater Changes =
+
+== Rename enableOCSP to enableRevocationCheck ==
+
+The `enableOCSP` param has been deprecated. Use `enableRevocationCheck` instead.

--- a/tomcat/src/main/java/org/dogtagpki/jss/tomcat/Http11NioProtocol.java
+++ b/tomcat/src/main/java/org/dogtagpki/jss/tomcat/Http11NioProtocol.java
@@ -73,12 +73,20 @@ public class Http11NioProtocol extends AbstractHttp11JsseProtocol<NioChannel> {
         tomcatjss.setServerCertNickFile(serverCertNickFile);
     }
 
-    public boolean getEnabledOCSP() {
-        return tomcatjss.getEnableOCSP();
+    public boolean getEnableOCSP() {
+        return tomcatjss.getEnableRevocationCheck();
     }
 
     public void setEnableOCSP(boolean enableOCSP) {
-        tomcatjss.setEnableOCSP(enableOCSP);
+        tomcatjss.setEnableRevocationCheck(enableOCSP);
+    }
+
+    public boolean getEnableRevocationCheck() {
+        return tomcatjss.getEnableRevocationCheck();
+    }
+    
+    public void setEnableRevocationCheck(boolean enableRevocationCheck) {
+        tomcatjss.setEnableRevocationCheck(enableRevocationCheck);
     }
 
     public String getOcspResponderURL() {

--- a/tomcat/src/main/java/org/dogtagpki/jss/tomcat/TomcatJSS.java
+++ b/tomcat/src/main/java/org/dogtagpki/jss/tomcat/TomcatJSS.java
@@ -88,7 +88,7 @@ public class TomcatJSS implements SSLSocketListener {
     boolean requireClientAuth;
     boolean wantClientAuth;
 
-    boolean enableOCSP;
+    boolean enableRevocationCheck;
     String ocspResponderURL;
     String ocspResponderCertNickname;
     int ocspCacheSize = 1000; // entries
@@ -183,12 +183,12 @@ public class TomcatJSS implements SSLSocketListener {
         return wantClientAuth;
     }
 
-    public boolean getEnableOCSP() {
-        return enableOCSP;
+    public boolean getEnableRevocationCheck() {
+        return enableRevocationCheck;
     }
 
-    public void setEnableOCSP(boolean enableOCSP) {
-        this.enableOCSP = enableOCSP;
+    public void setEnableRevocationCheck(boolean enableRevocationCheck) {
+        this.enableRevocationCheck = enableRevocationCheck;
     }
 
     public String getOcspResponderURL() {
@@ -269,7 +269,11 @@ public class TomcatJSS implements SSLSocketListener {
 
         String enableOCSPProp = config.getProperty("enableOCSP");
         if (enableOCSPProp != null)
-            setEnableOCSP(Boolean.parseBoolean(enableOCSPProp));
+            setEnableRevocationCheck(Boolean.parseBoolean(enableOCSPProp));
+
+        String enableRevocationCheckProp = config.getProperty("enableRevocationCheck");
+        if (enableRevocationCheckProp != null)
+            setEnableRevocationCheck(Boolean.parseBoolean(enableRevocationCheckProp));
 
         String ocspResponderURLProp = config.getProperty("ocspResponderURL");
         if (ocspResponderURLProp != null)
@@ -328,31 +332,35 @@ public class TomcatJSS implements SSLSocketListener {
         }
 
         String certDbProp = connector.getAttribute("certdbDir");
-        if (certDbProp != null)
+        if (StringUtils.isNotEmpty(certDbProp))
             setCertdbDir(certDbProp);
 
         String passwordClassProp = connector.getAttribute("passwordClass");
-        if (passwordClassProp != null)
+        if (StringUtils.isNotEmpty(passwordClassProp))
             setPasswordClass(passwordClassProp);
 
         String passwordFileProp = connector.getAttribute("passwordFile");
-        if (passwordFileProp != null)
+        if (StringUtils.isNotEmpty(passwordFileProp))
             setPasswordFile(passwordFileProp);
 
         String serverCertNickFileProp = connector.getAttribute("serverCertNickFile");
-        if (serverCertNickFileProp != null)
+        if (StringUtils.isNotEmpty(serverCertNickFileProp))
             setServerCertNickFile(serverCertNickFileProp);
 
         String enableOCSPProp = connector.getAttribute("enableOCSP");
-        if (enableOCSPProp != null)
-            setEnableOCSP(Boolean.parseBoolean(enableOCSPProp));
+        if (StringUtils.isNotEmpty(enableOCSPProp))
+            setEnableRevocationCheck(Boolean.parseBoolean(enableOCSPProp));
+
+        String enableRevocationCheckProp = connector.getAttribute("enableRevocationCheck");
+        if (StringUtils.isNotEmpty(enableRevocationCheckProp))
+            setEnableRevocationCheck(Boolean.parseBoolean(enableRevocationCheckProp));
 
         String ocspResponderURLProp = connector.getAttribute("ocspResponderURL");
-        if (ocspResponderURLProp != null)
+        if (StringUtils.isNotEmpty(ocspResponderURLProp))
             setOcspResponderURL(ocspResponderURLProp);
 
         String ocspResponderCertNicknameProp = connector.getAttribute("ocspResponderCertNickname");
-        if (ocspResponderCertNicknameProp != null)
+        if (StringUtils.isNotEmpty(ocspResponderCertNicknameProp))
             setOcspResponderCertNickname(ocspResponderCertNicknameProp);
 
         String ocspCacheSizeProp = connector.getAttribute("ocspCacheSize");
@@ -469,7 +477,7 @@ public class TomcatJSS implements SSLSocketListener {
         logger.debug("wantClientAuth: {}", wantClientAuth);
 
         if (requireClientAuth || wantClientAuth) {
-            configureOCSP();
+            configureRevocationCheck();
         }
 
         // 12 hours = 43200 seconds
@@ -549,12 +557,12 @@ public class TomcatJSS implements SSLSocketListener {
         return null;
     }
 
-    public void configureOCSP() throws GeneralSecurityException, ConfigurationException {
+    public void configureRevocationCheck() throws GeneralSecurityException, ConfigurationException {
 
-        logger.info("configuring OCSP");
+        logger.info("configuring Revocation Check");
 
-        logger.debug("enableOCSP: {}", enableOCSP);
-        if (!enableOCSP) {
+        logger.debug("enableCertificateCheck: {}", enableRevocationCheck);
+        if (!enableRevocationCheck) {
             return;
         }
 


### PR DESCRIPTION
Currently certificates can be validated only using OCSP with a configured responder or using the AIA certificate extension. If the responder cannot be used verification is not possible. This is the case for the startup certificates of the responder.

The new policy add a verification using the CRL-DP extension defined in the certificate. If this extension is defined it has precedence over the OCSP and if it pass no other check are performed. If CRL cannot be retrieved then the OCSP responder is used. This new method takes place when OCSP is configured without a default responder and the PKIX verification method is adopted (with the policy OCSP_LEAF_AND_CHAIN_POLICY).

At least a verification method has to return success to accept the certificate.

Additionally, the connector parameter `enableOCSP` is renamed to `enableRevocationCheck` since this is used to enable CRL-DP and AIA based validation