### PR TITLE
Adding option for ENABLE_NSS_VERSION_PQC_DEF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,13 @@ if (DEFINED ENV{WITH_INTERNET})
 endif()
 option(TEST_WITH_INTERNET "When enabled, runs various tests which require an internet connection. " ${TEST_WITH_INTERNET_ENV})
 
+##
+# NSS V3.112 have some PQC defs in auth_alg_defs of ssl3con.c
+# that need to be reflected into JSS SSLCipher.c (auth_alg_defs[])
+# The upstream NSS (currently v3.113) apparently has no such defs.
+#
+option(ENABLE_NSS_VERSION_PQC_DEF "Enable PQC DEF to match NSS" OFF)
+
 option(WITH_JAVA "Build Java binaries." TRUE)
 option(WITH_NATIVE "Build native binaries." TRUE)
 option(WITH_JAVADOC "Build Javadoc package." TRUE)

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -140,6 +140,10 @@ macro(jss_config_cflags)
         list(APPEND JSS_RAW_C_FLAGS "-O2")
     endif()
 
+    if(ENABLE_NSS_VERSION_PQC_DEF)
+        list(APPEND JSS_RAW_C_FLAGS "-DNSS_VERSION_PQC_DEF")
+    endif()
+
     list(APPEND JSS_RAW_C_FLAGS "-Wall")
     list(APPEND JSS_RAW_C_FLAGS "-std=gnu99")
     list(APPEND JSS_RAW_C_FLAGS "-Wno-cast-function-type")


### PR DESCRIPTION
Note that we still need jss.spec to differentiate NSS versions to decide whether to set ENABLE_NSS_VERSION_PQC_DEF to on or off.

Fix as part of the build task:
https://issues.redhat.com/browse/IDM-2360