### PR TITLE
Fix TPS test failure

### DIFF
--- a/.github/workflows/pki-ca-test.yml
+++ b/.github/workflows/pki-ca-test.yml
@@ -4,7 +4,7 @@ on: workflow_call
 
 env:
   NAMESPACE: ${{ vars.REGISTRY_NAMESPACE || 'dogtagpki' }}
-  DS_IMAGE: ${{ vars.DS_IMAGE || 'jss-runner' }}
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
 
 jobs:
   test:

--- a/.github/workflows/pki-tps-test.yml
+++ b/.github/workflows/pki-tps-test.yml
@@ -4,7 +4,7 @@ on: workflow_call
 
 env:
   NAMESPACE: ${{ vars.REGISTRY_NAMESPACE || 'dogtagpki' }}
-  DS_IMAGE: ${{ vars.DS_IMAGE || 'jss-runner' }}
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
 
 jobs:
   test:


### PR DESCRIPTION
PKI CA and TPS tests have been updated to use DS container from Quay instead of DS packages from Fedora to avoid JSS issue #994.

Resolves: https://github.com/dogtagpki/jss/issues/994