### PR TITLE
Remove the unused method JSS_NSS_getEventArrayList()

### DIFF
--- a/native/src/main/native/org/mozilla/jss/nss/SSLFDProxy.c
+++ b/native/src/main/native/org/mozilla/jss/nss/SSLFDProxy.c
@@ -46,35 +46,6 @@ JSS_NSS_getSSLClientCert(JNIEnv *env, jobject sslfd_proxy, CERTCertificate **cer
     return JSS_PK11_getCertPtr(env, certProxy, cert);
 }
 
-static PRStatus
-JSS_NSS_getEventArrayList(JNIEnv *env, jobject sslfd_proxy, const char *which, jobject *list)
-{
-    jclass sslfdProxyClass;
-    jfieldID eventArrayListField;
-
-    PR_ASSERT(env != NULL && sslfd_proxy != NULL && list != NULL);
-
-    sslfdProxyClass = (*env)->GetObjectClass(env, sslfd_proxy);
-    if (sslfdProxyClass == NULL) {
-        return PR_FAILURE;
-    }
-
-    eventArrayListField = (*env)->GetFieldID(env, sslfdProxyClass, which,
-                                             SSLFD_PROXY_EVENT_LIST_SIG);
-    if (eventArrayListField == NULL) {
-        /* Unlike JSS_NSS_getSSLClientCert above, this is a failure to process
-         * the event. We expect the  */
-        return PR_FAILURE;
-    }
-
-    *list = (*env)->GetObjectField(env, sslfd_proxy, eventArrayListField);
-    if (*list == NULL) {
-        return PR_FAILURE;
-    }
-
-    return PR_SUCCESS;
-}
-
 PRStatus
 JSS_NSS_getGlobalRef(JNIEnv *env, jobject sslfd_proxy, jobject *global_ref)
 {


### PR DESCRIPTION
The method was used to get SSLSoecketEvent but the mechanism has been modified in the following commit and this is method is not used.

Update SSLFDProxy to implement SSLSocketListener (0f352ecb0848ff549cf6bc255d102e1077bb1eaa)

The problem has been identified and reported as side effect of PR #1024 by @siteshwar