### PR TITLE
Fix missing SSL Alert

### DIFF
--- a/.github/workflows/pki-ca-test.yml
+++ b/.github/workflows/pki-ca-test.yml
@@ -194,7 +194,8 @@ jobs:
           # TODO: fix missing SSL alert
           cat > expected << EOF
           WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com,OU=pki-tomcat,O=EXAMPLE' indicates an unknown CA cert 'CN=CA Signing Certificate,OU=pki-tomcat,O=EXAMPLE'
-          Trust this certificate (y/N)? IOException: Unable to write to socket: Unable to validate CN=pki.example.com, OU=pki-tomcat, O=EXAMPLE: Unknown issuer: CN=CA Signing Certificate, OU=pki-tomcat, O=EXAMPLE
+          Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: UNKNOWN_CA
+          IOException: Unable to write to socket: Unable to validate CN=pki.example.com, OU=pki-tomcat, O=EXAMPLE: Unknown issuer: CN=CA Signing Certificate, OU=pki-tomcat, O=EXAMPLE
           EOF
 
           diff expected stderr
@@ -255,7 +256,8 @@ jobs:
           cat > expected << EOF
           WARNING: BAD_CERT_DOMAIN encountered on 'CN=pki.example.com,OU=pki-tomcat,O=EXAMPLE' indicates a common-name mismatch
           WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com,OU=pki-tomcat,O=EXAMPLE' indicates an unknown CA cert 'CN=CA Signing Certificate,OU=pki-tomcat,O=EXAMPLE'
-          Trust this certificate (y/N)? IOException: Unable to write to socket: Unable to validate CN=pki.example.com, OU=pki-tomcat, O=EXAMPLE: Bad certificate domain: CN=pki.example.com, OU=pki-tomcat, O=EXAMPLE
+          Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: ACCESS_DENIED
+          IOException: Unable to write to socket: Unable to validate CN=pki.example.com, OU=pki-tomcat, O=EXAMPLE: Bad certificate domain: CN=pki.example.com, OU=pki-tomcat, O=EXAMPLE
           EOF
 
           diff expected stderr

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -1565,9 +1565,11 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             }
         } while (this_src_write != 0 || this_dst_write != 0);
 
-        if (seen_exception == false && ssl_exception == null) {
-            ssl_exception = checkSSLAlerts();
-            seen_exception = (ssl_exception != null);
+        // Check for new outbound alerts to the peer and fire the related events
+        SSLException newSSLException = checkSSLAlerts();
+        if (!seen_exception && ssl_exception == null && newSSLException != null) {
+            ssl_exception = newSSLException;
+            seen_exception = true;
         }
 
         logWrap(dst);


### PR DESCRIPTION
When trust manager fails to validate the certificate the generated SSL exception does not trigger any alert. To fix the problem the SSL alert are always verified during the wrap operation.