### PR TITLE
Address- Investigate and fix CA installation is failing in exporting …

### DIFF
--- a/base/src/main/java/org/mozilla/jss/pkcs12/PFX.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs12/PFX.java
@@ -11,7 +11,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+
 import java.security.DigestException;
+import java.security.NoSuchAlgorithmException;
 
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NotInitializedException;
@@ -28,10 +30,12 @@ import org.mozilla.jss.asn1.SET;
 import org.mozilla.jss.asn1.Tag;
 import org.mozilla.jss.crypto.JSSSecureRandom;
 import org.mozilla.jss.crypto.PBEAlgorithm;
+import org.mozilla.jss.crypto.DigestAlgorithm;
 import org.mozilla.jss.crypto.TokenException;
 import org.mozilla.jss.pkcs7.ContentInfo;
 import org.mozilla.jss.pkcs7.DigestInfo;
 import org.mozilla.jss.pkix.cert.Certificate;
+import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
 import org.mozilla.jss.pkix.primitive.Attribute;
 import org.mozilla.jss.pkix.primitive.EncryptedPrivateKeyInfo;
 import org.mozilla.jss.pkix.primitive.PrivateKeyInfo;
@@ -211,11 +215,14 @@ public class PFX implements ASN1Value {
      */
     public void computeMacData(Password password,
             byte[] salt, int iterationCount)
-        throws NotInitializedException, DigestException,
+        throws NotInitializedException, DigestException,NoSuchAlgorithmException,
         TokenException, CharConversionException
     {
+
+        //Make this alg the default mac alg.
+        AlgorithmIdentifier algID = new AlgorithmIdentifier(DigestAlgorithm.SHA256.toOID());
         macData = new MacData( password, salt, iterationCount,
-                ASN1Util.encode(authSafes) );
+                ASN1Util.encode(authSafes), algID );
     }
 
 

--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11Store.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11Store.c
@@ -794,28 +794,22 @@ Java_org_mozilla_jss_pkcs11_PK11Store_getEncryptedPrivateKeyInfo(
         goto finish;
     }
 
-    // export the epki
-    epki = PK11_ExportEncryptedPrivKeyInfo(
-        slot, algTag, pwItem, privk, iterations, NULL /*wincx*/);
-    if (epki == NULL) {
-	    //try our own version for the new AES KWP algs.
-
-	epki = JSS_ExportEncryptedPrivKeyInfoV2(
+    // Call our JSS version of the  newer V2 version of PK11_ExportEncryptedPrivateKeyInfoV2
+    epki = JSS_ExportEncryptedPrivKeyInfoV2(
                    slot,
-        algTag,     /* PBE algorithm to encrypt the  key with */
-        SEC_OID_UNKNOWN,     /* Encryption algorithm to Encrypt the key with */
-        SEC_OID_UNKNOWN,     /* Hash algorithm for PRF */
-        pwItem,      /* password for PBE encryption */
-        privk, /* encrypt this private key */
-        iterations,        /* interations for PBE alg */
-        NULL);
+       algTag,     /* PBE algorithm to encrypt the  key with */
+       SEC_OID_UNKNOWN,     /* Encryption algorithm to Encrypt the key with */
+       SEC_OID_HMAC_SHA256, /* Hash algorithm for PRF, make this upgraded to SHA256, we can make configurable in future. */
+       pwItem,      /* password for PBE encryption */
+       privk, /* encrypt this private key */
+       iterations,        /* interations for PBE alg */
+       NULL);
 
-	if(epki == NULL) {
-            JSS_throwMsgPrErr(
+    if(epki == NULL) {
+        JSS_throwMsgPrErr(
                 env, TOKEN_EXCEPTION, "Failed to export EncryptedPrivateKeyInfo");
             goto finish;
 	}
-    }
 
     // DER-encode the epki
     if (SEC_ASN1EncodeItem(NULL, &epkiItem, epki,


### PR DESCRIPTION
…the admin certificate at pk12util command in FIPS mode.

https://issues.redhat.com/browse/RHCS-5222

The fix to follow addresses the part of the above issue with respect to how PKI through JSS creates p12 files. This patch modifies the procedure to include higher rated algs for things such as the MAC of the entire PFX and the HMAC and possible algs allowed when creating the encrypted private key info blob to place in the private key safe bag.

Currently we support our own version of PK11_ExportEncryptedPrivKeyInfoV2 that , to this point has served two purposes:

1. Allow us to use the new AES key wrap KWP algs.
2. In the case of fips mode, we have added a routine that moves a key between slots when needed, which doesn't currently work in the current nss routine.

The fix implements changes that alows the routine to support the various AES_CBC enc algs as well as KWP. KWP is called by the pki kra when creating p12 files, if so configured to do so. Alternatively we have a pkcs12 related comand utility that specifies AES_256_CBC.

The fix to JSS simply upgrades some defaults at this point. If we want to get more involved, we could also modify the cmd line tools to be able to specify the algs in question through params.