### PR TITLE
fix: use size_t in calls to JSS_FromByteArray

### DIFF
--- a/native/src/main/native/org/mozilla/jss/crypto/JSSOAEPParameterSpec.c
+++ b/native/src/main/native/org/mozilla/jss/crypto/JSSOAEPParameterSpec.c
@@ -66,7 +66,11 @@ oaep_GetSpecifiedSourceData(JNIEnv *env, jobject this, jclass this_class, CK_VOI
     }
 
     if (ret_len != NULL) {
-        *ret_len = st_ret_len;
+        if (sizeof(size_t) > sizeof(CK_ULONG) && st_ret_len > (CK_ULONG)-1) {
+            /* This should be impossible as length comes from a jbyteArray */
+            return PR_FAILURE;
+        }
+        *ret_len = (CK_ULONG)st_ret_len;
     }
 
     return PR_SUCCESS;

--- a/native/src/main/native/org/mozilla/jss/crypto/JSSOAEPParameterSpec.c
+++ b/native/src/main/native/org/mozilla/jss/crypto/JSSOAEPParameterSpec.c
@@ -47,6 +47,7 @@ oaep_GetSpecifiedSourceData(JNIEnv *env, jobject this, jclass this_class, CK_VOI
 {
     jfieldID field_id = NULL;
     jbyteArray data = NULL;
+    size_t st_ret_len = 0;
 
     field_id = (*env)->GetFieldID(env, this_class, "sourceData", "[B");
     if (field_id == NULL) {
@@ -60,8 +61,12 @@ oaep_GetSpecifiedSourceData(JNIEnv *env, jobject this, jclass this_class, CK_VOI
         return PR_SUCCESS;
     }
 
-    if (!JSS_FromByteArray(env, data, (uint8_t **)ret, ret_len)) {
+    if (!JSS_FromByteArray(env, data, (uint8_t **)ret, &st_ret_len)) {
         return PR_FAILURE;
+    }
+
+    if (ret_len != NULL) {
+        *ret_len = st_ret_len;
     }
 
     return PR_SUCCESS;

--- a/native/src/main/native/org/mozilla/jss/crypto/KBKDF.c
+++ b/native/src/main/native/org/mozilla/jss/crypto/KBKDF.c
@@ -757,6 +757,7 @@ kbkdf_GetInitialValue(JNIEnv *env, jobject this, jclass this_class, CK_ULONG *in
 {
     jfieldID field_id = NULL;
     jobjectArray iv_array = NULL;
+    size_t st_initial_value_length = 0;
 
     field_id = (*env)->GetFieldID(env, this_class, "initial_value", "[B");
     if (field_id == NULL) {
@@ -770,8 +771,12 @@ kbkdf_GetInitialValue(JNIEnv *env, jobject this, jclass this_class, CK_ULONG *in
         return PR_SUCCESS;
     }
 
-    if (!JSS_FromByteArray(env, iv_array, initial_value, initial_value_length)) {
+    if (!JSS_FromByteArray(env, iv_array, initial_value, &st_initial_value_length)) {
         return PR_FAILURE;
+    }
+
+    if (initial_value_length != NULL) {
+        *initial_value_length = st_initial_value_length;
     }
 
     return PR_SUCCESS;

--- a/native/src/main/native/org/mozilla/jss/crypto/KBKDF.c
+++ b/native/src/main/native/org/mozilla/jss/crypto/KBKDF.c
@@ -776,7 +776,11 @@ kbkdf_GetInitialValue(JNIEnv *env, jobject this, jclass this_class, CK_ULONG *in
     }
 
     if (initial_value_length != NULL) {
-        *initial_value_length = st_initial_value_length;
+        if (sizeof(size_t) > sizeof(CK_ULONG) && st_initial_value_length > (CK_ULONG)-1) {
+            /* This should be impossible as length comes from a jbyteArray */
+            return PR_FAILURE;
+        }
+        *initial_value_length = (CK_ULONG)st_initial_value_length;
     }
 
     return PR_SUCCESS;


### PR DESCRIPTION
This PR addresses:  https://github.com/dogtagpki/jss/issues/1077

It adds `size_t` variable to be used in calls to JSS_FromByteArray and assigns the returned value on the successfull calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected length handling when converting byte arrays in cryptographic routines so actual byte lengths are reliably captured and returned, preventing incorrect size reporting and ensuring callers receive accurate data lengths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->