### PR TITLE
Replace IPasswordStore with PasswordStore

### DIFF
--- a/docs/changes/v5.6.0/API-Changes.adoc
+++ b/docs/changes/v5.6.0/API-Changes.adoc
@@ -1,0 +1,6 @@
+= API Changes =
+
+== Deprecate IPasswordStore ==
+
+The `org.dogtagpki.jss.tomcat.IPasswordStore` has been deprecated.
+Use `org.dogtagpki.jss.tomcat.PasswordStore` instead.

--- a/tomcat/src/main/java/org/dogtagpki/jss/tomcat/PasswordStore.java
+++ b/tomcat/src/main/java/org/dogtagpki/jss/tomcat/PasswordStore.java
@@ -19,9 +19,20 @@
 
 package org.dogtagpki.jss.tomcat;
 
-/**
- * @deprecated Use org.dogtagpki.jss.tomcat.PasswordStore instead.
- */
-@Deprecated(since="5.6.0", forRemoval=true)
-public interface IPasswordStore extends PasswordStore {
+import java.io.IOException;
+import java.util.Enumeration;
+
+public interface PasswordStore {
+    public void init(String pwdPath) throws IOException;
+
+    public String getPassword(String tag, int iteration);
+
+    public String getPassword(String tag);
+
+    public Enumeration<String> getTags();
+
+    public Object putPassword(String tag, String password);
+
+    public void commit() throws IOException, ClassCastException,
+            NullPointerException;
 }

--- a/tomcat/src/main/java/org/dogtagpki/jss/tomcat/PlainPasswordFile.java
+++ b/tomcat/src/main/java/org/dogtagpki/jss/tomcat/PlainPasswordFile.java
@@ -29,7 +29,7 @@ import java.io.OutputStreamWriter;
 import java.util.Enumeration;
 import java.util.Properties;
 
-public class PlainPasswordFile implements IPasswordStore {
+public class PlainPasswordFile implements PasswordStore {
     private String mPwdPath = "";
     private Properties mPwdStore;
     private static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PlainPasswordFile.class);

--- a/tomcat/src/main/java/org/dogtagpki/jss/tomcat/TomcatJSS.java
+++ b/tomcat/src/main/java/org/dogtagpki/jss/tomcat/TomcatJSS.java
@@ -79,7 +79,7 @@ public class TomcatJSS implements SSLSocketListener {
 
     String passwordClass;
     String passwordFile;
-    IPasswordStore passwordStore;
+    PasswordStore passwordStore;
 
     String serverCertNickFile;
     String serverCertNick;
@@ -147,11 +147,11 @@ public class TomcatJSS implements SSLSocketListener {
         return serverCertNickFile;
     }
 
-    public IPasswordStore getPasswordStore() {
+    public PasswordStore getPasswordStore() {
         return passwordStore;
     }
 
-    public void setPasswordStore(IPasswordStore passwordStore) {
+    public void setPasswordStore(PasswordStore passwordStore) {
         this.passwordStore = passwordStore;
     }
 
@@ -451,7 +451,7 @@ public class TomcatJSS implements SSLSocketListener {
 
         manager = CryptoManager.getInstance();
 
-        passwordStore = (IPasswordStore) Class.forName(passwordClass).getDeclaredConstructor().newInstance();
+        passwordStore = (PasswordStore) Class.forName(passwordClass).getDeclaredConstructor().newInstance();
         passwordStore.init(passwordFile);
 
         login();


### PR DESCRIPTION
The `PasswordStore` has been added to replace `IPasswordStore`. The `IPasswordStore` has been deprecated and will be removed in the future.

https://github.com/edewata/jss/blob/deprecation/docs/changes/v5.6.0/API-Changes.adoc
