### PR TITLE
Refactor SSLSocket and JSSSocket

### DIFF
--- a/base/src/main/java/org/mozilla/jss/ssl/SSLSocket.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/SSLSocket.java
@@ -13,10 +13,13 @@ import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.SSLSession;
+
 /**
  * SSL client socket.
  */
-public class SSLSocket extends java.net.Socket {
+public class SSLSocket extends javax.net.ssl.SSLSocket {
 
     /**
      *
@@ -388,7 +391,7 @@ public class SSLSocket extends java.net.Socket {
     /**
      * For sockets that get created by accept().
      */
-    SSLSocket() {
+    protected SSLSocket() {
     }
 
     /**
@@ -1363,13 +1366,13 @@ public class SSLSocket extends java.net.Socket {
         base.requestClientAuth(b);
     }
 
-    /**
-     * @deprecated As of JSS 3.0. This method is misnamed. Use
-     *             <code>requestClientAuth</code> instead.
-     */
-    @Deprecated
-    public void setNeedClientAuth(boolean b) throws SocketException {
-        base.requestClientAuth(b);
+    @Override
+    public void setNeedClientAuth(boolean b) {
+        try {
+            base.requestClientAuth(b);
+        } catch (SocketException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
@@ -1644,4 +1647,72 @@ public class SSLSocket extends java.net.Socket {
      * <code>TLS_RSA_WITH_AES_128_CBC_SHA</code>).
      */
     public static native int[] getImplementedCipherSuites();
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return null;
+    }
+
+    @Override
+    public String[] getEnabledCipherSuites() {
+        return null;
+    }
+
+    @Override
+    public void setEnabledCipherSuites(String[] suites) {
+    }
+
+    @Override
+    public String[] getSupportedProtocols() {
+        return null;
+    }
+
+    @Override
+    public String[] getEnabledProtocols() {
+        return null;
+    }
+
+    @Override
+    public void setEnabledProtocols(String[] protocols) {
+    }
+
+    @Override
+    public SSLSession getSession() {
+        return null;
+    }
+
+    @Override
+    public void addHandshakeCompletedListener(HandshakeCompletedListener listener) {
+    }
+
+    @Override
+    public void removeHandshakeCompletedListener(HandshakeCompletedListener listener) {
+    }
+
+    @Override
+    public void startHandshake() throws IOException {
+    }
+
+    @Override
+    public boolean getNeedClientAuth() {
+        return false;
+    }
+
+    @Override
+    public void setWantClientAuth(boolean want) {
+    }
+
+    @Override
+    public boolean getWantClientAuth() {
+        return false;
+    }
+
+    @Override
+    public void setEnableSessionCreation(boolean flag) {
+    }
+
+    @Override
+    public boolean getEnableSessionCreation() {
+        return false;
+    }
 }

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
@@ -22,13 +22,13 @@ import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocket;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
 import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.pkcs11.PK11PrivKey;
 import org.mozilla.jss.provider.javax.crypto.JSSTrustManager;
+import org.mozilla.jss.ssl.SSLSocket;
 
 /**
  * SSL-enabled socket following the javax.net.ssl.SSLSocket interface.

--- a/docs/changes/v5.6.0/API-Changes.adoc
+++ b/docs/changes/v5.6.0/API-Changes.adoc
@@ -4,3 +4,11 @@
 
 The `org.dogtagpki.jss.tomcat.IPasswordStore` has been deprecated.
 Use `org.dogtagpki.jss.tomcat.PasswordStore` instead.
+
+== SSLSocket Changes ==
+
+The `org.mozilla.jss.ssl.SSLSocket` has been modified to extend `javax.net.ssl.SSLSocket`.
+
+== JSSSocket Changes ==
+
+The `org.mozilla.jss.ssl.javax.JSSSocket` has been modified to extend `org.mozilla.jss.ssl.SSLSocket`.


### PR DESCRIPTION
`SSLSocket` is an older code based on the plain Java `Socket`. `JSSSocket` is a newer code based on Java `SSLEngine` and should eventually replace `SSLSocket`.

To help the transition, `SSLSocket` has been modified to extend `javax.net.ssl.SSLSocket` and `JSSSocket` has been modified to extend `SSLSocket`. Once everything is migrated to `JSSSocket`, the `SSLSocket` can be deprecated and eventually dropped.

https://github.com/edewata/jss/blob/socket/docs/changes/v5.6.0/API-Changes.adoc
