### PR TITLE
Fix race condition segfault in JSSEngineReferenceImpl cleanup

### DIFF
--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -736,7 +736,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
     }
 
     @Override
-    public void closeInbound() {
+    public synchronized void closeInbound() {
         debug("JSSEngine: closeInbound()");
 
         if (!is_inbound_closed && ssl_fd != null && !closed_fd) {
@@ -750,7 +750,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
     }
 
     @Override
-    public void closeOutbound() {
+    public synchronized void closeOutbound() {
         debug("JSSEngine: closeOutbound()");
 
         if (!is_outbound_closed && ssl_fd != null && !closed_fd) {
@@ -1675,7 +1675,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
      * connection.
      */
     @Override
-    public void tryCleanup() {
+    public synchronized void tryCleanup() {
         debug("JSSEngine: tryCleanup()");
         if (is_inbound_closed && is_outbound_closed) {
             // throw new RuntimeException("Probably shouldn't be here!");
@@ -1688,7 +1688,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
      * data streams if still open.
      */
     @Override
-    public void cleanup() {
+    public synchronized void cleanup() {
         debug("JSSEngine: cleanup()");
 
         if (!is_inbound_closed) {


### PR DESCRIPTION
The finalizer thread was experiencing segfaults during `PR.Shutdown()` calls due to a race condition where multiple threads could execute cleanup operations simultaneously on the same object.

Root cause:
- `cleanup()`, `closeInbound()`, `closeOutbound()`, and `tryCleanup()` methods were not synchronized
- Multiple threads could simultaneously check and modify the boolean flags (`closed_fd`, `is_inbound_closed`, `is_outbound_closed`)
- One thread could close/free `ssl_fd` while another thread was still using it in `PR.Shutdown()`, causing `SIGSEGV` in NSS `memcpy`

Changes:
- Add `synchronized` modifier to `closeInbound()`, `closeOutbound()`, `cleanup()`, and `tryCleanup()` methods
- The `synchronized` keyword provides both mutual exclusion (only one thread can execute these methods at a time) and memory visibility (changes to fields are visible to other threads)

This prevents concurrent cleanup operations from corrupting the native `PRFileDesc` pointer and eliminates the segfault during finalization.

Assisted-by: Claude Sonnet 4.5

**Note:** This PR is originally generated by Claude and updated based on reviews. There's no guarantee it will fully fix the issue. We'll need to keep monitoring for crashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connection shutdown and cleanup now run serially to avoid interleaving during concurrent teardowns. This reduces race conditions during SSL connection close, improving stability, preventing sporadic errors or resource leaks, and making simultaneous connection terminations more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->