### PR TITLE
Fix tomcat CI

### DIFF
--- a/.github/workflows/tomcat-tests.yml
+++ b/.github/workflows/tomcat-tests.yml
@@ -157,8 +157,8 @@ jobs:
               sslscan.xml > actual
           diff expected actual
 
-          # TLS 1.2 should be disabled
-          echo -n "0" > expected
+          # TLS 1.2 should be enabled
+          echo -n "1" > expected
           xmlstarlet sel -t -v \
               "/document/ssltest/protocol[@type='tls' and @version='1.2']/@enabled" \
               sslscan.xml > actual


### PR DESCRIPTION
The TLS 1.2 is supported and enabled in the crypto policy so it is enabled in tomcat by default.