### PR TITLE
Fix test 17 error on build

### DIFF
--- a/base/src/test/java/org/mozilla/jss/tests/TestRawSSL.java
+++ b/base/src/test/java/org/mozilla/jss/tests/TestRawSSL.java
@@ -1,5 +1,6 @@
 package org.mozilla.jss.tests;
 
+import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.nss.PR;
 import org.mozilla.jss.nss.PRFDProxy;
 import org.mozilla.jss.nss.SSL;
@@ -27,15 +28,15 @@ public class TestRawSSL {
         SSLFDProxy ssl_fd = SSL.ImportFD(null, fd);
         assert(ssl_fd != null);
 
-        // 8 == SSL_ENABLE_SSL3; disable it
-        assert(SSL.OptionSet(ssl_fd, 8, 0) == SSL.SECSuccess);
+        // 9 == SSL_NO_CACHE; disable it
+        assert(SSL.OptionSet(ssl_fd, 9, 0) == SSL.SECSuccess);
 
         // Validate that the set worked.
-        assert(SSL.OptionGet(ssl_fd, 8) == SSL.SECSuccess);
+        assert(SSL.OptionGet(ssl_fd, 9) == SSL.SECSuccess);
 
-        // Renable SSL_ENABLE_SSL3 and validate it worked
-        assert(SSL.OptionSet(ssl_fd, 8, 1) == SSL.SECSuccess);
-        assert(SSL.OptionGet(ssl_fd, 8) == 1);
+        // Renable SSL_NO_CACHE and validate it worked
+        assert(SSL.OptionSet(ssl_fd, 9, 1) == SSL.SECSuccess);
+        assert(SSL.OptionGet(ssl_fd, 9) == 1);
 
         // Ensure that setting an invalid option fails
         assert(SSL.OptionSet(ssl_fd, 799999, 0) != SSL.SECSuccess);
@@ -160,7 +161,7 @@ public class TestRawSSL {
             System.out.println("Usage: TestRawSSL /path/to/nssdb");
             System.exit(1);
         }
-
+        CryptoManager cm = CryptoManager.getInstance();
         System.out.println("Calling TestSSLImportFD()...");
         TestSSLImportFD();
 


### PR DESCRIPTION
With the nss update to >= 3.101 the nss context gets initialised after the CryptoManager instance is retrieved so this step is added before the test.

The original error was in this NSS line: https://github.com/nss-dev/nss/blob/4b0cca5ba45b3713e279f9d528dfa01dd886cea8/lib/nss/nssinit.c#L1002

All the other tests were working because the use of the CryptoManager before performing and operation involving NSS.

Additionally, the ssl option test for get and set has been modified to enable/disable ssl cache since the ssl3 option is policy dependent and do not always work. 
Fix #1010 


Note about the options: running the test with NSS released on fedora using SSL3 option was not working but using my build (I have included debug options) the test works. Looking at the code SSL3 cannot be enabled if it is not supported by the policy: https://github.com/nss-dev/nss/blob/4b0cca5ba45b3713e279f9d528dfa01dd886cea8/lib/ssl/sslsock.c#L629. Therefore I have just used a different option since the test was just to verify that option can be configured and it was not related to ssl3. We can investigate more if needed.
