### PR TITLE
Update SSLFDProxy to implement SSLSocketListener

### DIFF
--- a/base/src/main/java/org/mozilla/jss/nss/SSLFDProxy.java
+++ b/base/src/main/java/org/mozilla/jss/nss/SSLFDProxy.java
@@ -5,9 +5,11 @@ import java.util.ArrayList;
 import org.mozilla.jss.crypto.X509Certificate;
 import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.ssl.SSLAlertEvent;
+import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
+import org.mozilla.jss.ssl.SSLSocketListener;
 import org.mozilla.jss.util.GlobalRefProxy;
 
-public class SSLFDProxy extends PRFDProxy {
+public class SSLFDProxy extends PRFDProxy implements SSLSocketListener {
     public PK11Cert clientCert;
     public GlobalRefProxy globalRef;
 
@@ -59,5 +61,20 @@ public class SSLFDProxy extends PRFDProxy {
 
     public int invokeBadCertHandler(int error) {
         return badCertHandler.check(this, error);
+    }
+
+    @Override
+    public void handshakeCompleted(SSLHandshakeCompletedEvent event) {
+        handshakeComplete = true;
+    }
+
+    @Override
+    public void alertReceived(SSLAlertEvent event) {
+        inboundAlerts.add(event);
+    }
+
+    @Override
+    public void alertSent(SSLAlertEvent event) {
+        outboundAlerts.add(event);
     }
 }

--- a/base/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/SSLHandshakeCompletedEvent.java
@@ -9,9 +9,10 @@
 
 package org.mozilla.jss.ssl;
 
-import java.net.*;
-import java.util.*;
+import java.net.SocketException;
+import java.util.EventObject;
 
+import org.mozilla.jss.nss.SSLFDProxy;
 import org.mozilla.jss.ssl.javax.JSSEngine;
 
 /*
@@ -28,6 +29,10 @@ public class SSLHandshakeCompletedEvent extends EventObject {
 
     public SSLHandshakeCompletedEvent(SSLSocket socket) {
         super(socket);
+    }
+
+    public SSLHandshakeCompletedEvent(SSLFDProxy proxy) {
+        super(proxy);
     }
 
     public SSLHandshakeCompletedEvent(JSSEngine engine) {

--- a/native/src/main/native/org/mozilla/jss/nss/SSLFDProxy.h
+++ b/native/src/main/native/org/mozilla/jss/nss/SSLFDProxy.h
@@ -6,11 +6,7 @@
 
 PRStatus JSS_NSS_getSSLClientCert(JNIEnv *env, jobject sslfd_proxy, CERTCertificate **cert);
 
-PRStatus JSS_NSS_getSSLAlertSentList(JNIEnv *env, jobject sslfd_proxy, jobject *list);
-
-PRStatus JSS_NSS_getSSLAlertReceivedList(JNIEnv *env, jobject sslfd_proxy, jobject *list);
-
-PRStatus JSS_NSS_addSSLAlert(JNIEnv *env, jobject sslfd_proxy, jobject list, const SSLAlert *alert);
+jobject JSS_NSS_createSSLAlert(JNIEnv *env, jobject sslfd_proxy, const SSLAlert *alert);
 
 PRStatus JSS_NSS_getGlobalRef(JNIEnv *env, jobject sslfd_proxy, jobject *global_ref);
 

--- a/native/src/main/native/org/mozilla/jss/util/java_ids.h
+++ b/native/src/main/native/org/mozilla/jss/util/java_ids.h
@@ -286,6 +286,11 @@ PR_BEGIN_EXTERN_C
 #define SSL_ALERT_EVENT_CLASS "org/mozilla/jss/ssl/SSLAlertEvent"
 
 /*
+ * SSLHandshakeCompletedEvent
+ */
+#define SSL_HANDSHAKE_COMPLETED_EVENT_CLASS "org/mozilla/jss/ssl/SSLHandshakeCompletedEvent"
+
+/*
  * SSLCertificateApprovalCallback
  */
 #define SSLCERT_APP_CB_APPROVE_NAME "approve"


### PR DESCRIPTION
Previously `SSLFDProxy.c` was accessing the fields in `SSLFDProxy` class directly using JNI to update `handshakeComplete` and add SSL alert events into `inboundAlerts` and `outboundAlerts`.

To make it easier to investigate SSL alert issues, `SSLFDProxy` has been updated to implement `SSLSocketListener` then `SSLFDProxy.c` will call `SSLSocketListener` methods to perform the above operations.