### PR TITLE
Make JSSSocket close() idempotent

### DIFF
--- a/.github/workflows/pki-ca-test.yml
+++ b/.github/workflows/pki-ca-test.yml
@@ -558,7 +558,7 @@ jobs:
           cat > expected << EOF
           SEVERE: FATAL: SSL alert received: UNKNOWN_CA
           SEVERE: FATAL: SSL alert sent: UNEXPECTED_MESSAGE
-          RuntimeException: Unexpected error trying to construct channel: Unable to perform operations on a closed socket!
+          IOException: Unable to read from socket: Unexpected return from PR.Read(): SSL_ERROR_UNKNOWN_CA_ALERT (-12195)
           EOF
 
           diff expected stderr

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSocket.java
@@ -752,6 +752,9 @@ public class JSSSocket extends SSLSocket {
 
     @Override
     public synchronized void close() throws IOException {
+        if (closed) {
+            return;
+        }
         getInternalChannel().close();
         engine.cleanup();
         engine = null;


### PR DESCRIPTION
Invoking multiple times the close() method generate an exception because it calls the init() which tries to access closed channels.

The close() method is defined in Closeable interface and it has to be idempotent so it should be possible to call again without errors.

This is a problem with third party libraries not checking if the socket has been closed but call multiple times the close() method generating error.

An example of the error is in [this test](https://github.com/fmarco76/pki/actions/runs/13988696953/job/391679594390. The socket is closed by the server and and the client gets a notify which will close also the client side. Then the httpclient will close again the socket generating the error.