### PR TITLE
Fix Red Hat Certificate SystemRHCS-5261:  Fix JSS self tests to not use DSA and generate < 2048 bit RSA keys

### DIFF
--- a/base/src/test/java/org/mozilla/jss/tests/TestKeyGen.java
+++ b/base/src/test/java/org/mozilla/jss/tests/TestKeyGen.java
@@ -19,8 +19,6 @@
 package org.mozilla.jss.tests;
 
 import java.math.BigInteger;
-import java.security.interfaces.DSAParams;
-import java.security.interfaces.DSAPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Enumeration;
@@ -55,125 +53,32 @@ public class TestKeyGen {
             System.out.println("\t"+
                 tokens.nextElement().getName() );
         }
-        tokens = manager.getTokensSupportingAlgorithm(KeyPairAlgorithm.DSA);
-        System.out.println("The following tokens support DSA keygen:");
-        while(tokens.hasMoreElements()) {
-            System.out.println("\t"+
-                tokens.nextElement().getName() );
-        }
 
         RSAPublicKey rsaPubKey;
-        DSAPublicKey dsaPubKey;
-        DSAParams dsaParams;
         RSAKeyGenParameterSpec rsaParams;
 
         java.security.KeyPairGenerator kpg =
             java.security.KeyPairGenerator.getInstance("RSA", "Mozilla-JSS");
 
-        // 512-bit RSA with default exponent
-        System.out.println("Generating 512-bit RSA KeyPair!");
+        //Get rid of all the DSA keygen tests and the small keysize and exponent RSA tests.
+        //This is due to evolving nss policy changes away from weaker algs.
+      
+        // 2048-bit RSA with default exponent
+        System.out.println("Generating 2048-bit RSA KeyPair!");
         for (int cntr=0; cntr<5; cntr++ ) {
             try {
-                kpg.initialize(512);
+                kpg.initialize(2048);
                 keyPair = kpg.genKeyPair();
                 assert( keyPair.getPublic() instanceof RSAPublicKey);
                 rsaPubKey = (RSAPublicKey) keyPair.getPublic();
-                System.out.println("Generated 512-bit RSA KeyPair!");
+                System.out.println("Generated 2048-bit RSA KeyPair!");
                 System.out.println("Modulus: "+rsaPubKey.getModulus());
                 System.out.println("Exponent: "+rsaPubKey.getPublicExponent());
                 break;
-            } catch (org.mozilla.jss.crypto.TokenRuntimeException TRExRSA512) {
+            } catch (org.mozilla.jss.crypto.TokenRuntimeException TRExRSA2048) {
                 if (cntr==5) {
-                    System.out.println("Generation of 512-bit RSA KeyPair Failed\n");
-                    TRExRSA512.printStackTrace();
-                }
-            }
-        }
-
-        // 1024-bit RSA with default exponent
-        System.out.println("Generating 1024-bit RSA KeyPair!");
-        for (int cntr=0; cntr<5; cntr++ ) {
-            try {
-                kpg.initialize(1024);
-                keyPair = kpg.genKeyPair();
-                assert( keyPair.getPublic() instanceof RSAPublicKey);
-                rsaPubKey = (RSAPublicKey) keyPair.getPublic();
-                System.out.println("Generated 1024-bit RSA KeyPair!");
-                System.out.println("Modulus: "+rsaPubKey.getModulus());
-                System.out.println("Exponent: "+rsaPubKey.getPublicExponent());
-                break;
-            } catch (org.mozilla.jss.crypto.TokenRuntimeException TRExRSA1024) {
-                if (cntr==5) {
-                    System.out.println("Generation of 1024-bit RSA KeyPair Failed\n");
-                    TRExRSA1024.printStackTrace();
-                }
-            }
-        }
-
-        // 512-bit RSA with exponent = 3
-        System.out.println("Generating 512-bit RSA KeyPair with public exponent=3!");
-        for (int cntr=0; cntr<5; cntr++ ) {
-            try {
-                rsaParams = new RSAKeyGenParameterSpec(512, BigInteger.valueOf(3));
-                kpg.initialize(rsaParams);
-                keyPair = kpg.genKeyPair();
-                assert( keyPair.getPublic() instanceof RSAPublicKey);
-                rsaPubKey = (RSAPublicKey) keyPair.getPublic();
-                System.out.println("Generated 512-bit RSA KeyPair with public exponent=3!");
-                System.out.println("Modulus: "+rsaPubKey.getModulus());
-                System.out.println("Exponent: "+rsaPubKey.getPublicExponent());
-                break;
-            } catch (org.mozilla.jss.crypto.TokenRuntimeException TRExRSA512Exp3) {
-                if (cntr==5) {
-                    System.out.println("Generation of 512-bit RSA KeyPair with public exponent=3 Failed\n");
-                    TRExRSA512Exp3.printStackTrace();
-                }
-            }
-        }
-
-        // 512-bit DSA
-        System.out.println("Generating 512-bit DSA KeyPair!");
-        kpg = java.security.KeyPairGenerator.getInstance("DSA", "Mozilla-JSS");
-        for (int cntr=0; cntr<5; cntr++ ) {
-            try {
-                kpg.initialize(512);
-                keyPair = kpg.genKeyPair();
-                assert( keyPair.getPublic() instanceof DSAPublicKey);
-                dsaPubKey = (DSAPublicKey) keyPair.getPublic();
-                System.out.println("Generated 512-bit DSA KeyPair!");
-                dsaParams = dsaPubKey.getParams();
-                System.out.println("P: "+dsaParams.getP());
-                System.out.println("Q: "+dsaParams.getQ());
-                System.out.println("G: "+dsaParams.getG());
-                System.out.println("Y: "+dsaPubKey.getY());
-                break;
-            } catch (org.mozilla.jss.crypto.TokenRuntimeException TRExDSA512) {
-                if (cntr==5) {
-                    System.out.println("Generation of 512-bit DSA KeyPair Failed\n");
-                    TRExDSA512.printStackTrace();
-                }
-            }
-        }
-
-        // 1024-bit DSA, passing in PQG params
-        System.out.println("Generating 1024-bit DSA KeyPair with PQG params!");
-        for (int cntr=0; cntr<5; cntr++ ) {
-            try {
-                kpg.initialize(PK11KeyPairGenerator.PQG1024);
-                keyPair = kpg.genKeyPair();
-                assert( keyPair.getPublic() instanceof DSAPublicKey);
-                dsaPubKey = (DSAPublicKey) keyPair.getPublic();
-                System.out.println("Generated 1024-bit DSA KeyPair with PQG params!");
-                dsaParams = dsaPubKey.getParams();
-                System.out.println("P: "+dsaParams.getP());
-                System.out.println("Q: "+dsaParams.getQ());
-                System.out.println("G: "+dsaParams.getG());
-                System.out.println("Y: "+dsaPubKey.getY());
-                break;
-            } catch (org.mozilla.jss.crypto.TokenRuntimeException TRExDSA1024) {
-                if (cntr==5) {
-                    System.out.println("Generation of 1024-bit DSA KeyPair with PQG params Failed\n");
-                    TRExDSA1024.printStackTrace();
+                    System.out.println("Generation of 2048-bit RSA KeyPair Failed\n");
+                    TRExRSA2048.printStackTrace();
                 }
             }
         }


### PR DESCRIPTION
Fix JSS self tests to not use DSA and generate < 2048 bit RSA keys

Remove / modify JSS self test code that previously generated DSA key pairs and RSA key pairs of < 2048 bit sizes. Also remove tests generating RSA key pairs with smaller than the minimum exponent sizes.