### PR TITLE
Reintroduce SHA-1 references from JSSProvider

### DIFF
--- a/base/src/main/java/org/mozilla/jss/JSSProvider.java
+++ b/base/src/main/java/org/mozilla/jss/JSSProvider.java
@@ -140,6 +140,16 @@ public final class JSSProvider extends java.security.Provider {
         /////////////////////////////////////////////////////////////
         // Signature
         /////////////////////////////////////////////////////////////
+        put("Signature.SHA1withDSA",
+            "org.mozilla.jss.provider.java.security.JSSSignatureSpi$DSA");
+
+        put("Alg.Alias.Signature.DSA", "SHA1withDSA");
+        put("Alg.Alias.Signature.DSS", "SHA1withDSA");
+        put("Alg.Alias.Signature.SHA/DSA", "SHA1withDSA");
+        put("Alg.Alias.Signature.SHA-1/DSA", "SHA1withDSA");
+        put("Alg.Alias.Signature.SHA1/DSA", "SHA1withDSA");
+        put("Alg.Alias.Signature.DSAWithSHA1", "SHA1withDSA");
+        put("Alg.Alias.Signature.SHAwithDSA", "SHA1withDSA");
 
         put("Signature.MD5/RSA",
             "org.mozilla.jss.provider.java.security.JSSSignatureSpi$MD5RSA");
@@ -147,6 +157,11 @@ public final class JSSProvider extends java.security.Provider {
 
         put("Signature.MD2/RSA",
             "org.mozilla.jss.provider.java.security.JSSSignatureSpi$MD2RSA");
+
+        put("Signature.SHA-1/RSA",
+            "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA1RSA");
+        put("Alg.Alias.Signature.SHA1/RSA", "SHA-1/RSA");
+        put("Alg.Alias.Signature.SHA1withRSA", "SHA-1/RSA");
 
         put("Signature.SHA-256/RSA",
             "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA256RSA");
@@ -185,6 +200,17 @@ public final class JSSProvider extends java.security.Provider {
         put("Alg.Alias.Signature.SHA512/RSA", "SHA-512/RSA");
         put("Alg.Alias.Signature.SHA512withRSA", "SHA-512/RSA");
 // ECC
+        put("Signature.SHA1withEC",
+            "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA1EC");
+        put("Alg.Alias.Signature.EC", "SHA1withEC");
+        put("Alg.Alias.Signature.ECC", "SHA1withEC");
+        put("Alg.Alias.Signature.ECDSA", "SHA1withEC");
+        put("Alg.Alias.Signature.SHA/EC", "SHA1withEC");
+        put("Alg.Alias.Signature.SHA1/EC", "SHA1withEC");
+        put("Alg.Alias.Signature.SHA-1/EC", "SHA1withEC");
+        put("Alg.Alias.Signature.SHA/ECDSA", "SHA1withEC");
+        put("Alg.Alias.Signature.SHA1/ECDSA", "SHA1withEC");
+        put("Alg.Alias.Signature.SHA1withECDSA", "SHA1withEC"); //JCE Standard Name
 
         put("Signature.SHA256withEC",
             "org.mozilla.jss.provider.java.security.JSSSignatureSpi$SHA256EC");
@@ -208,6 +234,8 @@ public final class JSSProvider extends java.security.Provider {
         // Message Digesting
         /////////////////////////////////////////////////////////////
 
+        put("MessageDigest.SHA-1",
+                "org.mozilla.jss.provider.java.security.JSSMessageDigestSpi$SHA1");
         put("MessageDigest.MD2",
                 "org.mozilla.jss.provider.java.security.JSSMessageDigestSpi$MD2");
         put("MessageDigest.MD5",
@@ -219,6 +247,8 @@ public final class JSSProvider extends java.security.Provider {
         put("MessageDigest.SHA-512",
                 "org.mozilla.jss.provider.java.security.JSSMessageDigestSpi$SHA512");
 
+        put("Alg.Alias.MessageDigest.SHA1", "SHA-1");
+        put("Alg.Alias.MessageDigest.SHA", "SHA-1");
         put("Alg.Alias.MessageDigest.SHA256", "SHA-256");
         put("Alg.Alias.MessageDigest.SHA384", "SHA-384");
         put("Alg.Alias.MessageDigest.SHA512", "SHA-512");
@@ -402,6 +432,7 @@ public final class JSSProvider extends java.security.Provider {
             "org.mozilla.jss.provider.javax.crypto.JSSMacSpi$HmacSHA512");
         put("Mac.CmacAES", "org.mozilla.jss.provider.javax.crypto.JSSMacSpi$CmacAES");
         put("Alg.Alias.Mac.Hmac-SHA512", "HmacSHA512");
+        put("Alg.Alias.Mac.SHA-1-HMAC", "HmacSHA1");
         put("Alg.Alias.Mac.SHA-256-HMAC", "HmacSHA256");
         put("Alg.Alias.Mac.SHA-384-HMAC", "HmacSHA384");
         put("Alg.Alias.Mac.SHA-512-HMAC", "HmacSHA512");


### PR DESCRIPTION
Adding SHA1/RSA alias to JSSProvider.

Recently I run into issue during update of PKI infrastructure where some old systems are sending CSRs with `SHA1withRSA` singing alg. This fails with:

```
SEVERE: Unable to parse PKCS #10 request: no such algorithm: SHA1/RSA for provider Mozilla-JSS
java.security.NoSuchAlgorithmException: no such algorithm: SHA1/RSA for provider Mozilla-JSS
```

Since I need to support this old CSRs I dig into the code and found out that SHA1 algs was reintroduced to the JSS (here: https://github.com/dogtagpki/jss/commit/11ecabc9086f8b797b7545356a7b2fb8c7e94677) after removal (here: https://github.com/dogtagpki/jss/commit/f9d83e27ff6d22c9cefe4a7d1f651498782bb8cb).

In this commit  SHA1 alias was removed https://github.com/dogtagpki/jss/commit/038a3a5bb7ae92890ad1a08a2f20bea416d1da95 but never reintroduced.

So here is a version that should fix my issue. 
 