### PR TITLE
Port tomcatjss to tomcat 10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>examples</module>
         <module>tomcat</module>
         <module>tomcat-9.0</module>
+        <module>tomcat-10.1</module>
     </modules>
 
     <build>

--- a/tomcat-10.1/pom.xml
+++ b/tomcat-10.1/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki.jss</groupId>
+        <artifactId>jss-parent</artifactId>
+        <version>5.7.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jss-tomcat-10.1</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <version>10.1.40</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-coyote</artifactId>
+            <version>10.1.40</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-juli</artifactId>
+            <version>10.1.40</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jss-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jss-tomcat</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+        <finalName>jss-tomcat-10.1</finalName>
+    </build>
+
+</project>

--- a/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/Http11NioProtocol.java
+++ b/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/Http11NioProtocol.java
@@ -1,0 +1,164 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+package org.dogtagpki.jss.tomcat;
+
+import org.apache.coyote.http11.AbstractHttp11JsseProtocol;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.net.NioChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Http11NioProtocol extends AbstractHttp11JsseProtocol<NioChannel> {
+
+    public static Logger logger = LoggerFactory.getLogger(Http11NioProtocol.class);
+    private static final Log log = LogFactory.getLog(Http11NioProtocol.class);
+
+    TomcatJSS tomcatjss = TomcatJSS.getInstance();
+
+    public Http11NioProtocol() {
+       super(new JSSNioEndpoint());
+    }
+
+    public String getCertdbDir() {
+        return tomcatjss.getCertdbDir();
+    }
+
+    public void setCertdbDir(String certdbDir) {
+        tomcatjss.setCertdbDir(certdbDir);
+    }
+
+    public String getPasswordClass() {
+        return tomcatjss.getPasswordClass();
+    }
+
+    public void setPasswordClass(String passwordClass) {
+        tomcatjss.setPasswordClass(passwordClass);
+    }
+
+    public String getPasswordFile() {
+        return tomcatjss.getPasswordFile();
+    }
+
+    public void setPasswordFile(String passwordFile) {
+        tomcatjss.setPasswordFile(passwordFile);
+    }
+
+    public String getServerCertNickFile() {
+        return tomcatjss.getServerCertNickFile();
+    }
+
+    public void setServerCertNickFile(String serverCertNickFile) {
+        tomcatjss.setServerCertNickFile(serverCertNickFile);
+    }
+
+    public boolean getEnableOCSP() {
+        return tomcatjss.getEnableRevocationCheck();
+    }
+
+    public void setEnableOCSP(boolean enableOCSP) {
+        tomcatjss.setEnableRevocationCheck(enableOCSP);
+    }
+
+    public boolean getEnableRevocationCheck() {
+        return tomcatjss.getEnableRevocationCheck();
+    }
+    
+    public void setEnableRevocationCheck(boolean enableRevocationCheck) {
+        tomcatjss.setEnableRevocationCheck(enableRevocationCheck);
+    }
+
+    public String getOcspResponderURL() {
+        return tomcatjss.getOcspResponderURL();
+    }
+
+    public void setOcspResponderURL(String ocspResponderURL) {
+        tomcatjss.setOcspResponderURL(ocspResponderURL);
+    }
+
+    public String getOcspResponderCertNickname() {
+        return tomcatjss.getOcspResponderCertNickname();
+    }
+
+    public void setOcspResponderCertNickname(String ocspResponderCertNickname) {
+        tomcatjss.setOcspResponderCertNickname(ocspResponderCertNickname);
+    }
+
+    public int getOcspCacheSize() {
+        return tomcatjss.getOcspCacheSize();
+    }
+
+    public void setOcspCacheSize(int ocspCacheSize) {
+        tomcatjss.setOcspCacheSize(ocspCacheSize);
+    }
+
+    public int getOcspMinCacheEntryDuration() {
+        return tomcatjss.getOcspMinCacheEntryDuration();
+    }
+
+    public void setOcspMinCacheEntryDuration(int ocspMinCacheEntryDuration) {
+        tomcatjss.setOcspMinCacheEntryDuration(ocspMinCacheEntryDuration);
+    }
+
+    public int getOcspMaxCacheEntryDuration() {
+        return tomcatjss.getOcspMaxCacheEntryDuration();
+    }
+
+    public void setOcspMaxCacheEntryDuration(int ocspMaxCacheEntryDuration) {
+        tomcatjss.setOcspMaxCacheEntryDuration(ocspMaxCacheEntryDuration);
+    }
+
+    public int getOcspTimeout() {
+        return tomcatjss.getOcspTimeout();
+    }
+
+    public void setOcspTimeout(int ocspTimeout) {
+        tomcatjss.setOcspTimeout(ocspTimeout);
+    }
+
+    @Override
+    protected Log getLog() {
+        return log;
+    }
+
+    @Override
+    protected String getNamePrefix() {
+        if (isSSLEnabled()) {
+            return "https-" + getSslImplementationShortName()+ "-jss-nio";
+        }
+        return "http-jss-nio";
+    }
+
+    // These methods are temporarly present to replicate the default behaviour provided by tomcat
+    public void setSelectorTimeout(long timeout) {
+        ((JSSNioEndpoint)getEndpoint()).setSelectorTimeout(timeout);
+    }
+
+    public long getSelectorTimeout() {
+        return ((JSSNioEndpoint)getEndpoint()).getSelectorTimeout();
+    }
+
+    public void setPollerThreadPriority(int threadPriority) {
+        ((JSSNioEndpoint)getEndpoint()).setPollerThreadPriority(threadPriority);
+    }
+
+    public int getPollerThreadPriority() {
+      return ((JSSNioEndpoint)getEndpoint()).getPollerThreadPriority();
+    }
+}

--- a/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSContext.java
+++ b/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSContext.java
@@ -1,0 +1,123 @@
+package org.dogtagpki.jss.tomcat;
+
+import java.security.KeyManagementException;
+import java.security.SecureRandom;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.mozilla.jss.JSSProvider;
+import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
+import org.mozilla.jss.provider.javax.crypto.JSSTrustManager;
+import org.mozilla.jss.ssl.javax.JSSEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JSSContext implements org.apache.tomcat.util.net.SSLContext {
+    public static Logger logger = LoggerFactory.getLogger(JSSContext.class);
+
+    private javax.net.ssl.SSLContext ctx;
+    private String alias;
+
+    private JSSKeyManager jkm;
+    private JSSTrustManager jtm;
+
+    public JSSContext(String alias) {
+        logger.debug("JSSContext(" + alias + ")");
+        this.alias = alias;
+
+        /* These KeyManagers and TrustManagers aren't used with the SSLEngine;
+         * they're only used to implement certain function calls below. */
+        try {
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance("NssX509", "Mozilla-JSS");
+            jkm = (JSSKeyManager) kmf.getKeyManagers()[0];
+
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance("NssX509", "Mozilla-JSS");
+            jtm = (JSSTrustManager) tmf.getTrustManagers()[0];
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void init(KeyManager[] kms, TrustManager[] tms, SecureRandom sr) throws KeyManagementException {
+        logger.debug("JSSContext.init(...)");
+
+        try {
+            String provider = "SunJSSE";
+            if (JSSProvider.ENABLE_JSSENGINE) {
+                provider = "Mozilla-JSS";
+            }
+
+            ctx = javax.net.ssl.SSLContext.getInstance("TLS", provider);
+            ctx.init(kms, tms, sr);
+        } catch (Exception e) {
+            throw new KeyManagementException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public javax.net.ssl.SSLEngine createSSLEngine() {
+        logger.debug("JSSContext.createSSLEngine()");
+        javax.net.ssl.SSLEngine eng = ctx.createSSLEngine();
+
+        TomcatJSS instance = TomcatJSS.getInstance();
+
+        if (eng instanceof JSSEngine) {
+            JSSEngine j_eng = (JSSEngine) eng;
+            j_eng.setCertFromAlias(alias);
+            if(instance != null) {
+                j_eng.setListeners(instance.getSocketListeners());
+            }
+        }
+
+        return eng;
+    }
+
+    @Override
+    public javax.net.ssl.SSLSessionContext getServerSessionContext() {
+        logger.debug("JSSContext.getServerSessionContext()");
+        return ctx.getServerSessionContext();
+    }
+
+    @Override
+    public javax.net.ssl.SSLServerSocketFactory getServerSocketFactory() {
+        logger.debug("JSSContext.getServerSocketFactory()");
+        return ctx.getServerSocketFactory();
+    }
+
+    @Override
+    public javax.net.ssl.SSLParameters getSupportedSSLParameters() {
+        logger.debug("JSSContext.getSupportedSSLParameters()");
+        return ctx.getSupportedSSLParameters();
+    }
+
+    @Override
+    public java.security.cert.X509Certificate[] getCertificateChain(java.lang.String alias) {
+        logger.debug("JSSContext.getCertificateChain(" + alias + ")");
+
+        try {
+            return jkm.getCertificateChain(alias);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+        logger.debug("JSSContext.getAcceptedIssuers()");
+
+        try {
+            return jtm.getAcceptedIssuers();
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        logger.debug("JSSContext.destroy()");
+    }
+}

--- a/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSImplementation.java
+++ b/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSImplementation.java
@@ -1,0 +1,63 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2007 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.jss.tomcat;
+
+import javax.net.ssl.SSLSession;
+
+import org.apache.tomcat.util.net.SSLHostConfig;
+import org.apache.tomcat.util.net.SSLHostConfigCertificate;
+import org.apache.tomcat.util.net.SSLImplementation;
+import org.apache.tomcat.util.net.SSLSupport;
+import org.apache.tomcat.util.net.SSLUtil;
+import org.apache.tomcat.util.net.jsse.JSSESupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class JSSImplementation extends SSLImplementation {
+
+    public static final Logger logger = LoggerFactory.getLogger(JSSImplementation.class);
+
+    public JSSImplementation() {
+        logger.debug("JSSImplementation: instance created");
+    }
+
+    @Override
+    public SSLSupport getSSLSupport(SSLSession session, Map<String, List<String>> map) {
+        logger.debug("JSSImplementation.getSSLSupport()");
+        return new JSSESupport(session, map);
+    }
+
+    @Override
+    public SSLUtil getSSLUtil(SSLHostConfigCertificate cert) {
+        logger.debug("JSSImplementation: getSSLUtil()");
+        logger.debug("JSSImplementation: key alias: {}", cert.getCertificateKeyAlias());
+        logger.debug("JSSImplementation: keystore provider: {}", cert.getCertificateKeystoreProvider());
+
+        SSLHostConfig hostConfig = cert.getSSLHostConfig();
+        logger.debug("JSSImplementation: key manager alg: {}", hostConfig.getKeyManagerAlgorithm());
+        logger.debug("JSSImplementation: truststore alg: {}", hostConfig.getTruststoreAlgorithm());
+        logger.debug("JSSImplementation: truststore provider: {}", hostConfig.getTruststoreProvider());
+
+        return new JSSUtil(cert);
+    }
+}

--- a/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSListener.java
+++ b/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSListener.java
@@ -1,0 +1,65 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.jss.tomcat;
+
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JSSListener implements LifecycleListener {
+
+    final static Logger logger = LoggerFactory.getLogger(JSSListener.class);
+
+    public String configFile;
+
+    public String getConfigFile() {
+        return configFile;
+    }
+
+    public void setConfigFile(String configFile) {
+        this.configFile = configFile;
+    }
+
+    @Override
+    public void lifecycleEvent(LifecycleEvent event) {
+
+        String type = event.getType();
+
+        if (type.equals(Lifecycle.BEFORE_INIT_EVENT)) {
+            initJSS();
+        }
+    }
+
+    public void initJSS() {
+
+        logger.info("JSSListener: Initializing JSS");
+
+        try {
+            TomcatJSS tomcatjss = TomcatJSS.getInstance();
+            tomcatjss.loadConfig();
+            tomcatjss.init();
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSNioEndpoint.java
+++ b/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSNioEndpoint.java
@@ -1,0 +1,133 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ * All rights reserved.
+ *
+ *
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *  Apache Tomcat
+ *  Copyright 1999-2023 The Apache Software Foundation
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. *
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.jss.tomcat;
+
+
+import java.nio.channels.SocketChannel;
+import java.util.List;
+
+import javax.net.ssl.SSLEngine;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.ExceptionUtils;
+import org.apache.tomcat.util.net.NioChannel;
+import org.apache.tomcat.util.net.NioEndpoint;
+import org.apache.tomcat.util.net.SocketBufferHandler;
+import org.apache.tomcat.util.net.openssl.ciphers.Cipher;
+
+public class JSSNioEndpoint extends NioEndpoint {
+
+    private static final Log log = LogFactory.getLog(NioEndpoint.class);
+    /**
+     * Code in the following method is almost identical of that available in the base
+     * class {@link org.apache.tomcat.util.net.NioEndpoint#setSocketOptions(SocketChannel) from tomcat
+     * git repository for the version 9.0.78..
+     * <p>
+     * The only difference is the instantiation of the JSSSecureNioChannel class instead of the tomcat
+     * provided SecureNioChannel class. This is needed because the channel class is hard-coded in the
+     * base class method.
+     *
+     * @see org.apache.tomcat.util.net.NioEndpoint#setSocketOptions(SocketChannel socket)
+     */
+
+    @Override
+    protected boolean setSocketOptions(SocketChannel socket) {
+        NioSocketWrapper socketWrapper = null;
+        try {
+            // Allocate channel and wrapper
+            NioChannel channel = null;
+            if (getNioChannels() != null) {
+                channel = getNioChannels().pop();
+            }
+            if (channel == null) {
+                SocketBufferHandler bufhandler = new SocketBufferHandler(
+                        socketProperties.getAppReadBufSize(),
+                        socketProperties.getAppWriteBufSize(),
+                        socketProperties.getDirectBuffer());
+                if (isSSLEnabled()) {
+// This is the change from the code in the base class
+                    channel = new JSSSecureNioChannel(bufhandler, this);
+// End of difference
+                } else {
+                    channel = new NioChannel(bufhandler);
+                }
+            }
+            NioSocketWrapper newWrapper = new NioSocketWrapper(channel, this);
+            channel.reset(socket, newWrapper);
+            connections.put(socket, newWrapper);
+            socketWrapper = newWrapper;
+
+            // Set socket properties
+            // Disable blocking, polling will be used
+            socket.configureBlocking(false);
+            if (getUnixDomainSocketPath() == null) {
+                socketProperties.setProperties(socket.socket());
+            }
+
+            socketWrapper.setReadTimeout(getConnectionTimeout());
+            socketWrapper.setWriteTimeout(getConnectionTimeout());
+            socketWrapper.setKeepAliveLeft(JSSNioEndpoint.this.getMaxKeepAliveRequests());
+            getPoller().register(socketWrapper);
+            return true;
+        } catch (Throwable t) {
+            ExceptionUtils.handleThrowable(t);
+            try {
+                log.error(sm.getString("endpoint.socketOptionsError"), t);
+            } catch (Throwable tt) {
+                ExceptionUtils.handleThrowable(tt);
+            }
+            if (socketWrapper == null) {
+                destroySocket(socket);
+            }
+        }
+        // Tell to close the socket if needed
+        return false;
+
+    }
+    @Override
+    protected SSLEngine createSSLEngine(String arg0, List<Cipher> arg1, List<String> arg2) {
+        return super.createSSLEngine(arg0, arg1, arg2);
+    }
+
+}

--- a/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSSecureNioChannel.java
+++ b/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSSecureNioChannel.java
@@ -1,0 +1,331 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ * All rights reserved.
+ *
+ *
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *  Apache Tomcat
+ *  Copyright 1999-2023 The Apache Software Foundation
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. *
+ * END COPYRIGHT BLOCK */
+package org.dogtagpki.jss.tomcat;
+
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLEngineResult.Status;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.buf.ByteBufferUtils;
+import org.apache.tomcat.util.compat.JreCompat;
+import org.apache.tomcat.util.net.NioEndpoint;
+import org.apache.tomcat.util.net.SSLSupport;
+import org.apache.tomcat.util.net.SSLUtil;
+import org.apache.tomcat.util.net.SecureNioChannel;
+import org.apache.tomcat.util.net.SocketBufferHandler;
+import org.apache.tomcat.util.net.TLSClientHelloExtractor;
+import org.apache.tomcat.util.net.TLSClientHelloExtractor.ExtractorResult;
+import org.apache.tomcat.util.net.openssl.ciphers.Cipher;
+import org.apache.tomcat.util.res.StringManager;
+import org.mozilla.jss.ssl.javax.JSSSession;
+/**
+ * Implementation of a secure socket channel
+ * <p>
+ * Code in the following methods are almost identical of that available in the base
+ * class {@link org.apache.tomcat.util.net.SecureNioChannel from tomcat git repository
+ * for the version 9.0.78.
+ * <p>
+ * The only difference is the registration of local and remote IP in the SSL engine session.
+ * These IPs are required for audit purpose but the tomcat implementation does not provide
+ * such information to the engine, since they are not needed for Java SSL engine specification.
+ * <p>
+ * The SSL engine is created in the private method {@link JSSSecureNioChannel#processSNI()} so
+ * the calling methods have been duplicated in order to work properly.
+ *
+ * @see org.apache.tomcat.util.net.SecureNioChannel
+ */
+
+public class JSSSecureNioChannel extends SecureNioChannel {
+
+    private static final Log log = LogFactory.getLog(JSSSecureNioChannel.class);
+    private static final StringManager sm = StringManager.getManager(JSSSecureNioChannel.class);
+
+    private final JSSNioEndpoint endpoint;
+
+    private final Map<String,List<String>> additionalTlsAttributes = new HashMap<>();
+
+    public JSSSecureNioChannel(SocketBufferHandler bufHandler, NioEndpoint endpoint) {
+        super(bufHandler, endpoint);
+        this.endpoint = (JSSNioEndpoint) endpoint;
+    }
+
+
+    /**
+     * Performs SSL handshake, non blocking, but performs NEED_TASK on the same
+     * thread. Hence, you should never call this method using your Acceptor
+     * thread, as you would slow down your system significantly. If the return
+     * value from this method is positive, the selection key should be
+     * registered interestOps given by the return value.
+     *
+     * @param read boolean - true if the underlying channel is readable
+     * @param write boolean - true if the underlying channel is writable
+     *
+     * @return 0 if hand shake is complete, -1 if an error (other than an
+     *         IOException) occurred, otherwise it returns a SelectionKey
+     *         interestOps value
+     *
+     * @throws IOException If an I/O error occurs during the handshake or if the
+     *                     handshake fails during wrapping or unwrapping
+     */
+    @Override
+    public int handshake(boolean read, boolean write) throws IOException {
+        if (handshakeComplete) {
+            return 0; //we have done our initial handshake
+        }
+
+        if (!sniComplete) {
+// This is the change from the code in the base class
+            int sniResult = processJSSSNI();
+// End of difference
+
+            if (sniResult == 0) {
+                sniComplete = true;
+            } else {
+                return sniResult;
+            }
+        }
+
+        if (!flush(netOutBuffer)) {
+            return SelectionKey.OP_WRITE; //we still have data to write
+        }
+
+        SSLEngineResult handshake;
+
+        while (!handshakeComplete) {
+            switch (handshakeStatus) {
+                case NOT_HANDSHAKING:
+                    //should never happen
+                    throw new IOException(sm.getString("channel.nio.ssl.notHandshaking"));
+                case FINISHED:
+                    if (endpoint.hasNegotiableProtocols()) {
+                        if (sslEngine instanceof SSLUtil.ProtocolInfo) {
+                            socketWrapper.setNegotiatedProtocol(
+                                    ((SSLUtil.ProtocolInfo) sslEngine).getNegotiatedProtocol());
+                        } else {
+                            socketWrapper.setNegotiatedProtocol(sslEngine.getApplicationProtocol());
+                        }
+                    }
+                    //we are complete if we have delivered the last package
+                    handshakeComplete = !netOutBuffer.hasRemaining();
+                    //return 0 if we are complete, otherwise we still have data to write
+                    return handshakeComplete ? 0 : SelectionKey.OP_WRITE;
+                case NEED_WRAP:
+                    //perform the wrap function
+                    try {
+                        handshake = handshakeWrap(write);
+                    } catch (SSLException e) {
+                        handshake = handshakeWrap(write);
+                        throw e;
+                    }
+                    if (handshake.getStatus() == Status.OK) {
+                        if (handshakeStatus == HandshakeStatus.NEED_TASK) {
+                            handshakeStatus = tasks();
+                        }
+                    } else if (handshake.getStatus() == Status.CLOSED) {
+                        flush(netOutBuffer);
+                        return -1;
+                    } else {
+                        //wrap should always work with our buffers
+                        throw new IOException(sm.getString("channel.nio.ssl.unexpectedStatusDuringWrap", handshake.getStatus()));
+                    }
+                    if (handshakeStatus != HandshakeStatus.NEED_UNWRAP || (!flush(netOutBuffer))) {
+                        //should actually return OP_READ if we have NEED_UNWRAP
+                        return SelectionKey.OP_WRITE;
+                    }
+                    //fall down to NEED_UNWRAP on the same call, will result in a
+                    //BUFFER_UNDERFLOW if it needs data
+                //$FALL-THROUGH$
+                case NEED_UNWRAP:
+                    //perform the unwrap function
+                    handshake = handshakeUnwrap(read);
+                    if (handshake.getStatus() == Status.OK) {
+                        if (handshakeStatus == HandshakeStatus.NEED_TASK) {
+                            handshakeStatus = tasks();
+                        }
+                    } else if ( handshake.getStatus() == Status.BUFFER_UNDERFLOW ){
+                        //read more data, reregister for OP_READ
+                        return SelectionKey.OP_READ;
+                    } else {
+                        throw new IOException(sm.getString("channel.nio.ssl.unexpectedStatusDuringWrap", handshake.getStatus()));
+                    }
+                    break;
+                case NEED_TASK:
+                    handshakeStatus = tasks();
+                    break;
+                default:
+                    throw new IllegalStateException(sm.getString("channel.nio.ssl.invalidStatus", handshakeStatus));
+            }
+        }
+        // Handshake is complete if this point is reached
+        return 0;
+    }
+
+
+    /*
+     * Peeks at the initial network bytes to determine if the SNI extension is
+     * present and, if it is, what host name has been requested. Based on the
+     * provided host name, configure the SSLEngine for this connection.
+     *
+     * @return 0 if SNI processing is complete, -1 if an error (other than an
+     *         IOException) occurred, otherwise it returns a SelectionKey
+     *         interestOps value
+     *
+     * @throws IOException If an I/O error occurs during the SNI processing
+     */
+// This is the change from the code in the base class
+    private int processJSSSNI() throws IOException {
+//End of difference
+        // Read some data into the network input buffer so we can peek at it.
+        int bytesRead = sc.read(netInBuffer);
+        if (bytesRead == -1) {
+            // Reached end of stream before SNI could be processed.
+            return -1;
+        }
+        TLSClientHelloExtractor extractor = new TLSClientHelloExtractor(netInBuffer);
+
+        while (extractor.getResult() == ExtractorResult.UNDERFLOW &&
+                netInBuffer.capacity() < endpoint.getSniParseLimit()) {
+            // extractor needed more data to process but netInBuffer was full so
+            // expand the buffer and read some more data.
+            int newLimit = Math.min(netInBuffer.capacity() * 2, endpoint.getSniParseLimit());
+            log.info(sm.getString("channel.nio.ssl.expandNetInBuffer",
+                    Integer.toString(newLimit)));
+
+            netInBuffer = ByteBufferUtils.expand(netInBuffer, newLimit);
+            sc.read(netInBuffer);
+            extractor = new TLSClientHelloExtractor(netInBuffer);
+        }
+
+        String hostName = null;
+        List<Cipher> clientRequestedCiphers = null;
+        List<String> clientRequestedApplicationProtocols = null;
+        switch (extractor.getResult()) {
+        case COMPLETE:
+            hostName = extractor.getSNIValue();
+            clientRequestedApplicationProtocols =
+                    extractor.getClientRequestedApplicationProtocols();
+            //$FALL-THROUGH$ to set the client requested ciphers
+        case NOT_PRESENT:
+            clientRequestedCiphers = extractor.getClientRequestedCiphers();
+            break;
+        case NEED_READ:
+            return SelectionKey.OP_READ;
+        case UNDERFLOW:
+            // Unable to buffer enough data to read SNI extension data
+            if (log.isDebugEnabled()) {
+                log.debug(sm.getString("channel.nio.ssl.sniDefault"));
+            }
+            hostName = endpoint.getDefaultSSLHostConfigName();
+            clientRequestedCiphers = Collections.emptyList();
+            break;
+        case NON_SECURE:
+            netOutBuffer.clear();
+            netOutBuffer.put(TLSClientHelloExtractor.USE_TLS_RESPONSE);
+            netOutBuffer.flip();
+            flushOutbound();
+            throw new IOException(sm.getString("channel.nio.ssl.foundHttp"));
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug(sm.getString("channel.nio.ssl.sniHostName", sc, hostName));
+        }
+
+        sslEngine = endpoint.createSSLEngine(hostName, clientRequestedCiphers,
+                clientRequestedApplicationProtocols);
+
+// This is the change from the code in the base class
+        JSSSession jsession = (JSSSession) sslEngine.getSession();
+        jsession.setLocalAddr(socketWrapper.getLocalAddr());
+        jsession.setRemoteAddr(socketWrapper.getRemoteAddr());
+// End of difference
+        // Populate additional TLS attributes obtained from the handshake that
+        // aren't available from the session
+        additionalTlsAttributes.put(SSLSupport.REQUESTED_PROTOCOL_VERSIONS_KEY,
+                extractor.getClientRequestedProtocols());
+        additionalTlsAttributes.put(SSLSupport.REQUESTED_CIPHERS_KEY,
+                extractor.getClientRequestedCipherNames());
+
+        // Ensure the application buffers (which have to be created earlier) are
+        // big enough.
+        getBufHandler().expand(sslEngine.getSession().getApplicationBufferSize());
+        if (netOutBuffer.capacity() < sslEngine.getSession().getApplicationBufferSize()) {
+            // Info for now as we may need to increase DEFAULT_NET_BUFFER_SIZE
+            log.info(sm.getString("channel.nio.ssl.expandNetOutBuffer",
+                    Integer.toString(sslEngine.getSession().getApplicationBufferSize())));
+        }
+        netInBuffer = ByteBufferUtils.expand(netInBuffer, sslEngine.getSession().getPacketBufferSize());
+        netOutBuffer = ByteBufferUtils.expand(netOutBuffer, sslEngine.getSession().getPacketBufferSize());
+
+        // Set limit and position to expected values
+        netOutBuffer.position(0);
+        netOutBuffer.limit(0);
+
+        // Initiate handshake
+        sslEngine.beginHandshake();
+        handshakeStatus = sslEngine.getHandshakeStatus();
+
+        return 0;
+    }
+
+
+
+    @Override
+    public SSLSupport getSSLSupport() {
+        if (sslEngine != null) {
+            SSLSession session = sslEngine.getSession();
+            return endpoint.getSslImplementation().getSSLSupport(session, additionalTlsAttributes);
+        }
+        return null;
+    }
+
+}

--- a/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSUtil.java
+++ b/tomcat-10.1/src/main/java/org/dogtagpki/jss/tomcat/JSSUtil.java
@@ -1,0 +1,130 @@
+/* BEGIN COPYRIGHT BLOCK
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ * All rights reserved.
+ * END COPYRIGHT BLOCK */
+
+package org.dogtagpki.jss.tomcat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.net.SSLContext;
+import org.apache.tomcat.util.net.SSLHostConfigCertificate;
+import org.apache.tomcat.util.net.SSLUtilBase;
+import org.mozilla.jss.JSSProvider;
+import org.mozilla.jss.provider.javax.crypto.JSSNativeTrustManager;
+
+public class JSSUtil extends SSLUtilBase {
+    public static Log logger = LogFactory.getLog(JSSUtil.class);
+
+    private String keyAlias;
+
+    private SSLEngine engine;
+    private Set<String> protocols;
+    private Set<String> ciphers;
+
+    public JSSUtil(SSLHostConfigCertificate cert) {
+        super(cert);
+
+        keyAlias = certificate.getCertificateKeyAlias();
+        logger.debug("JSSUtil: instance created");
+    }
+
+    private void init() {
+        if (engine != null) {
+            return;
+        }
+
+        try {
+            JSSContext ctx = new JSSContext(null);
+            ctx.init(null, null, null);
+            engine = ctx.createSSLEngine();
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+
+        protocols = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(engine.getSupportedProtocols()))
+        );
+
+        ciphers = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(engine.getSupportedCipherSuites()))
+        );
+    }
+
+    @Override
+    public KeyManager[] getKeyManagers() throws Exception {
+        logger.debug("JSSUtil: getKeyManagers()");
+        KeyManagerFactory jkm = KeyManagerFactory.getInstance("NssX509", "Mozilla-JSS");
+        return jkm.getKeyManagers();
+    }
+
+    @Override
+    public TrustManager[] getTrustManagers() throws Exception {
+        logger.debug("JSSUtil: getTrustManagers()");
+        if (!JSSProvider.ENABLE_JSSENGINE) {
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance("NssX509");
+            return tmf.getTrustManagers();
+        }
+
+        return new TrustManager[] { new JSSNativeTrustManager() };
+    }
+
+    @Override
+    public SSLContext createSSLContextInternal(List<String> negotiableProtocols) throws Exception {
+        logger.debug("JSSUtil createSSLContextInternal(...) keyAlias=" + keyAlias);
+        return new JSSContext(keyAlias);
+    }
+
+    @Override
+    public boolean isTls13RenegAuthAvailable() {
+        logger.debug("JSSUtil: isTls13RenegAuthAvailable()");
+        return true;
+    }
+
+    @Override
+    public Log getLog() {
+        logger.debug("JSSUtil: getLog()");
+        return logger;
+    }
+
+    @Override
+    protected Set<String> getImplementedProtocols() {
+        logger.debug("JSSUtil: getImplementedProtocols()");
+        init();
+        return protocols;
+    }
+
+    @Override
+    protected Set<String> getImplementedCiphers() {
+        logger.debug("JSSUtil: getImplementedCiphers()");
+        init();
+
+        return ciphers;
+    }
+}


### PR DESCRIPTION
This PR implements support for Tomcat 10, updating some method overrides and removing obsoleted functionality. Most of the changes have been made rather naively, and will probably need some tweaking and/or change requests before they can be merged.

It's more or less a direct port of the PR in dogtagpki/tomcatjss#78 with the same caveats and reasoning.

Closes #1009.