### PR TITLE
Update SSLCertificateApprovalCallback.approve()

### DIFF
--- a/base/src/main/java/org/mozilla/jss/ssl/SSLCertificateApprovalCallback.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/SSLCertificateApprovalCallback.java
@@ -8,6 +8,7 @@
 
 package org.mozilla.jss.ssl;
 
+import java.security.cert.X509Certificate;
 import java.util.Enumeration;
 import java.util.Vector;
 
@@ -43,8 +44,7 @@ public interface SSLCertificateApprovalCallback {
 	 *         <b>false</b> terminate the connection (Expect an IOException
 	 *              on the outstanding read()/write() on the socket)
 	*/
-	public boolean approve(org.mozilla.jss.crypto.X509Certificate cert,
-			ValidityStatus status);
+	public boolean approve(X509Certificate cert, ValidityStatus status);
 
 	/**
 	 *  This class holds details about the errors for each cert in

--- a/base/src/main/java/org/mozilla/jss/ssl/TestCertApprovalCallback.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/TestCertApprovalCallback.java
@@ -4,6 +4,7 @@
 
 package org.mozilla.jss.ssl;
 
+import java.security.cert.X509Certificate;
 import java.util.Enumeration;
 
 import org.mozilla.jss.CryptoManager;
@@ -19,7 +20,7 @@ public class TestCertApprovalCallback
 
     @Override
     public boolean approve(
-            org.mozilla.jss.crypto.X509Certificate servercert,
+            X509Certificate servercert,
             SSLCertificateApprovalCallback.ValidityStatus status) {
 
         SSLCertificateApprovalCallback.ValidityItem item;
@@ -60,7 +61,9 @@ public class TestCertApprovalCallback
             System.out.println("importing certificate.");
             try {
                 CryptoManager cm = CryptoManager.getInstance();
-                PK11Cert newcert = (PK11Cert) cm.importCertToPerm(servercert, "testnick");
+                PK11Cert newcert = (PK11Cert) cm.importCertToPerm(
+                        (org.mozilla.jss.crypto.X509Certificate) servercert,
+                        "testnick");
                 newcert.setSSLTrust(PK11Cert.TRUSTED_PEER | PK11Cert.VALID_PEER);
             } catch (Exception e) {
                 System.out.println("thrown exception: " + e);

--- a/base/src/test/java/org/mozilla/jss/tests/TestCertificateApprovalCallback.java
+++ b/base/src/test/java/org/mozilla/jss/tests/TestCertificateApprovalCallback.java
@@ -4,6 +4,7 @@
 
 package org.mozilla.jss.tests;
 
+import java.security.cert.X509Certificate;
 import java.util.Enumeration;
 
 import org.mozilla.jss.CryptoManager;
@@ -26,7 +27,7 @@ public class TestCertificateApprovalCallback
 
     @Override
     public boolean approve(
-        org.mozilla.jss.crypto.X509Certificate servercert,
+        X509Certificate servercert,
         SSLCertificateApprovalCallback.ValidityStatus status) {
 
         SSLCertificateApprovalCallback.ValidityItem item;
@@ -68,7 +69,9 @@ public class TestCertificateApprovalCallback
 
             try {
                 CryptoManager cm = CryptoManager.getInstance();
-                PK11Cert newcert = (PK11Cert) cm.importCertToPerm(servercert, "testnick");
+                PK11Cert newcert = (PK11Cert) cm.importCertToPerm(
+                        (org.mozilla.jss.crypto.X509Certificate) servercert,
+                        "testnick");
                 newcert.setSSLTrust(PK11Cert.TRUSTED_PEER | PK11Cert.VALID_PEER);
             } catch (Exception e) {
                 System.out.println("thrown exception: "+e);

--- a/docs/changes/v5.6.0/API-Changes.adoc
+++ b/docs/changes/v5.6.0/API-Changes.adoc
@@ -12,3 +12,8 @@ The `org.mozilla.jss.ssl.SSLSocket` has been modified to extend `javax.net.ssl.S
 == JSSSocket Changes ==
 
 The `org.mozilla.jss.ssl.javax.JSSSocket` has been modified to extend `org.mozilla.jss.ssl.SSLSocket`.
+
+== SSLCertificateApprovalCallback Changes ==
+
+The `approve()` method in `org.mozilla.jss.ssl.SSLCertificateApprovalCallback` has been modified
+to accept `java.security.cert.X509Certificate` instead of `org.mozilla.jss.crypto.X509Certificate`.

--- a/native/src/main/native/org/mozilla/jss/util/java_ids.h
+++ b/native/src/main/native/org/mozilla/jss/util/java_ids.h
@@ -299,7 +299,7 @@ PR_BEGIN_EXTERN_C
  * SSLCertificateApprovalCallback
  */
 #define SSLCERT_APP_CB_APPROVE_NAME "approve"
-#define SSLCERT_APP_CB_APPROVE_SIG "(Lorg/mozilla/jss/crypto/X509Certificate;Lorg/mozilla/jss/ssl/SSLCertificateApprovalCallback$ValidityStatus;)Z"
+#define SSLCERT_APP_CB_APPROVE_SIG "(Ljava/security/cert/X509Certificate;Lorg/mozilla/jss/ssl/SSLCertificateApprovalCallback$ValidityStatus;)Z"
 
 /*
  * SSLSecurityStatus


### PR DESCRIPTION
The `SSLCertificateApprovalCallback.approve()` has been updated to accept `java.security.cert.X509Certificate` instead of `org.mozilla.jss.crypto.X509Certificate` so that it can be used with certs coming from standard Java library.

https://github.com/edewata/jss/blob/callback/docs/changes/v5.6.0/API-Changes.adoc
