### PR TITLE
Refactor X509Certificate

### DIFF
--- a/base/src/main/java/org/mozilla/jss/crypto/InternalCertificate.java
+++ b/base/src/main/java/org/mozilla/jss/crypto/InternalCertificate.java
@@ -11,7 +11,7 @@ import org.mozilla.jss.pkcs11.PK11Cert;
  * can be viewed and modified. Other types of certificates do not
  * have trust flags.
  */
-public interface InternalCertificate extends X509Certificate
+public interface InternalCertificate
 {
     /**
      * @deprecated Use PK11Cert.VALID_PEER instead.

--- a/base/src/main/java/org/mozilla/jss/crypto/TokenCertificate.java
+++ b/base/src/main/java/org/mozilla/jss/crypto/TokenCertificate.java
@@ -10,7 +10,7 @@ package org.mozilla.jss.crypto;
  * To find out if an X509Certificate is a TokenCertificate, use 
  *  <code>instanceof</code>.
  */
-public interface TokenCertificate extends X509Certificate {
+public interface TokenCertificate {
 
     /**
      * Returns the unique ID of this key.  Unique IDs can be used to match

--- a/base/src/main/java/org/mozilla/jss/crypto/X509Certificate.java
+++ b/base/src/main/java/org/mozilla/jss/crypto/X509Certificate.java
@@ -11,14 +11,15 @@ import java.security.cert.CertificateEncodingException;
  * Certificates handled by JSS.  All certificates handled by JSS are
  * of this type.
  */
-public interface X509Certificate
-{
+public abstract class X509Certificate
+        extends java.security.cert.X509Certificate
+        implements InternalCertificate, TokenCertificate {
     /**
      * @return The DER encoding of this certificate.
      * @throws CertificateEncodingException If an error occurred.
      */
-    public byte[] getEncoded()
-		throws CertificateEncodingException;
+    public abstract byte[] getEncoded()
+            throws CertificateEncodingException;
 
     /**
      * @return The nickname of this certificate (could be null).

--- a/base/src/main/java/org/mozilla/jss/pkcs11/PK11Cert.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs11/PK11Cert.java
@@ -20,18 +20,15 @@ import java.util.Date;
 import java.util.Set;
 
 import org.mozilla.jss.crypto.CryptoToken;
-import org.mozilla.jss.crypto.InternalCertificate;
-import org.mozilla.jss.crypto.TokenCertificate;
+import org.mozilla.jss.crypto.X509Certificate;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 public class PK11Cert
-        extends java.security.cert.X509Certificate
-        implements InternalCertificate,
-                TokenCertificate,
-                java.lang.AutoCloseable
+        extends X509Certificate
+        implements AutoCloseable
 {
     public static Logger logger = LoggerFactory.getLogger(PK11Cert.class);
 


### PR DESCRIPTION
To improve interoperability with standard Java classes, the `org.mozilla.jss.crypto.X509Certificate` interface has been converted into a class that extends `java.security.cert.X509Certificate` and also implements `InternalCertificate` and `TokenCertificate`. The `PK11Cert` class has been modified to extend this class.