### PR TITLE
Update Password.readPasswordFromConsole()

### DIFF
--- a/base/src/main/java/org/mozilla/jss/util/Password.java
+++ b/base/src/main/java/org/mozilla/jss/util/Password.java
@@ -286,7 +286,37 @@ public class Password implements PasswordCallback, Cloneable,
     public static Password readPasswordFromConsole() throws PasswordCallback.GiveUpException {
 
         Console console = System.console();
-        char[] password = console.readPassword();
+
+        char[] password;
+        if (console == null) {
+            // no console, read password from standard input
+            try {
+                char[] buffer = new char[128];
+                int len = 0;
+                int c;
+
+                // read a single line into buffer
+                while ((c = System.in.read()) != -1 && c != '\n' && c != '\r') {
+                    if (len == buffer.length) {
+                        // buffer full, resize buffer
+                        buffer = Arrays.copyOf(buffer, buffer.length * 2);
+                    }
+                    buffer[len++] = (char) c;
+                }
+
+                // get password from buffer
+                password = Arrays.copyOf(buffer, len);
+                Arrays.fill(buffer, (char) 0);
+
+            } catch (java.io.IOException e) {
+                logger.error("Unable to read password: " + e.getMessage(), e);
+                password = null;
+            }
+
+        } else {
+            // read password from console
+            password = console.readPassword();
+        }
 
         if (password == null || password.length == 0) {
             throw new PasswordCallback.GiveUpException();


### PR DESCRIPTION
The `Password.readPasswordFromConsole()` has been modified to read the password from the standard input in case the system console is not available (e.g. in CI environment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password input handling to work reliably when console access is unavailable (e.g., non-interactive or IDE environments); preserves prior behavior when a console is present.
  * Better handles input termination and errors, avoiding silent empty passwords and surfacing failures appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->