### PR TITLE
Include certificate information in SSL session

### DIFF
--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -1006,7 +1006,6 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
     private void updateHandshakeState() {
         debug("JSSEngine: updateHandshakeState()");
-
         // If we've previously seen an exception, we should just return
         // here; there's already an alert on the wire, so there's no point
         // in checking for new ones and/or stepping the handshake: it has
@@ -1053,6 +1052,14 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         debug("JSSEngine.updateHandshakeState() - forcing handshake");
         if (SSL.ForceHandshake(ssl_fd) == SSL.SECFailure) {
             int error_value = PR.GetError();
+
+            try {
+                PK11Cert[] peer_chain = SSL.PeerCertificateChain(ssl_fd);
+                session.setPeerCertificates(peer_chain);
+            } catch (Exception e) {
+                // If certificate is not available, then the handshake error is before
+                // peerCertificate was retrieved. The following message is enough to report
+            }
 
             if (error_value != PRErrors.WOULD_BLOCK_ERROR) {
                 debug("JSSEngine.updateHandshakeState() - FATAL " + getStatus());


### PR DESCRIPTION
Certificates are included in the SSL session also in case of handshake failure. If certificate are not available there are no exception and or error reported beside the one creating the failure.

Certificate information are needed in case of event audits.