### PR TITLE
Workaround for SSL events in JSSEngine

### DIFF
--- a/base/src/main/java/org/mozilla/jss/nss/SSLFDProxy.java
+++ b/base/src/main/java/org/mozilla/jss/nss/SSLFDProxy.java
@@ -1,21 +1,29 @@
 package org.mozilla.jss.nss;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.mozilla.jss.crypto.X509Certificate;
 import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.ssl.SSLAlertEvent;
+import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
+import org.mozilla.jss.ssl.SSLSocketListener;
 import org.mozilla.jss.util.GlobalRefProxy;
 
 public class SSLFDProxy extends PRFDProxy {
     public PK11Cert clientCert;
     public GlobalRefProxy globalRef;
 
+    // inboundAlerts and outboundAlerts do not seem to be working properly
+    // TODO: investigate the problem
     public ArrayList<SSLAlertEvent> inboundAlerts;
     public int inboundOffset;
 
     public ArrayList<SSLAlertEvent> outboundAlerts;
     public int outboundOffset;
+
+    // temporary workaround for inboundAlerts and outboundAlerts
+    public List<SSLSocketListener> socketListeners = new ArrayList<>();
 
     public boolean needCertValidation;
     public boolean needBadCertValidation;
@@ -53,11 +61,37 @@ public class SSLFDProxy extends PRFDProxy {
         }
     }
 
+    public void addSocketListener(SSLSocketListener socketListener) {
+        socketListeners.add(socketListener);
+    }
+
+    public void removeSocketListener(SSLSocketListener socketListener) {
+        socketListeners.remove(socketListener);
+    }
+
     public int invokeCertAuthHandler() {
         return certAuthHandler.check(this);
     }
 
     public int invokeBadCertHandler(int error) {
         return badCertHandler.check(this, error);
+    }
+
+    public void fireHandshakeCompleted(SSLHandshakeCompletedEvent event) {
+        for (SSLSocketListener socketListener : socketListeners) {
+            socketListener.handshakeCompleted(event);
+        }
+    }
+
+    public void fireAlertReceived(SSLAlertEvent event) {
+        for (SSLSocketListener socketListener : socketListeners) {
+            socketListener.alertReceived(event);
+        }
+    }
+
+    public void fireAlertSent(SSLAlertEvent event) {
+        for (SSLSocketListener socketListener : socketListeners) {
+            socketListener.alertSent(event);
+        }
     }
 }

--- a/base/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
@@ -9,9 +9,10 @@
 
 package org.mozilla.jss.ssl;
 
-import java.net.*;
-import java.util.*;
+import java.net.SocketException;
+import java.util.EventObject;
 
+import org.mozilla.jss.nss.SSLFDProxy;
 import org.mozilla.jss.ssl.javax.JSSEngine;
 
 /*
@@ -28,6 +29,10 @@ public class SSLHandshakeCompletedEvent extends EventObject {
 
     public SSLHandshakeCompletedEvent(SSLSocket socket) {
         super(socket);
+    }
+
+    public SSLHandshakeCompletedEvent(SSLFDProxy proxy) {
+        super(proxy);
     }
 
     public SSLHandshakeCompletedEvent(JSSEngine engine) {

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -37,6 +37,7 @@ import org.mozilla.jss.ssl.SSLAlertEvent;
 import org.mozilla.jss.ssl.SSLAlertLevel;
 import org.mozilla.jss.ssl.SSLCipher;
 import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
+import org.mozilla.jss.ssl.SSLSocketListener;
 import org.mozilla.jss.ssl.SSLVersion;
 import org.mozilla.jss.ssl.SSLVersionRange;
 
@@ -285,6 +286,8 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         // certificate.
         applyTrustManagers();
 
+        configureSocketListener();
+
         // Finally, set up any debug logging necessary.
         createLoggingSocket();
     }
@@ -532,6 +535,27 @@ public class JSSEngineReferenceImpl extends JSSEngine {
                 throw new SSLException("Unable to configure server hostname: " + errorText(PR.GetError()));
             }
         }
+    }
+
+    private void configureSocketListener() {
+
+        // register a listener in SSLFDProxy
+        ssl_fd.addSocketListener(new SSLSocketListener() {
+            @Override
+            public void handshakeCompleted(SSLHandshakeCompletedEvent event) {
+                fireHandshakeComplete(event);
+            }
+
+            @Override
+            public void alertReceived(SSLAlertEvent event) {
+                fireAlertReceived(event);
+            }
+
+            @Override
+            public void alertSent(SSLAlertEvent event) {
+                fireAlertSent(event);
+            }
+        });
     }
 
     private void applyTrustManagers() throws SSLException {

--- a/native/src/main/native/org/mozilla/jss/nss/SSLFDProxy.h
+++ b/native/src/main/native/org/mozilla/jss/nss/SSLFDProxy.h
@@ -10,7 +10,8 @@ PRStatus JSS_NSS_getSSLAlertSentList(JNIEnv *env, jobject sslfd_proxy, jobject *
 
 PRStatus JSS_NSS_getSSLAlertReceivedList(JNIEnv *env, jobject sslfd_proxy, jobject *list);
 
-PRStatus JSS_NSS_addSSLAlert(JNIEnv *env, jobject sslfd_proxy, jobject list, const SSLAlert *alert);
+jobject JSS_NSS_createSSLAlert(JNIEnv *env, jobject sslfd_proxy, const SSLAlert *alert);
+PRStatus JSS_NSS_addSSLAlert(JNIEnv *env, jobject list, jobject event);
 
 PRStatus JSS_NSS_getGlobalRef(JNIEnv *env, jobject sslfd_proxy, jobject *global_ref);
 

--- a/native/src/main/native/org/mozilla/jss/util/java_ids.h
+++ b/native/src/main/native/org/mozilla/jss/util/java_ids.h
@@ -286,6 +286,11 @@ PR_BEGIN_EXTERN_C
 #define SSL_ALERT_EVENT_CLASS "org/mozilla/jss/ssl/SSLAlertEvent"
 
 /*
+ * SSLHandshakeCompletedEvent
+ */
+#define SSL_HANDSHAKE_COMPLETED_EVENT_CLASS "org/mozilla/jss/ssl/SSLHandshakeCompletedEvent"
+
+/*
  * SSLCertificateApprovalCallback
  */
 #define SSLCERT_APP_CB_APPROVE_NAME "approve"


### PR DESCRIPTION
Currently `JSSEngine` does not generate SSL events although it seems to receive the alerts from NSS.

As a temporary workaround, the `SSLFDProxy` has been updated to keep a list of SSL socket listeners, then `JSSEngine` will add a listener into it. When NSS generates an SSL event, it will be passed to `SSLFDProxy` listeners directly, then eventually to `JSSEngine` listeners as well.

The code that creates the SSL event in `JSS_NSS_addSSLAlert()` has been moved into `JSS_NSS_createSSLAlert()` so it can be reused.

**Note:** This PR is needed by https://github.com/dogtagpki/pki/pull/4832
