### PR TITLE
Fix: Add support to PBMAC1 in pkcs 12 [JSS]

### DIFF
--- a/base/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
@@ -67,12 +67,20 @@ import org.mozilla.jss.pkcs12.SafeBag;
 import org.mozilla.jss.pkix.primitive.Attribute;
 import org.mozilla.jss.pkix.primitive.EncryptedPrivateKeyInfo;
 import org.mozilla.jss.util.Password;
+import org.mozilla.jss.crypto.DigestAlgorithm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PKCS12Util {
 
     private static Logger logger = LoggerFactory.getLogger(PKCS12Util.class);
+
+
+    //Differentiate between newer PBMAC1 and older algs
+    public static enum MacType {
+        LEGACY,
+        PBMAC1
+    }
 
     public final static String NO_ENCRYPTION = "none";
 
@@ -96,6 +104,26 @@ public class PKCS12Util {
     PBEAlgorithm certEncryption = DEFAULT_CERT_ENCRYPTION;
     PBEAlgorithm keyEncryption = DEFAULT_KEY_ENCRYPTION;
     boolean trustFlagsEnabled = true;
+
+    // MAC configuration (separate from encryption)
+    private MacType macType = MacType.LEGACY;  // default for backward compatibility
+    private DigestAlgorithm macDigest = DigestAlgorithm.SHA256;  // default digest
+
+    public void setMacType(MacType type) {
+        this.macType = type;
+    }
+
+    public MacType getMacType() {
+        return macType;
+    }
+
+    public void setMacDigest(DigestAlgorithm digest) {
+        this.macDigest = digest;
+    }
+
+    public DigestAlgorithm getMacDigest() {
+        return macDigest;
+    }
 
     public PKCS12Util() throws Exception {
         random = SecureRandom.getInstance("pkcs11prng", "Mozilla-JSS");
@@ -603,6 +631,10 @@ public class PKCS12Util {
 
         byte[] salt = new byte[16];
         random.nextBytes(salt);
+
+        pfx.setMacType(macType);
+        pfx.setMacDigest(macDigest);
+
         pfx.computeMacData(password, salt, 100000);
 
         return pfx;

--- a/base/src/main/java/org/mozilla/jss/pkcs12/MacData.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs12/MacData.java
@@ -8,6 +8,8 @@ import java.io.CharConversionException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.security.DigestException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -22,6 +24,8 @@ import org.mozilla.jss.asn1.InvalidBERException;
 import org.mozilla.jss.asn1.OCTET_STRING;
 import org.mozilla.jss.asn1.SEQUENCE;
 import org.mozilla.jss.asn1.Tag;
+import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
+import org.mozilla.jss.asn1.ANY;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.DigestAlgorithm;
 import org.mozilla.jss.crypto.HMACAlgorithm;
@@ -32,8 +36,11 @@ import org.mozilla.jss.crypto.KeyGenerator;
 import org.mozilla.jss.crypto.PBEKeyGenParams;
 import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.TokenException;
+import org.mozilla.jss.crypto.PBEAlgorithm;
+import org.mozilla.jss.pkix.primitive.PBMAC1Params;
 import org.mozilla.jss.pkcs7.DigestInfo;
 import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
+import org.mozilla.jss.pkix.primitive.PBKDF2Params;
 import org.mozilla.jss.util.Password;
 
 public class MacData implements ASN1Value {
@@ -137,13 +144,30 @@ public class MacData implements ASN1Value {
             rand.nextBytes(macSalt);
         }
 
+        // Handle null algID - default to SHA1 for backward compatibility
+
+        try {
+            if (algID == null) {
+                algID = new AlgorithmIdentifier(DigestAlgorithm.SHA1.toOID());
+            }
+
+            // Check if this is PBMAC1 - route to new implementation
+            if (algID.getOID().equals(PBEAlgorithm.PBE_PKCS5_PBMAC1.toOID())) {
+                computePBMAC1(token, password, toBeMACed, algID);
+                return; // Early return - skip legacy code below
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new TokenException("Algorithm OID error: " + e.getMessage(), e);
+        } catch (TokenException | CharConversionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new TokenException("Failed to compute PBMAC1: " + e.getMessage(), e);
+        }
+
         PBEKeyGenParams params = new PBEKeyGenParams(password, macSalt, iterations);
 
         try {
             // generate key from password and salt
-            if(algID == null) {
-                algID = new AlgorithmIdentifier(DigestAlgorithm.SHA1.toOID());
-            }
             KeyGenerator kg = null;
             JSSMessageDigest digest = null;
             if(DigestAlgorithm.SHA1.toOID().equals(algID.getOID())){
@@ -195,6 +219,116 @@ public class MacData implements ASN1Value {
             params.clear();
         }
     }
+
+    private void computePBMAC1(CryptoToken token, Password password,
+                           byte[] data, AlgorithmIdentifier algID)
+        throws Exception
+    {
+        // Parse PBMAC1 parameters to extract KDF and MAC algorithms
+
+        PBMAC1Params pbmac1Params;
+        ASN1Value params =  algID.getParameters();
+
+        if (params instanceof PBMAC1Params) {
+           // Already decoded (create/write path)
+           pbmac1Params = (PBMAC1Params) params;
+        } else if (params instanceof ANY) {
+          // Needs decoding (read from file path)
+          pbmac1Params = (PBMAC1Params) ((ANY) params).decodeWith(PBMAC1Params.getTemplate());
+        } else {
+            throw new Exception("Unexpected PBMAC1 parameter type: " + params.getClass().getName());
+        }
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+        algID.encode(bos);
+        byte[] pbmac1AlgIDBytes = bos.toByteArray();
+
+        AlgorithmIdentifier kdfAlg = pbmac1Params.getKeyDerivationFunc();
+        AlgorithmIdentifier macAlg = pbmac1Params.getMessageAuthScheme();
+
+        ASN1Value kdfParams = kdfAlg.getParameters();
+
+        //Extract PBKDF2 parameters
+        PBKDF2Params pbkdf2Params;
+
+        if (kdfParams instanceof SEQUENCE) {
+             // Need to decode SEQUENCE bytes to PBKDF2Params
+             ByteArrayOutputStream bosForDecode = new ByteArrayOutputStream();
+             kdfParams.encode(bosForDecode);
+             pbkdf2Params = (PBKDF2Params) PBKDF2Params.getTemplate().decode(
+             new ByteArrayInputStream(bosForDecode.toByteArray()));
+
+        } else if (kdfParams instanceof ANY) {
+            // Create template that knows PBKDF2 structure
+            pbkdf2Params = (PBKDF2Params) ((ANY) kdfParams).decodeWith(PBKDF2Params.getTemplate());
+        } else {
+            throw new Exception("Unexpected PBKDF2 parameter type: " + kdfParams.getClass().getName());
+        }
+
+        byte[] kdfSalt = pbkdf2Params.getSalt();
+        int kdfIterations = pbkdf2Params.getIterations();
+
+        // Get HMAC OID from MAC AlgorithmIdentifier
+        OBJECT_IDENTIFIER macOID = macAlg.getOID();
+
+        HMACAlgorithm hmacAlgorithm;
+        if (macOID.equals(HMACAlgorithm.SHA256.toOID())) {
+            hmacAlgorithm = HMACAlgorithm.SHA256;
+        } else if (macOID.equals(HMACAlgorithm.SHA384.toOID())) {
+            hmacAlgorithm = HMACAlgorithm.SHA384;
+        } else if (macOID.equals(HMACAlgorithm.SHA512.toOID())) {
+            hmacAlgorithm = HMACAlgorithm.SHA512;
+        } else {
+            throw new NoSuchAlgorithmException("Unsupported HMAC algorithm for PBMAC1: " + macOID.toString());
+        }
+
+        // Call native JSS code to perform PBKDF2 + HMAC
+        // This uses certified NSS crypto (PK11_PBEKeyGen + PK11_DigestOp)
+        // The OID will be mapped to the appropriate NSS HMAC mechanism
+
+
+        char[] passwordChars = password.getCharCopy();
+        byte[] passwordBytes = null;
+
+        try {
+                passwordBytes = Password.charToByte(passwordChars);
+                byte[] macValue = nativeComputePBMAC1(
+                token,
+                passwordBytes,
+                data,
+                pbmac1AlgIDBytes,
+                hmacAlgorithm
+                );
+
+                this.mac = new DigestInfo(algID, new OCTET_STRING(macValue));
+                this.macSalt = new OCTET_STRING(kdfSalt);
+                this.macIterationCount = new INTEGER(1);
+        } finally {
+            if (passwordBytes != null) {
+                Password.wipeBytes(passwordBytes);
+            }
+            Password.wipeChars(passwordChars);
+        }
+    }
+
+    /**
+     * Native method to compute PBMAC1 MAC using NSS.
+     *
+     * @param password Password bytes
+     * @param salt PBKDF2 salt
+     * @param iterations PBKDF2 iteration count
+     * @param data Data to MAC
+     * @param hmacOID HMAC algorithm OID (e.g., hmacWithSHA256)
+     * @return HMAC value
+     */
+    private native byte[] nativeComputePBMAC1(
+        CryptoToken token,
+        byte[] password,
+        byte[] data,
+        byte[] pbmac1AlgID,
+        HMACAlgorithm hmacAlgorithm
+    ) throws Exception;
 
     ///////////////////////////////////////////////////////////////////////
     // DER encoding

--- a/base/src/main/java/org/mozilla/jss/pkcs12/PFX.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs12/PFX.java
@@ -28,10 +28,13 @@ import org.mozilla.jss.asn1.OCTET_STRING;
 import org.mozilla.jss.asn1.SEQUENCE;
 import org.mozilla.jss.asn1.SET;
 import org.mozilla.jss.asn1.Tag;
+import org.mozilla.jss.asn1.NULL;
+import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
 import org.mozilla.jss.crypto.JSSSecureRandom;
 import org.mozilla.jss.crypto.PBEAlgorithm;
 import org.mozilla.jss.crypto.DigestAlgorithm;
 import org.mozilla.jss.crypto.TokenException;
+import org.mozilla.jss.crypto.HMACAlgorithm;
 import org.mozilla.jss.pkcs7.ContentInfo;
 import org.mozilla.jss.pkcs7.DigestInfo;
 import org.mozilla.jss.pkix.cert.Certificate;
@@ -39,7 +42,9 @@ import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
 import org.mozilla.jss.pkix.primitive.Attribute;
 import org.mozilla.jss.pkix.primitive.EncryptedPrivateKeyInfo;
 import org.mozilla.jss.pkix.primitive.PrivateKeyInfo;
+import org.mozilla.jss.pkix.primitive.PBMAC1Params;
 import org.mozilla.jss.util.Password;
+import org.mozilla.jss.netscape.security.pkcs.PKCS12Util.MacType;
 
 /**
  * The top level ASN.1 structure for a PKCS #12 blob.
@@ -94,12 +99,23 @@ public class PFX implements ASN1Value {
     // currently we are on version 3 of the standard
     private static final INTEGER VERSION = new INTEGER(3);
 
+    // MAC configuration
+    private MacType macType = MacType.LEGACY;  // default
+    private DigestAlgorithm macDigest = DigestAlgorithm.SHA256;  // default
+
     /**
      * The default number of iterations to use when generating the MAC.
      * Currently, it is 1.
      */
     public static final int DEFAULT_ITERATIONS = 1;
 
+    public void setMacType(MacType type) {
+        this.macType = type;
+    }
+
+    public void setMacDigest(DigestAlgorithm digest) {
+        this.macDigest = digest;
+    }
 
     public INTEGER getVersion() {
         return version;
@@ -153,6 +169,7 @@ public class PFX implements ASN1Value {
 
         // create a new MacData based on the encoded Auth Safes
         DigestInfo macDataMac = macData.getMac();
+
         MacData testMac = new MacData(password,
                 macData.getMacSalt().toByteArray(),
                 macData.getMacIterationCount().intValue(),
@@ -219,12 +236,81 @@ public class PFX implements ASN1Value {
         TokenException, CharConversionException
     {
 
-        //Make this alg the default mac alg.
-        AlgorithmIdentifier algID = new AlgorithmIdentifier(DigestAlgorithm.SHA256.toOID());
-        macData = new MacData( password, salt, iterationCount,
-                ASN1Util.encode(authSafes), algID );
+        AlgorithmIdentifier algID;
+
+        if (salt == null) {
+            CryptoManager cm = CryptoManager.getInstance();
+            JSSSecureRandom rand = cm.createPseudoRandomNumberGenerator();
+            salt = new byte[20];  // SALT_LENGTH from MacData
+            rand.nextBytes(salt);
+        }
+
+        if (macType == MacType.PBMAC1) {
+            // Create PBMAC1 AlgorithmIdentifier with PBKDF2 parameters
+            algID = createPBMAC1AlgorithmID(salt, iterationCount, macDigest);
+        } else {
+            // Legacy: Use configured digest 
+            algID = new AlgorithmIdentifier(macDigest.toOID());
+        }
+
+        macData = new MacData(password, salt, iterationCount,
+            ASN1Util.encode(authSafes), algID);
     }
 
+    private AlgorithmIdentifier createPBMAC1AlgorithmID(
+        byte[] salt, int iterationCount, DigestAlgorithm digest)
+        throws NoSuchAlgorithmException
+    {
+        // Determine HMAC OID and key length from digest algorithm
+        // Use existing HMACAlgorithm constants instead of hardcoded OIDs
+
+        int keyLength = digest.getOutputSize();
+        // Get the corresponding HMAC algorithm
+        HMACAlgorithm hmacAlg;
+
+        if (digest.equals(DigestAlgorithm.SHA256)) {
+            hmacAlg = HMACAlgorithm.SHA256;
+        } else if (digest.equals(DigestAlgorithm.SHA384)) {
+            hmacAlg = HMACAlgorithm.SHA384;
+        } else if (digest.equals(DigestAlgorithm.SHA512)) {
+            hmacAlg = HMACAlgorithm.SHA512;
+        } else {
+            throw new NoSuchAlgorithmException(
+                "Unsupported PBMAC1 digest: " + digest);
+        }
+
+        OBJECT_IDENTIFIER hmacOID = hmacAlg.toOID();
+
+        // Construct PBKDF2 parameters
+        // PBKDF2-params ::= SEQUENCE {
+        //   salt OCTET STRING,
+        //   iterationCount INTEGER,
+        //   keyLength INTEGER OPTIONAL,
+        //   prf AlgorithmIdentifier DEFAULT hmacWithSHA1
+        // }
+        SEQUENCE pbkdf2Params = new SEQUENCE();
+        pbkdf2Params.addElement(new OCTET_STRING(salt));
+        pbkdf2Params.addElement(new INTEGER(iterationCount));
+        pbkdf2Params.addElement(new INTEGER(keyLength));
+
+        // PRF algorithm for PBKDF2 (same HMAC algorithm)
+        AlgorithmIdentifier prfAlg = new AlgorithmIdentifier(hmacOID);
+        pbkdf2Params.addElement(prfAlg);
+
+        // Construct PBKDF2 AlgorithmIdentifier
+        AlgorithmIdentifier kdfAlg = new AlgorithmIdentifier(
+            PBEAlgorithm.PBE_PKCS5_PBKDF2.toOID(), pbkdf2Params);
+
+        // Construct HMAC AlgorithmIdentifier for MAC scheme
+        AlgorithmIdentifier macAlg = new AlgorithmIdentifier(hmacOID);
+
+        // Construct PBMAC1 parameters using dedicated ASN.1 type
+        PBMAC1Params pbmac1Params = new PBMAC1Params(kdfAlg, macAlg);
+
+        // Construct final PBMAC1 AlgorithmIdentifier
+        return new AlgorithmIdentifier(
+            PBEAlgorithm.PBE_PKCS5_PBMAC1.toOID(), pbmac1Params);
+    }
 
     ///////////////////////////////////////////////////////////////////////
     // DER encoding

--- a/base/src/main/java/org/mozilla/jss/pkix/primitive/PBMAC1Params.java
+++ b/base/src/main/java/org/mozilla/jss/pkix/primitive/PBMAC1Params.java
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.jss.pkix.primitive;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.mozilla.jss.asn1.ASN1Template;
+import org.mozilla.jss.asn1.ASN1Value;
+import org.mozilla.jss.asn1.InvalidBERException;
+import org.mozilla.jss.asn1.SEQUENCE;
+import org.mozilla.jss.asn1.Tag;
+
+/**
+ * PKCS #5 <i>PBMAC1-params</i> from RFC 9579.
+ *
+ * <pre>
+ * PBMAC1-params ::= SEQUENCE {
+ *   keyDerivationFunc AlgorithmIdentifier {{PBMAC1-KDFs}},
+ *   messageAuthScheme AlgorithmIdentifier {{PBMAC1-MACs}}
+ * }
+ * </pre>
+ */
+public class PBMAC1Params implements ASN1Value {
+
+    ///////////////////////////////////////////////////////////////////////
+    // members and member access
+    ///////////////////////////////////////////////////////////////////////
+    private AlgorithmIdentifier keyDerivationFunc;
+    private AlgorithmIdentifier messageAuthScheme;
+    private SEQUENCE sequence;
+
+    /**
+     * Returns the key derivation function (typically PBKDF2).
+     */
+    public AlgorithmIdentifier getKeyDerivationFunc() {
+        return keyDerivationFunc;
+    }
+
+    /**
+     * Returns the message authentication scheme (typically HMAC-SHA256/384/512).
+     */
+    public AlgorithmIdentifier getMessageAuthScheme() {
+        return messageAuthScheme;
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    // constructors
+    ///////////////////////////////////////////////////////////////////////
+
+    /**
+     * Creates PBMAC1 parameters.
+     *
+     * @param keyDerivationFunc The key derivation function AlgorithmIdentifier
+     *                          (typically PBKDF2 with salt, iterations, and PRF)
+     * @param messageAuthScheme The MAC algorithm AlgorithmIdentifier
+     *                          (typically HMAC-SHA256, HMAC-SHA384, or HMAC-SHA512)
+     */
+    public PBMAC1Params(AlgorithmIdentifier keyDerivationFunc,
+                        AlgorithmIdentifier messageAuthScheme) {
+
+        if (keyDerivationFunc == null || messageAuthScheme == null) {
+            throw new IllegalArgumentException("Parameters cannot be null");
+        }
+
+        this.keyDerivationFunc = keyDerivationFunc;
+        this.messageAuthScheme = messageAuthScheme;
+        sequence = new SEQUENCE();
+        sequence.addElement(keyDerivationFunc);
+        sequence.addElement(messageAuthScheme);
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    // DER encoding
+    ///////////////////////////////////////////////////////////////////////
+
+    private static final Tag TAG = SEQUENCE.TAG;
+
+    @Override
+    public Tag getTag() {
+        return TAG;
+    }
+
+    @Override
+    public void encode(OutputStream ostream) throws IOException {
+        sequence.encode(ostream);
+    }
+
+    @Override
+    public void encode(Tag implicitTag, OutputStream ostream)
+        throws IOException
+    {
+        sequence.encode(implicitTag, ostream);
+    }
+
+    private static final Template templateInstance = new Template();
+    public static Template getTemplate() {
+        return templateInstance;
+    }
+
+    /**
+     * A template class for decoding PBMAC1Params.
+     */
+    public static class Template implements ASN1Template {
+
+        private SEQUENCE.Template seqt;
+
+        public Template() {
+            seqt = new SEQUENCE.Template();
+            seqt.addElement(AlgorithmIdentifier.getTemplate());
+            seqt.addElement(AlgorithmIdentifier.getTemplate());
+        }
+
+        @Override
+        public boolean tagMatch(Tag tag) {
+            return TAG.equals(tag);
+        }
+
+        @Override
+        public ASN1Value decode(InputStream istream)
+            throws InvalidBERException, IOException
+        {
+            return decode(TAG, istream);
+        }
+
+        @Override
+        public ASN1Value decode(Tag implicitTag, InputStream istream)
+            throws InvalidBERException, IOException
+        {
+            SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
+
+            return new PBMAC1Params((AlgorithmIdentifier) seq.elementAt(0),
+                                    (AlgorithmIdentifier) seq.elementAt(1));
+        }
+    }
+}

--- a/base/src/test/java/org/mozilla/jss/tests/PBMAC1Test.java
+++ b/base/src/test/java/org/mozilla/jss/tests/PBMAC1Test.java
@@ -1,0 +1,348 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.jss.tests;
+
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.asn1.SEQUENCE;
+import org.mozilla.jss.crypto.AlreadyInitializedException;
+import org.mozilla.jss.crypto.DigestAlgorithm;
+import org.mozilla.jss.netscape.security.pkcs.PKCS12Util.MacType;
+import org.mozilla.jss.pkcs12.AuthenticatedSafes;
+import org.mozilla.jss.pkcs12.MacData;
+import org.mozilla.jss.pkcs12.PFX;
+import org.mozilla.jss.util.Password;
+import java.util.Calendar;
+import java.util.Date;
+import org.mozilla.jss.asn1.ASN1Util;
+import org.mozilla.jss.asn1.INTEGER;
+import org.mozilla.jss.crypto.CryptoStore;
+import org.mozilla.jss.crypto.ObjectNotFoundException;
+import org.mozilla.jss.crypto.SignatureAlgorithm;
+import org.mozilla.jss.crypto.X509Certificate;
+import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
+import org.mozilla.jss.netscape.security.pkcs.PKCS12;
+import org.mozilla.jss.netscape.security.pkcs.PKCS12Util;
+import org.mozilla.jss.pkix.cert.Certificate;
+import org.mozilla.jss.pkix.cert.CertificateInfo;
+import org.mozilla.jss.pkix.primitive.Name;
+import org.mozilla.jss.pkix.primitive.SubjectPublicKeyInfo;
+import org.mozilla.jss.tests.FilePasswordCallback;
+
+/**
+ * Test PBMAC1 (RFC 9579) MAC computation for PKCS#12.
+ */
+public class PBMAC1Test {
+
+    public static void main(String[] args) {
+        try {
+            if (args.length != 2) {
+                System.out.println("Usage: java org.mozilla.jss.tests.PBMAC1Test <dbdir> <passwordfile>");
+                System.exit(1);
+            }
+
+            try {
+                CryptoManager.initialize(args[0]);
+            } catch(AlreadyInitializedException e) {
+                // already initialized, it's ok
+            }
+
+            CryptoManager cm = CryptoManager.getInstance();
+            cm.setPasswordCallback(new FilePasswordCallback(args[1]));
+
+            System.out.println("Testing PBMAC1 MAC computation...\n");
+
+            // Test with SHA-256
+            testPBMAC1("SHA-256", DigestAlgorithm.SHA256, 32);
+
+            // Test with SHA-384
+            testPBMAC1("SHA-384", DigestAlgorithm.SHA384, 48);
+
+            // Test with SHA-512
+            testPBMAC1("SHA-512", DigestAlgorithm.SHA512, 64);
+
+            // Test repeatability (same inputs = same output)
+            testRepeatability();
+
+            // Test legacy path
+            testLegacyMAC();
+
+            //Test creating and verifying actual p12 file
+
+            testCreateP12WithPBMAC1(args[0]);
+
+            System.out.println("\nAll PBMAC1 and Legacy MAC and p12 tests PASSED!");
+
+        } catch (Exception e) {
+            System.err.println("PBMAC1 test FAILED: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    private static void testPBMAC1(String name, DigestAlgorithm digest, int expectedMacLen)
+        throws Exception {
+        System.out.println("Testing PBMAC1 with HMAC-" + name + "...");
+
+        Password password = new Password("testPassword123".toCharArray());
+        byte[] salt = new byte[20];
+        fillTestSalt(salt);
+        int iterations = 100000;
+
+        // Create minimal AuthenticatedSafes (empty is fine for MAC testing)
+        AuthenticatedSafes authSafes = new AuthenticatedSafes();
+        authSafes.addSafeContents(new SEQUENCE());
+
+        // Create PFX and configure for PBMAC1
+        PFX pfx = new PFX(authSafes);
+        pfx.setMacType(MacType.PBMAC1);
+        pfx.setMacDigest(digest);
+
+        // Compute MAC using real API
+        pfx.computeMacData(password, salt, iterations);
+
+        // Get the MacData and verify
+        MacData macData = pfx.getMacData();
+        if (macData == null || macData.getMac() == null) {
+            throw new Exception("PBMAC1 MAC computation failed - MacData is null");
+        }
+
+        // Verify MAC output length
+        byte[] macValue = macData.getMac().getDigest().toByteArray();
+        if (macValue.length != expectedMacLen) {
+            throw new Exception("PBMAC1 MAC length mismatch: expected " + expectedMacLen +
+                              " bytes, got " + macValue.length + " bytes");
+        }
+
+        System.out.println("  ✓ MAC length correct: " + macValue.length + " bytes");
+        System.out.println("  ✓ PBMAC1 with HMAC-" + name + " PASSED\n");
+
+        password.clear();
+    }
+
+    private static void testRepeatability() throws Exception {
+        System.out.println("Testing PBMAC1 repeatability (same inputs = same output)...");
+
+        Password password1 = new Password("samePassword".toCharArray());
+        Password password2 = new Password("samePassword".toCharArray());
+
+        byte[] salt = new byte[16];
+        fillTestSalt(salt);
+        int iterations = 100000;
+
+        // Create identical AuthenticatedSafes
+        AuthenticatedSafes authSafes1 = new AuthenticatedSafes();
+        authSafes1.addSafeContents(new SEQUENCE());
+
+        AuthenticatedSafes authSafes2 = new AuthenticatedSafes();
+        authSafes2.addSafeContents(new SEQUENCE());
+
+        // Compute MAC twice with same configuration
+        PFX pfx1 = new PFX(authSafes1);
+        pfx1.setMacType(MacType.PBMAC1);
+        pfx1.setMacDigest(DigestAlgorithm.SHA256);
+        pfx1.computeMacData(password1, salt, iterations);
+        byte[] mac1 = pfx1.getMacData().getMac().getDigest().toByteArray();
+
+        PFX pfx2 = new PFX(authSafes2);
+        pfx2.setMacType(MacType.PBMAC1);
+        pfx2.setMacDigest(DigestAlgorithm.SHA256);
+        pfx2.computeMacData(password2, salt, iterations);
+        byte[] mac2 = pfx2.getMacData().getMac().getDigest().toByteArray();
+
+        // Verify both MACs are identical
+        if (mac1.length != mac2.length) {
+            throw new Exception("MAC lengths differ");
+        }
+
+        for (int i = 0; i < mac1.length; i++) {
+            if (mac1[i] != mac2[i]) {
+                throw new Exception("MACs differ at byte " + i);
+            }
+        }
+
+        System.out.println("  ✓ Repeatability verified - same inputs produce same MAC");
+        System.out.println("  ✓ Repeatability test PASSED\n");
+
+        password1.clear();
+        password2.clear();
+    }
+
+    private static void testLegacyMAC() throws Exception {
+        System.out.println("Testing Legacy MAC (backward compatibility)...");
+
+        Password password = new Password("legacyPassword".toCharArray());
+        byte[] salt = new byte[16];
+        fillTestSalt(salt);
+        int iterations = 100000;
+
+        // Create AuthenticatedSafes
+        AuthenticatedSafes authSafes = new AuthenticatedSafes();
+        authSafes.addSafeContents(new SEQUENCE());
+
+        // Create PFX - DON'T set MacType (should default to LEGACY)
+        PFX pfx = new PFX(authSafes);
+
+        // Compute MAC using default (legacy) algorithm
+        pfx.computeMacData(password, salt, iterations);
+
+        // Verify MAC was created
+        MacData macData = pfx.getMacData();
+        if (macData == null || macData.getMac() == null) {
+            throw new Exception("Legacy MAC computation failed - MacData is null");
+        }
+
+        // Verify MAC length (SHA-256 = 32 bytes, which is the legacy default)
+        byte[] macValue = macData.getMac().getDigest().toByteArray();
+        if (macValue.length != 32) {
+            throw new Exception("Legacy MAC length unexpected: " + macValue.length);
+        }
+
+        System.out.println("  ✓ Legacy MAC created successfully");
+        System.out.println("  ✓ MAC length: " + macValue.length + " bytes (SHA-256)");
+        System.out.println("  ✓ Legacy MAC test PASSED\n");
+
+        password.clear();
+    }
+
+    /**
+     * Fill salt array with test values.
+     * For tests only - real code should use SecureRandom.
+     */
+    private static void fillTestSalt(byte[] salt) {
+        for (int i = 0; i < salt.length; i++) {
+            salt[i] = (byte) i;
+        }
+    }
+
+private static void testCreateP12WithPBMAC1(String dbdir) throws Exception {
+      System.out.println("Testing PKCS#12 file creation with PBMAC1...");
+
+      CryptoManager cm = CryptoManager.getInstance();
+
+      // 1. Generate test cert and key
+      String nickname = "PBMAC1-Test" + System.currentTimeMillis();
+      java.security.KeyPair pair = generateTestCertAndKey("RSA", 2048, nickname);
+
+      System.out.println("  ✓ Generated 2048-bit RSA cert/key: " + nickname);
+
+      // 2. Get the imported certificate
+      X509Certificate nssCert = cm.findCertByNickname(nickname);
+
+      // 3. Create PKCS12 object and add cert/key
+      PKCS12 pkcs12 = new PKCS12();
+      PKCS12Util util = new PKCS12Util();
+      util.loadCertFromNSS(pkcs12, nssCert, true, false);
+
+      System.out.println("  ✓ Created PKCS12 object");
+
+      // 4. Export to file with PBMAC1
+      util.setMacType(MacType.PBMAC1);
+      util.setMacDigest(DigestAlgorithm.SHA256);
+
+      Password password = new Password("test123".toCharArray());
+      String filename = dbdir + "/test-pbmac1.p12";
+      util.storeIntoFile(pkcs12, filename, password);
+
+      System.out.println("  ✓ Exported to: " + filename);
+      System.out.println("  ✓ MAC type: PBMAC1 with HMAC-SHA256");
+
+      // 5. Delete cert/key from database
+      CryptoStore store = cm.getInternalKeyStorageToken().getCryptoStore();
+      store.deleteCert(nssCert);
+
+      System.out.println("  ✓ Deleted cert/key from database");
+
+      // 6. Verify cert is gone
+      try {
+          cm.findCertByNickname(nickname);
+          throw new Exception("Cert still exists after deletion!");
+      } catch (ObjectNotFoundException e) {
+          // Expected - cert is gone
+          System.out.println("  ✓ Verified cert was deleted");
+      }
+
+      // 7. Re-import from PKCS#12 file
+      PKCS12 pkcs12imported = util.loadFromFile(filename, password);
+      util.storeIntoNSS(pkcs12imported, password, false);
+
+      System.out.println("  ✓ Re-imported from PKCS#12 file");
+
+      // 8. Verify cert/key are restored
+      X509Certificate restoredCert = cm.findCertByNickname(nickname);
+      if (restoredCert == null) {
+          throw new Exception("Cert not restored from PKCS#12!");
+      }
+
+      System.out.println("  ✓ Cert/key successfully restored");
+
+      // 9. Final cleanup
+      store.deleteCert(restoredCert);
+      password.clear();
+
+      System.out.println("  ✓ PKCS#12 round-trip test PASSED\n");
+  }
+
+    private static java.security.KeyPair generateTestCertAndKey(
+      String keyType, int keySize, String nickname) throws Exception {
+
+      CryptoManager cm = CryptoManager.getInstance();
+
+      // Generate keypair
+      java.security.KeyPairGenerator kpg =
+          java.security.KeyPairGenerator.getInstance(keyType, "Mozilla-JSS");
+      kpg.initialize(keySize);
+      java.security.KeyPair pair = kpg.genKeyPair();
+
+      // Select signature algorithm based on key type
+      SignatureAlgorithm sigAlg;
+      if (keyType.equals("RSA")) {
+          sigAlg = SignatureAlgorithm.RSASignatureWithSHA256Digest;
+      } else if (keyType.equals("EC")) {
+          sigAlg = SignatureAlgorithm.ECSignatureWithSHA256Digest;
+      } else {
+          throw new IllegalArgumentException("Unsupported key type: " + keyType);
+      }
+
+      // Create self-signed certificate
+      Name subject = new Name();
+      subject.addCountryName("US");
+      subject.addOrganizationName("Mozilla");
+      subject.addCommonName(nickname);
+
+      Calendar cal = Calendar.getInstance();
+      Date notBefore = cal.getTime();
+      cal.add(Calendar.YEAR, 1);
+      Date notAfter = cal.getTime();
+
+      // AlgorithmIdentifier construction differs by key type
+      AlgorithmIdentifier sigAlgID;
+      if (keyType.equals("RSA")) {
+          sigAlgID = new AlgorithmIdentifier(sigAlg.toOID(), null);
+      } else {
+          sigAlgID = new AlgorithmIdentifier(sigAlg.toOID());
+      }
+
+      SubjectPublicKeyInfo spki = (SubjectPublicKeyInfo) ASN1Util.decode(
+          new SubjectPublicKeyInfo.Template(), pair.getPublic().getEncoded());
+
+      CertificateInfo info = new CertificateInfo(
+          CertificateInfo.v3,
+          new INTEGER(1),
+          sigAlgID,
+          subject,  // issuer
+          notBefore,
+          notAfter,
+          subject,  // subject (self-signed)
+          spki);
+
+      Certificate cert = new Certificate(info, pair.getPrivate(), sigAlg);
+
+      // Import cert into NSS database
+      cm.importCertPackage(ASN1Util.encode(cert), nickname);
+
+      return pair;
+  }
+
+}

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -98,6 +98,13 @@ macro(jss_tests)
         NAME "JSS_Test_PR_FileDesc"
         COMMAND "org.mozilla.jss.tests.TestPRFD"
     )
+
+    jss_test_java(
+        NAME "PBMAC1_Test"
+        COMMAND "org.mozilla.jss.tests.PBMAC1Test" "${RESULTS_NSSDB_OUTPUT_DIR}"  "${PASSWORD_FILE}"
+        DEPENDS "Setup_DBs"
+    )
+
     jss_test_java(
         NAME "JSS_Test_Raw_SSL"
         COMMAND "org.mozilla.jss.tests.TestRawSSL" "${RESULTS_NSSDB_OUTPUT_DIR}"

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -534,3 +534,9 @@ Java_org_mozilla_jss_pkcs11_PK11PrivKey_setTemporary;
     local:
         *;
 };
+JSS_5.11.1 {
+    global:
+Java_org_mozilla_jss_pkcs12_MacData_nativeComputePBMAC1;
+    local:
+        *;
+};

--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyGenerator.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyGenerator.c
@@ -614,3 +614,185 @@ finish:
     PK11_FreeSymKey(result);
     return resultObj;
 }
+
+JNIEXPORT jbyteArray JNICALL
+  Java_org_mozilla_jss_pkcs12_MacData_nativeComputePBMAC1(
+      JNIEnv *env, jobject this,
+      jobject token,
+      jbyteArray passwordArray,
+      jbyteArray dataArray,
+      jbyteArray pbmac1AlgIDArray,
+      jobject hmacAlgorithm)
+  {
+      PK11SlotInfo *slot = NULL;
+      SECItem *password = NULL;
+      SECItem *data = NULL;
+      SECItem *pbmac1AlgIDItem = NULL;
+      SECOidTag hmacAlgTag;
+      PK11SymKey *key = NULL;
+      SECAlgorithmID *pbmac1AlgID = NULL;
+      PK11Context *context = NULL;
+      SECItem macItem = {siBuffer, NULL, 0};
+      jbyteArray result = NULL;
+      unsigned int macLen = 0;
+      CK_MECHANISM_TYPE hmacMech;
+      SECStatus rv;
+
+      PR_ASSERT(env != NULL && this != NULL);
+
+      if (token == NULL || passwordArray == NULL || pbmac1AlgIDArray == NULL ||
+          dataArray == NULL || hmacAlgorithm == NULL) {
+          JSS_throw(env, NULL_POINTER_EXCEPTION);
+          goto finish;
+      }
+
+      // Get slot from token
+      if (JSS_PK11_getTokenSlotPtr(env, token, &slot) != PR_SUCCESS) {
+          goto finish;
+      }
+
+      if (slot == NULL) {
+          JSS_throwMsg(env, TOKEN_EXCEPTION, "Failed to get slot from token");
+          goto finish;
+      }
+
+      // Convert Java byte arrays to SECItems
+      password = JSS_ByteArrayToSECItem(env, passwordArray);
+      if (password == NULL) {
+          goto finish;
+      }
+
+      // Convert PBKDF2 AlgorithmID bytes to SECItem
+      pbmac1AlgIDItem = JSS_ByteArrayToSECItem(env, pbmac1AlgIDArray);
+      if (pbmac1AlgIDItem == NULL) {
+           goto finish;
+      }
+
+      pbmac1AlgID = PR_Calloc(1, sizeof(SECAlgorithmID));
+      if (pbmac1AlgID == NULL) {
+          JSS_throw(env, OUT_OF_MEMORY_ERROR);
+          goto finish;
+      }
+
+      if (SEC_ASN1DecodeItem(
+          NULL,
+          pbmac1AlgID,
+          SEC_ASN1_GET(SECOID_AlgorithmIDTemplate),
+          pbmac1AlgIDItem
+      ) != SECSuccess) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to decode PBMAC1 AlgorithmID");
+          goto finish;
+      }
+
+      data = JSS_ByteArrayToSECItem(env, dataArray);
+      if (data == NULL) {
+          goto finish;
+      }
+
+      // Convert HMAC algorithm to SECOidTag
+      hmacAlgTag = JSS_getOidTagFromAlg(env, hmacAlgorithm);
+      if (hmacAlgTag == SEC_OID_UNKNOWN) {
+          JSS_throwMsg(env, INVALID_PARAMETER_EXCEPTION,
+              "Unknown HMAC algorithm");
+          goto finish;
+      }
+
+      // Determine HMAC output length and mechanism based on algorithm
+      switch (hmacAlgTag) {
+          case SEC_OID_HMAC_SHA256:
+              macLen = 32;
+              hmacMech = CKM_SHA256_HMAC;
+              break;
+          case SEC_OID_HMAC_SHA384:
+              macLen = 48;
+              hmacMech = CKM_SHA384_HMAC;
+              break;
+          case SEC_OID_HMAC_SHA512:
+              macLen = 64;
+              hmacMech = CKM_SHA512_HMAC;
+              break;
+          default:
+              JSS_throwMsg(env, INVALID_PARAMETER_EXCEPTION,
+                  "Unsupported HMAC algorithm for PBMAC1");
+              goto finish;
+      }
+
+      key = PK11_PBEKeyGen(slot, pbmac1AlgID, password, PR_FALSE, NULL);
+
+      if (key == NULL) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to derive key for PBMAC1");
+          goto finish;
+      }
+
+      // Allocate buffer for HMAC output
+      macItem.data = (unsigned char *)PORT_Alloc(macLen);
+      if (macItem.data == NULL) {
+          JSS_throw(env, OUT_OF_MEMORY_ERROR);
+          goto finish;
+      }
+      macItem.len = macLen;
+
+      SECItem noParam = {siBuffer, NULL, 0};
+      context = PK11_CreateContextBySymKey(hmacMech, CKA_SIGN, key, &noParam);
+
+      if (context == NULL) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to create HMAC context for PBMAC1");
+          goto finish;
+      }
+
+      rv = PK11_DigestBegin(context);
+      if (rv != SECSuccess) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to begin HMAC operation");
+          goto finish;
+      }
+
+      rv = PK11_DigestOp(context, data->data, data->len);
+      if (rv != SECSuccess) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to process data for HMAC");
+          goto finish;
+      }
+
+      rv = PK11_DigestFinal(context, macItem.data, &macLen, macItem.len);
+      macItem.len = macLen;
+
+      if (rv != SECSuccess) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to finalize HMAC operation");
+          goto finish;
+      }
+
+      // Convert result to Java byte array
+      result = JSS_SECItemToByteArray(env, &macItem);
+
+  finish:
+      if (password != NULL) {
+          SECITEM_ZfreeItem(password, PR_TRUE);
+      }
+
+      if (pbmac1AlgIDItem != NULL) {
+          SECITEM_FreeItem(pbmac1AlgIDItem, PR_TRUE);
+      }
+
+      if (data != NULL) {
+          SECITEM_FreeItem(data, PR_TRUE);
+      }
+      if (pbmac1AlgID != NULL) {
+          SECOID_DestroyAlgorithmID(pbmac1AlgID, PR_TRUE);
+      }
+      if (key != NULL) {
+          PK11_FreeSymKey(key);
+      }
+      if (context != NULL) {
+          PK11_DestroyContext(context, PR_TRUE);
+      }
+      if (macItem.data != NULL) {
+          PORT_ZFree(macItem.data, macItem.len);
+      }
+
+      return result;
+  }


### PR DESCRIPTION
Add PBMAC1 (RFC 9579) support for PKCS#12 files

  Implement modern password-based MAC algorithm as defined in RFC 9579.
  Supports HMAC-SHA256/384/512 with PBKDF2 key derivation. Maintains
  full backward compatibility with legacy PKCS#12 v1.0 MAC.

  Includes comprehensive test suite and NSS interoperability validation.
  Coding assistant aided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable PKCS#12 MAC options: selectable MAC mode (legacy or PBMAC1), choice of digest (SHA-256/384/512), and PBMAC1/PBKDF2 parameter support; compute now generates a random salt when none is provided. Added ASN.1 support for PBMAC1 parameters and public setters/getters to configure MAC behavior. Native support added for PBMAC1 MAC computation.

* **Tests**
  * New executable tests validating PBMAC1 and legacy MAC generation, repeatability, and end-to-end PKCS#12 import/export; integrated into the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->