### PR TITLE
Add matching PQC algs to auth_alg_defs[] with NSS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ option(TEST_WITH_INTERNET "When enabled, runs various tests which require an int
 ##
 # NSS V3.112 have some PQC defs in auth_alg_defs of ssl3con.c
 # that need to be reflected into JSS SSLCipher.c (auth_alg_defs[])
-# The upstream NSS (currently v3.113) apparently has no such defs.
+# Some OS platforms not yet have such defs.
 #
 option(ENABLE_NSS_VERSION_PQC_DEF "Enable PQC DEF to match NSS" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,13 @@ if (DEFINED ENV{WITH_INTERNET})
 endif()
 option(TEST_WITH_INTERNET "When enabled, runs various tests which require an internet connection. " ${TEST_WITH_INTERNET_ENV})
 
+##
+# NSS V3.112 have some PQC defs in auth_alg_defs of ssl3con.c
+# that need to be reflected into JSS SSLCipher.c (auth_alg_defs[])
+# The upstream NSS (currently v3.113) apparently has no such defs.
+#
+option(ENABLE_NSS_VERSION_PQC_DEF "Enable PQC DEF to match NSS" OFF)
+
 option(WITH_JAVA "Build Java binaries." TRUE)
 option(WITH_NATIVE "Build native binaries." TRUE)
 option(WITH_JAVADOC "Build Javadoc package." TRUE)

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -140,6 +140,10 @@ macro(jss_config_cflags)
         list(APPEND JSS_RAW_C_FLAGS "-O2")
     endif()
 
+    if(ENABLE_NSS_VERSION_PQC_DEF)
+        list(APPEND JSS_RAW_C_FLAGS "-DNSS_VERSION_PQC_DEF")
+    endif()
+
     list(APPEND JSS_RAW_C_FLAGS "-Wall")
     list(APPEND JSS_RAW_C_FLAGS "-std=gnu99")
     list(APPEND JSS_RAW_C_FLAGS "-Wno-cast-function-type")

--- a/jss.spec
+++ b/jss.spec
@@ -21,6 +21,10 @@ Name:           jss
 # - GA/update (supported): <none>
 %global         phase beta1
 
+%if 0%{?rhel} && 0%{?rhel} >= 10
+%global enable_nss_version_pqc_def_flag -DENABLE_NSS_VERSION_PQC_DEF=ON
+%endif
+
 %undefine       timestamp
 %undefine       commit_id
 
@@ -316,7 +320,7 @@ touch %{_vpath_builddir}/.targets/finished_generate_javadocs
     --lib-dir=%{_libdir} \
     --sysconf-dir=%{_sysconfdir} \
     --share-dir=%{_datadir} \
-    --cmake=%{__cmake} \
+    --cmake="%{__cmake} %{?enable_nss_version_pqc_def_flag}" \
     --java-home=%{java_home} \
     --jni-dir=%{_jnidir} \
     --version=%{version} \

--- a/native/src/main/native/org/mozilla/jss/ssl/SSLCipher.c
+++ b/native/src/main/native/org/mozilla/jss/ssl/SSLCipher.c
@@ -19,7 +19,14 @@ static const CK_MECHANISM_TYPE auth_alg_defs[] = {
     CKM_RSA_PKCS,          /* ssl_auth_rsa_sign */
     CKM_RSA_PKCS_PSS,      /* ssl_auth_rsa_pss */
     CKM_NSS_HKDF_SHA256,   /* ssl_auth_psk (just check for HKDF) */
+#ifndef NSS_VERSION_PQC_DEF
     CKM_INVALID_MECHANISM  /* ssl_auth_tls13_any */
+#else
+    CKM_INVALID_MECHANISM,  /* ssl_auth_tls13_any */
+    CKM_ML_DSA,            /* ssl_auth_mldsa (same mech for each) */
+    CKM_ML_DSA,            /* ssl_auth_mldsa (key determines the*/
+    CKM_ML_DSA            /* ssl_auth_mldsa  parameter set) */
+#endif
 };
 PR_STATIC_ASSERT(PR_ARRAY_SIZE(auth_alg_defs) == ssl_auth_size);
 


### PR DESCRIPTION
Fix build failure caused by updated NSS version with new pqc defs int auth_alg_defs[]
For reference, this change corresponds to an NSS patch that currently exists on CentOS 10 only:
    https://gitlab.com/redhat/centos-stream/rpms/nss/-/blob/c10s/nss-3.112-add-ml-dsa-ssl-support.patch?ref_type=heads#L965
    * Adding option for ENABLE_NSS_VERSION_PQC_DEF (#1053)
    * cognizant of the os version.

fixes https://issues.redhat.com/browse/IDM-2428