### PR TITLE
Add matching PQC algs to auth_alg_defs[] with NSS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ option(TEST_WITH_INTERNET "When enabled, runs various tests which require an int
 ##
 # NSS V3.112 have some PQC defs in auth_alg_defs of ssl3con.c
 # that need to be reflected into JSS SSLCipher.c (auth_alg_defs[])
-# The upstream NSS (currently v3.113) apparently has no such defs.
+# Some OS platforms not yet have such defs.
 #
 option(ENABLE_NSS_VERSION_PQC_DEF "Enable PQC DEF to match NSS" OFF)
 

--- a/jss.spec
+++ b/jss.spec
@@ -21,6 +21,10 @@ Name:           jss
 # - GA/update (supported): <none>
 %global         phase beta2
 
+%if 0%{?rhel} && 0%{?rhel} >= 10
+%global enable_nss_version_pqc_def_flag -DENABLE_NSS_VERSION_PQC_DEF=ON
+%endif
+
 %undefine       timestamp
 %undefine       commit_id
 
@@ -310,7 +314,7 @@ touch %{_vpath_builddir}/.targets/finished_generate_javadocs
     --lib-dir=%{_libdir} \
     --sysconf-dir=%{_sysconfdir} \
     --share-dir=%{_datadir} \
-    --cmake=%{__cmake} \
+    --cmake="%{__cmake} %{?enable_nss_version_pqc_def_flag}" \
     --java-home=%{java_home} \
     --jni-dir=%{_jnidir} \
     --version=%{version} \


### PR DESCRIPTION
Fix build failure caused by updated NSS version with new pqc defs int auth_alg_defs[] This requires the previous commit:
8cbe1faa8aa0cd0c6cf91ed04e5d06678d114722

This patch makes cognizant of the os version.

fixes https://issues.redhat.com/browse/IDM-2428