### PR TITLE
Update version number to 5.9.0-alpha1

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>5.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jss-base</artifactId>

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -3,7 +3,7 @@ macro(jss_config)
     #   MAJOR MINOR PATCH BETA
     # When BETA is 1, it is a pre-release (it enables some tests).
     # When BETA is 0, it is a final release.
-    jss_config_version(5 8 0 1)
+    jss_config_version(5 9 0 1)
 
     # Configure output directories
     jss_config_outputs()

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>5.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jss-examples</artifactId>

--- a/jss.spec
+++ b/jss.spec
@@ -2,33 +2,41 @@
 Name:           jss
 ################################################################################
 
+Summary:        Java Security Services (JSS)
+URL:            https://github.com/dogtagpki/jss
+License:        (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND Apache-2.0
+
 %global         vendor_id dogtag
 %global         product_id %{vendor_id}-jss
 
 # Upstream version number:
 %global         major_version 5
-%global         minor_version 8
+%global         minor_version 9
 %global         update_version 0
-
-# Downstream release number:
-# - development/stabilization (unsupported): 0.<n> where n >= 1
-# - GA/update (supported): <n> where n >= 1
-%global         release_number 0.1
 
 # Development phase:
 # - development (unsupported): alpha<n> where n >= 1
-# - stabilization (unsupported): beta<n> where n >= 1
+# - stabilization (supported): beta<n> where n >= 1
 # - GA/update (supported): <none>
-%global         phase beta1
+%global         phase alpha1
 
 %undefine       timestamp
 %undefine       commit_id
 
-Summary:        Java Security Services (JSS)
-URL:            https://github.com/dogtagpki/jss
-License:        (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND Apache-2.0
-Version:        %{major_version}.%{minor_version}.%{update_version}
-Release:        %{release_number}%{?phase:.}%{?phase}%{?timestamp:.}%{?timestamp}%{?commit_id:.}%{?commit_id}%{?dist}
+# Full version number:
+# - development/stabilization: <major>.<minor>.<update>-<phase>
+# - GA/update:                 <major>.<minor>.<update>
+%global         full_version %{major_version}.%{minor_version}.%{update_version}%{?phase:-}%{?phase}
+
+# RPM version number:
+# - development:   <major>.<minor>.<update>~<phase>^<timestamp>.<commit_id>
+# - stabilization: <major>.<minor>.<update>~<phase>
+# - GA/update:     <major>.<minor>.<update>
+#
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning
+
+Version:        %{major_version}.%{minor_version}.%{update_version}%{?phase:~}%{?phase}%{?timestamp:^}%{?timestamp}%{?commit_id:.}%{?commit_id}
+Release:        %autorelease
 
 # To generate the source tarball:
 # $ git clone https://github.com/dogtagpki/jss.git
@@ -37,7 +45,7 @@ Release:        %{release_number}%{?phase:.}%{?phase}%{?timestamp:.}%{?timestamp
 # $ git push origin v4.5.<z>
 # Then go to https://github.com/dogtagpki/jss/releases and download the source
 # tarball.
-Source:         https://github.com/dogtagpki/jss/archive/v%{version}%{?phase:-}%{?phase}/jss-%{version}%{?phase:-}%{?phase}.tar.gz
+Source:         https://github.com/dogtagpki/jss/archive/v%{full_version}/jss-%{full_version}.tar.gz
 
 # To create a patch for all changes since a version tag:
 # $ git format-patch \
@@ -236,7 +244,7 @@ This package provides test suite for JSS.
 %prep
 ################################################################################
 
-%autosetup -n jss-%{version}%{?phase:-}%{?phase} -p 1
+%autosetup -n jss-%{full_version} -p 1
 
 # disable native modules since they will be built by CMake
 %pom_disable_module native
@@ -319,7 +327,6 @@ touch %{_vpath_builddir}/.targets/finished_generate_javadocs
     --cmake=%{__cmake} \
     --java-home=%{java_home} \
     --jni-dir=%{_jnidir} \
-    --version=%{version} \
     --without-java \
     --without-javadoc \
     %{!?with_tests:--without-tests} \

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>5.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>libjss</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dogtagpki.jss</groupId>
     <artifactId>jss-parent</artifactId>
-    <version>5.8.0-SNAPSHOT</version>
+    <version>5.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/symkey/pom.xml
+++ b/symkey/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>5.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>libjss-symkey</artifactId>

--- a/tomcat-9.0/pom.xml
+++ b/tomcat-9.0/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>5.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jss-tomcat-9.0</artifactId>

--- a/tomcat/pom.xml
+++ b/tomcat/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.jss</groupId>
         <artifactId>jss-parent</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>5.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jss-tomcat</artifactId>

--- a/update_version.sh
+++ b/update_version.sh
@@ -39,7 +39,6 @@ verify_phase() {
 
 change_spec_version() {
     CURRENT_PHASE=$(grep "phase " jss.spec | grep -E 'alpha|beta' | awk '{print $(NF)}')
-    CURRENT_RELEASE_NUMBER=$(grep "release_number " jss.spec | grep -Eo '[0-9]+(\.[0-9]+)?$')
 
     echo "Update major version to $NEXT_MAJOR"
     sed -i "/major_version /c\%global         major_version $NEXT_MAJOR" jss.spec
@@ -52,20 +51,12 @@ change_spec_version() {
         if [ -z "$NEXT_PHASE" ] ; then
             echo "Remove phase"
             sed -i "/phase /c\#global         phase" jss.spec
-            echo "Update release_number"
-            sed -i "/release_number /c\%global         release_number 1" jss.spec
         elif [ -z "$CURRENT_PHASE" ] ; then
             echo "Add phase, set to $NEXT_PHASE"
             sed -i "/#global         phase/c\%global         phase $NEXT_PHASE" jss.spec
-            echo "Update release_number"
-            sed -i "/release_number /c\%global         release_number 0.1" jss.spec
         else
             echo "Update phase to $NEXT_PHASE"
             sed -i "/phase /c\%global         phase $NEXT_PHASE" jss.spec
-            echo "Update release_number"
-            IFS='.' read -ra CRL <<< "$CURRENT_RELEASE_NUMBER"
-            (( CRL[1]++ ))
-            sed -i "/release_number /c\%global         release_number ${CRL[0]}.${CRL[1]}" jss.spec
         fi
     fi
 }


### PR DESCRIPTION
The build scripts have been modified to generate RPM version numbers more compliant with Fedora Packaging Guidelines.

https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning