### PR TITLE
Publish Maven artifacts to dogtagpki/repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,11 @@ jobs:
     name: Publishing Maven artifacts
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install xmlstarlet
+
       - name: Clone repository
         uses: actions/checkout@v4
 
@@ -23,15 +28,21 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Check settings.xml
+      - name: Configure settings.xml
         run: |
+          xmlstarlet edit --inplace \
+              -u "/_:settings/_:servers/_:server[_:id='github']/_:password" \
+              -v "$REPO_TOKEN" \
+              ~/.m2/settings.xml
           cat ~/.m2/settings.xml
+        env:
+          REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
 
-      - name: Update pom.xml
+      - name: Configure pom.xml
         run: |
-          sed -i \
-              -e "s/OWNER/$NAMESPACE/g" \
-              -e "s/REPOSITORY/jss/g" \
+          xmlstarlet edit --inplace \
+              -u "/_:project/_:build/_:plugins/_:plugin[_:artifactId='site-maven-plugin']/_:configuration/_:repositoryOwner" \
+              -v "$NAMESPACE" \
               pom.xml
           cat pom.xml
 
@@ -43,8 +54,6 @@ jobs:
               --update-snapshots \
               -pl '!native,!symkey' \
               deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   wait-for-images:
     if: vars.REGISTRY != ''

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <sonar.cpp.file.suffixes>-</sonar.cpp.file.suffixes>
         <sonar.objc.file.suffixes>-</sonar.objc.file.suffixes>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <github.global.server>github</github.global.server>
     </properties>
 
     <modules>
@@ -58,25 +59,39 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <configuration>
+                    <altDeploymentRepository>local::default::file://${project.build.directory}/repo</altDeploymentRepository>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.12</version>
+                <configuration>
+                    <message>Deploy ${project.groupId}:${project.artifactId}:${project.version}</message>
+                    <outputDirectory>${project.build.directory}/repo</outputDirectory>
+                    <includes>
+                        <include>**/*</include>
+                    </includes>
+                    <repositoryOwner>OWNER</repositoryOwner>
+                    <repositoryName>repo</repositoryName>
+                    <branch>refs/heads/maven</branch>
+                    <merge>true</merge>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/OWNER/*</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/OWNER/REPOSITORY</url>
-        </repository>
-    </distributionManagement>
 
 </project>


### PR DESCRIPTION
Previously JSS's Maven artifacts were published to [GitHub Packages](https://github.com/orgs/dogtagpki/packages?repo_name=jss) which is a private repository so it's difficult to use.

To resolve the problem, the `pom.xml` has been modified to publish the artifacts to a publicly accessible [dogtagpki/repo](https://github.com/dogtagpki/repo) instead.

https://github.com/dogtagpki/repo/wiki
https://github.com/dogtagpki/repo/wiki/Development-Guide

Once this PR is merged, the artifacts will be pushed into the `maven` branch like this:

https://github.com/edewata/repo/tree/maven
https://github.com/edewata/repo/commits/maven

Then I'll create a PR for LDAP SDK and PKI to use this repository.