### PR TITLE
Update PKCS11Constants.java

### DIFF
--- a/.github/workflows/pkcs11-tests.yml
+++ b/.github/workflows/pkcs11-tests.yml
@@ -51,16 +51,20 @@ jobs:
               --hostname=jss.example.com \
               jss
 
-      - name: Check PKCS11 constants
+      - name: Build PKCS11Constants.java
         run: |
           # generate new PKCS11Constants.java from NSS header files
+          # https://github.com/nss-dev/nss/blob/master/lib/util/pkcs11t.h
+          # https://github.com/nss-dev/nss/blob/master/lib/util/pkcs11n.h
+
           docker exec jss $SHARED/tools/build_pkcs11_constants.py \
               --pkcs11t /usr/include/nss3/pkcs11t.h \
               --pkcs11n /usr/include/nss3/pkcs11n.h \
               -o PKCS11Constants.java \
               --verbose
 
-          # compare existing PKCS11Constants.java with the new one
-          docker exec jss diff \
+      - name: Compare PKCS11Constants.java
+        run: |
+          docker exec jss diff -Naru \
               $SHARED/base/src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java \
               PKCS11Constants.java

--- a/base/src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java
@@ -6325,6 +6325,20 @@ public interface PKCS11Constants {
      *
      * Source file: /usr/include/nss3/pkcs11n.h
      */
+    public static final long CKK_NSS_KYBER = 0xCE534355L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKK_NSS_ML_KEM = 0xCE534356L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
     public static final long CKC_NSS = 0xCE534350L;
 
     /**
@@ -6564,6 +6578,13 @@ public interface PKCS11Constants {
      * Source file: /usr/include/nss3/pkcs11n.h
      */
     public static final long CKA_NSS_VALIDATION_MODULE_ID = 0xCE534377L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKA_NSS_PARAMETER_SET = 0xCE534378L;
 
     /**
      * Content automatically generated; see NSS documentation for more information.
@@ -7032,6 +7053,41 @@ public interface PKCS11Constants {
      *
      * Source file: /usr/include/nss3/pkcs11n.h
      */
+    public static final long CKM_NSS_KYBER_KEY_PAIR_GEN = 0xCE53437DL;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKM_NSS_KYBER = 0xCE53437EL;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKM_NSS_ECDHE_NO_PAIRWISE_CHECK_KEY_PAIR_GEN = 0xCE53437FL;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKM_NSS_ML_KEM_KEY_PAIR_GEN = 0xCE534380L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKM_NSS_ML_KEM = 0xCE534381L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
     public static final long CKM_NSS_PBE_SHA1_DES_CBC = 0x80000002L;
 
     /**
@@ -7103,6 +7159,27 @@ public interface PKCS11Constants {
      * Source file: /usr/include/nss3/pkcs11n.h
      */
     public static final long CKM_TLS_PRF_GENERAL = 0x80000373L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKP_NSS = 0xCE534350L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKP_NSS_KYBER_768_ROUND3 = 0xCE534351L;
+
+    /**
+     * Content automatically generated; see NSS documentation for more information.
+     *
+     * Source file: /usr/include/nss3/pkcs11n.h
+     */
+    public static final long CKP_NSS_ML_KEM_768 = 0xCE534352L;
 
     /**
      * Content automatically generated; see NSS documentation for more information.

--- a/docs/pkcs11_constants.md
+++ b/docs/pkcs11_constants.md
@@ -31,7 +31,7 @@ fail, notifying us that this will need to be updated.
 To do so, first make sure the system's NSS is up to date:
 
     dnf update --refresh
-    dnf install nss-dev
+    dnf install nss-devel
 
 Then, validate the location of the NSS header files; on Fedora, this location
 is `/usr/include/nss3`:
@@ -43,7 +43,7 @@ Lastly, run the utility:
     python3 ./tools/build_pkcs11_constants.py --system \
         --pkcs11t /usr/include/nss3/pkcs11t.h \
         --pkcs11n /usr/include/nss3/pkcs11n.h \
-        --output src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java
+        --output base/src/main/java/org/mozilla/jss/pkcs11/PKCS11Constants.java
 
 While not required, it is suggested to use the `--system` flag to ensure
 the values of `PKCS11Constants.java` are the same as the installed NSS

--- a/jss.spec
+++ b/jss.spec
@@ -96,8 +96,8 @@ BuildRequires:  zip
 BuildRequires:  unzip
 
 BuildRequires:  gcc-c++
-BuildRequires:  nss-devel >= 3.66
-BuildRequires:  nss-tools >= 3.66
+BuildRequires:  nss-devel >= 3.97
+BuildRequires:  nss-tools >= 3.97
 
 BuildRequires:  %{java_devel}
 BuildRequires:  maven-local
@@ -116,7 +116,7 @@ This only works with gcj. Other JREs require that JCE providers be signed.
 
 Summary:        Java Security Services (JSS)
 
-Requires:       nss >= 3.66
+Requires:       nss >= 3.97
 
 Requires:       %{java_headless}
 Requires:       mvn(org.apache.commons:commons-lang3)

--- a/tools/build_pkcs11_constants.py
+++ b/tools/build_pkcs11_constants.py
@@ -21,10 +21,6 @@ import tempfile
 import argparse
 import textwrap
 
-# Exclude new constants added in NSS 3.97 such that this script will
-# create a new PKCS11Constants.java that will match the existing
-# PKCS11Constants.java in base/src/main/java/org/mozilla/jss/pkcs11.
-#
 # https://github.com/dogtagpki/jss/issues/993
 EXCLUDED_CONSTANTS = [
     'CK_PTR',
@@ -33,12 +29,6 @@ EXCLUDED_CONSTANTS = [
     'CK_DECLARE_FUNCTION',
     'CK_DECLARE_FUNCTION_POINTER',
     'CK_UNAVAILABLE_INFORMATION',
-    'CKK_NSS_KYBER',                  # added in NSS 3.97
-    'CKA_NSS_PARAMETER_SET',          # added in NSS 3.97
-    'CKM_NSS_KYBER_KEY_PAIR_GEN',     # added in NSS 3.97
-    'CKM_NSS_KYBER',                  # added in NSS 3.97
-    'CKP_NSS',                        # added in NSS 3.97
-    'CKP_NSS_KYBER_768_ROUND3',       # added in NSS 3.97
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
The `build_pkcs11_constants.py` has been updated to no longer exclude constants introduced in NSS 3.97 since newer NSS versions are available on all supported platforms.