### PR TITLE
Add EC public key generation from spec

### DIFF
--- a/base/src/main/java/org/mozilla/jss/util/ECCurve.java
+++ b/base/src/main/java/org/mozilla/jss/util/ECCurve.java
@@ -170,4 +170,13 @@ public enum ECCurve {
 
         return null;
     }
+
+    public static ECCurve fromOrder(BigInteger order) {
+        for (ECCurve curve : ECCurve.values()) {
+            if (curve.getOrder().equals(order)) {
+                return curve;
+            }
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
Public key generation has been updated to allow the creation of ECPublicKey from the ECPublicKeySpec.
The code was requiring the encoded public key to generate a new key to use for signing verification but this is a limitation when the encoded key is not available, as for JWS validation using ES256 algorithm.