### PR TITLE
Add configurable PBMAC1 support for PKCS#12 integrity protection'

### DIFF
--- a/base/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
@@ -62,11 +62,13 @@ import org.mozilla.jss.pkcs11.PK11Store;
 import org.mozilla.jss.pkcs12.AuthenticatedSafes;
 import org.mozilla.jss.pkcs12.CertBag;
 import org.mozilla.jss.pkcs12.PFX;
+import org.mozilla.jss.pkcs12.MacType;
 import org.mozilla.jss.pkcs12.PasswordConverter;
 import org.mozilla.jss.pkcs12.SafeBag;
 import org.mozilla.jss.pkix.primitive.Attribute;
 import org.mozilla.jss.pkix.primitive.EncryptedPrivateKeyInfo;
 import org.mozilla.jss.util.Password;
+import org.mozilla.jss.crypto.DigestAlgorithm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,6 +98,49 @@ public class PKCS12Util {
     PBEAlgorithm certEncryption = DEFAULT_CERT_ENCRYPTION;
     PBEAlgorithm keyEncryption = DEFAULT_KEY_ENCRYPTION;
     boolean trustFlagsEnabled = true;
+
+    // MAC configuration (separate from encryption)
+    private MacType macType = MacType.CLASSIC;  // default for backward compatibility
+    private DigestAlgorithm macDigest = DigestAlgorithm.SHA256;  // default digest
+
+    /**
+    * Sets the MAC algorithm type for PKCS#12 file generation.
+    *
+    * @param type The MAC type (CLASSIC or PBMAC1)
+    * @throws IllegalArgumentException
+    */
+    public void setMacType(MacType type) {
+        if(type == null) {
+            throw new IllegalArgumentException("Must provide macType");
+        }
+        this.macType = type;
+    }
+
+    /**
+    * Returns the configured MAC algorithm type.
+    *
+    * @return The MAC type
+    */
+    public MacType getMacType() {
+        return macType;
+    }
+
+    /**
+    * Sets the configured MAC digest algorithm.
+    *
+    * @param digest The digest algorithm
+    * @throws IllegalArgumentException
+    */
+    public void setMacDigest(DigestAlgorithm digest) {
+        if(digest == null) {
+            throw new IllegalArgumentException("Must provide digest");
+        }
+        this.macDigest = digest;
+    }
+
+    public DigestAlgorithm getMacDigest() {
+        return macDigest;
+    }
 
     public PKCS12Util() throws Exception {
         random = SecureRandom.getInstance("pkcs11prng", "Mozilla-JSS");

--- a/base/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/pkcs/PKCS12Util.java
@@ -648,6 +648,10 @@ public class PKCS12Util {
 
         byte[] salt = new byte[16];
         random.nextBytes(salt);
+
+        pfx.setMacType(macType);
+        pfx.setMacDigest(macDigest);
+
         pfx.computeMacData(password, salt, 100000);
 
         return pfx;

--- a/base/src/main/java/org/mozilla/jss/pkcs12/MacData.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs12/MacData.java
@@ -8,6 +8,8 @@ import java.io.CharConversionException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.security.DigestException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -22,6 +24,9 @@ import org.mozilla.jss.asn1.InvalidBERException;
 import org.mozilla.jss.asn1.OCTET_STRING;
 import org.mozilla.jss.asn1.SEQUENCE;
 import org.mozilla.jss.asn1.Tag;
+import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
+import org.mozilla.jss.asn1.ANY;
+import org.mozilla.jss.asn1.ASN1Util;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.DigestAlgorithm;
 import org.mozilla.jss.crypto.HMACAlgorithm;
@@ -32,9 +37,13 @@ import org.mozilla.jss.crypto.KeyGenerator;
 import org.mozilla.jss.crypto.PBEKeyGenParams;
 import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.TokenException;
+import org.mozilla.jss.crypto.PBEAlgorithm;
+import org.mozilla.jss.pkix.primitive.PBMAC1Params;
 import org.mozilla.jss.pkcs7.DigestInfo;
 import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
+import org.mozilla.jss.pkix.primitive.PBKDF2Params;
 import org.mozilla.jss.util.Password;
+import org.mozilla.jss.util.UTF8Converter;
 
 public class MacData implements ASN1Value {
 
@@ -45,7 +54,7 @@ public class MacData implements ASN1Value {
     private static final int DEFAULT_ITERATIONS = 1;
 
     // 20 is the length of SHA-1 hash output
-    private static final int SALT_LENGTH = 20;
+    public static final int SALT_LENGTH = 20;
 
     public DigestInfo getMac() {
         return mac;
@@ -137,13 +146,30 @@ public class MacData implements ASN1Value {
             rand.nextBytes(macSalt);
         }
 
+        // Handle null algID - default to SHA1 for backward compatibility
+
+        try {
+            if (algID == null) {
+                algID = new AlgorithmIdentifier(DigestAlgorithm.SHA1.toOID());
+            }
+
+            // Check if this is PBMAC1 - route to new implementation
+            if (algID.getOID().equals(PBEAlgorithm.PBE_PKCS5_PBMAC1.toOID())) {
+                computePBMAC1(token, password, toBeMACed, algID);
+                return; // Early return - skip classic code below
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new TokenException("Algorithm OID error: " + e.getMessage(), e);
+        } catch (TokenException | CharConversionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new TokenException("Failed to compute PBMAC1: " + e.getMessage(), e);
+        }
+
         PBEKeyGenParams params = new PBEKeyGenParams(password, macSalt, iterations);
 
         try {
             // generate key from password and salt
-            if(algID == null) {
-                algID = new AlgorithmIdentifier(DigestAlgorithm.SHA1.toOID());
-            }
             KeyGenerator kg = null;
             JSSMessageDigest digest = null;
             if(DigestAlgorithm.SHA1.toOID().equals(algID.getOID())){
@@ -195,6 +221,129 @@ public class MacData implements ASN1Value {
             params.clear();
         }
     }
+
+    /**
+    * Computes a PBMAC1 MAC per RFC 9879 using NSS native crypto.
+    *
+    * @param token The crypto token for key derivation and HMAC
+    * @param password The password for PBKDF2 key derivation
+    * @param data The data to authenticate
+    * @param algID The PBMAC1 AlgorithmIdentifier containing KDF and MAC params
+    * @throws Exception if MAC computation fails
+    */
+    private void computePBMAC1(CryptoToken token, Password password,
+                           byte[] data, AlgorithmIdentifier algID)
+        throws Exception
+    {
+        // Parse PBMAC1 parameters to extract KDF and MAC algorithms
+
+        PBMAC1Params pbmac1Params;
+        ASN1Value params =  algID.getParameters();
+
+        if (params == null) {
+            throw new InvalidBERException("Missing PBMAC1 parameters");
+        }
+
+        if (params instanceof PBMAC1Params) {
+           // Already decoded (create/write path)
+           pbmac1Params = (PBMAC1Params) params;
+        } else if (params instanceof ANY) {
+          // Needs decoding (read from file path)
+          pbmac1Params = (PBMAC1Params) ((ANY) params).decodeWith(PBMAC1Params.getTemplate());
+        } else {
+            throw new InvalidBERException("Unexpected PBMAC1 parameter type: " + params.getClass().getName());
+        }
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+        algID.encode(bos);
+        byte[] pbmac1AlgIDBytes = bos.toByteArray();
+
+        AlgorithmIdentifier kdfAlg = pbmac1Params.getKeyDerivationFunc();
+        AlgorithmIdentifier macAlg = pbmac1Params.getMessageAuthScheme();
+
+        ASN1Value kdfParams = kdfAlg.getParameters();
+        if (kdfParams == null) {
+            throw new InvalidBERException("Missing PBKDF2 parameters");
+        }
+
+        //Extract PBKDF2 parameters
+        PBKDF2Params pbkdf2Params;
+
+        if (kdfParams instanceof PBKDF2Params) {
+        // Already decoded (create/write path using typed constructor)
+            pbkdf2Params = (PBKDF2Params) kdfParams;
+        } else if (kdfParams instanceof SEQUENCE) {
+            pbkdf2Params = (PBKDF2Params) ASN1Util.decode(
+            PBKDF2Params.getTemplate(), ASN1Util.encode(kdfParams));
+        } else if (kdfParams instanceof ANY) {
+            pbkdf2Params = (PBKDF2Params) ((ANY) kdfParams).decodeWith(PBKDF2Params.getTemplate());
+        } else {
+            throw new InvalidBERException("Unexpected PBKDF2 parameter type: " + kdfParams.getClass().getName());
+        }
+
+        byte[] kdfSalt = pbkdf2Params.getSalt();
+        if(kdfSalt == null) {
+            throw new InvalidBERException("PBKDF2 otherSource salt not supported");
+        }
+
+        // Get HMAC OID from MAC AlgorithmIdentifier
+        OBJECT_IDENTIFIER macOID = macAlg.getOID();
+
+        HMACAlgorithm hmacAlgorithm = HMACAlgorithm.fromOID(macOID);
+
+        // Call native JSS code to perform PBKDF2 + HMAC
+        // This uses certified NSS crypto (PK11_PBEKeyGen + PK11_DigestOp)
+        // The OID will be mapped to the appropriate NSS HMAC mechanism
+
+
+        char[] passwordChars = password.getCharCopy();
+        byte[] passwordBytes = null;
+
+        try {
+                passwordBytes = UTF8Converter.UnicodeToUTF8(passwordChars);
+                byte[] macValue = nativeComputePBMAC1(
+                token,
+                passwordBytes,
+                data,
+                pbmac1AlgIDBytes,
+                hmacAlgorithm
+                );
+
+                this.mac = new DigestInfo(algID, new OCTET_STRING(macValue));
+                // PBMAC1: outer macSalt comes from the PBKDF2 params within
+                // the AlgorithmIdentifier, not from the constructor argument,
+                // since the salt is bound to the KDF computation.
+                this.macSalt = new OCTET_STRING(kdfSalt);
+                // PBMAC1: outer macIterationCount is always 1 (default) because
+                // the actual iteration count is inside the PBKDF2 params within
+                // the AlgorithmIdentifier, not at the MacData level.
+                this.macIterationCount = new INTEGER(1);
+        } finally {
+            if (passwordBytes != null) {
+                Password.wipeBytes(passwordBytes);
+            }
+            Password.wipeChars(passwordChars);
+        }
+    }
+
+    /**
+     * Native method to compute PBMAC1 MAC using NSS.
+     *
+     * @param password Password bytes
+     * @param salt PBKDF2 salt
+     * @param iterations PBKDF2 iteration count
+     * @param data Data to MAC
+     * @param hmacOID HMAC algorithm OID (e.g., hmacWithSHA256)
+     * @return HMAC value
+     */
+    private native byte[] nativeComputePBMAC1(
+        CryptoToken token,
+        byte[] password,
+        byte[] data,
+        byte[] pbmac1AlgID,
+        HMACAlgorithm hmacAlgorithm
+    ) throws Exception;
 
     ///////////////////////////////////////////////////////////////////////
     // DER encoding

--- a/base/src/main/java/org/mozilla/jss/pkcs12/MacType.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs12/MacType.java
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+   * License, v. 2.0. If a copy of the MPL was not distributed with this
+   * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+  package org.mozilla.jss.pkcs12;
+
+  /**
+   * Defines the MAC algorithm type for PKCS#12 integrity protection.
+   */
+  public enum MacType {
+      CLASSIC,
+      PBMAC1
+  }

--- a/base/src/main/java/org/mozilla/jss/pkcs12/PFX.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs12/PFX.java
@@ -28,10 +28,13 @@ import org.mozilla.jss.asn1.OCTET_STRING;
 import org.mozilla.jss.asn1.SEQUENCE;
 import org.mozilla.jss.asn1.SET;
 import org.mozilla.jss.asn1.Tag;
+import org.mozilla.jss.asn1.NULL;
+import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
 import org.mozilla.jss.crypto.JSSSecureRandom;
 import org.mozilla.jss.crypto.PBEAlgorithm;
 import org.mozilla.jss.crypto.DigestAlgorithm;
 import org.mozilla.jss.crypto.TokenException;
+import org.mozilla.jss.crypto.HMACAlgorithm;
 import org.mozilla.jss.pkcs7.ContentInfo;
 import org.mozilla.jss.pkcs7.DigestInfo;
 import org.mozilla.jss.pkix.cert.Certificate;
@@ -39,8 +42,10 @@ import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
 import org.mozilla.jss.pkix.primitive.Attribute;
 import org.mozilla.jss.pkix.primitive.EncryptedPrivateKeyInfo;
 import org.mozilla.jss.pkix.primitive.PrivateKeyInfo;
+import org.mozilla.jss.pkix.primitive.PBMAC1Params;
+import org.mozilla.jss.pkix.primitive.PBKDF2Params;
 import org.mozilla.jss.util.Password;
-
+import org.mozilla.jss.pkcs12.MacType;
 /**
  * The top level ASN.1 structure for a PKCS #12 blob.
  *
@@ -94,12 +99,41 @@ public class PFX implements ASN1Value {
     // currently we are on version 3 of the standard
     private static final INTEGER VERSION = new INTEGER(3);
 
+    // MAC configuration
+    private MacType macType = MacType.CLASSIC;  // default
+    private DigestAlgorithm macDigest = DigestAlgorithm.SHA256;  // default
+
     /**
      * The default number of iterations to use when generating the MAC.
      * Currently, it is 1.
      */
     public static final int DEFAULT_ITERATIONS = 1;
 
+   /**
+    * Sets the MAC algorithm type for this PFX.
+    *
+    * @param type The MAC type (CLASSIC or PBMAC1)
+    * @throws IllegalArgumentException if type is null
+    */
+    public void setMacType(MacType type) {
+        if(type == null) {
+            throw new IllegalArgumentException("MacType must not be null");
+        }
+        this.macType = type;
+    }
+
+    /**
+    * Sets the digest algorithm for MAC computation.
+    *
+    * @param digest The digest algorithm (e.g., SHA256, SHA384, SHA512)
+    * @throws IllegalArgumentException if digest is null
+    */
+    public void setMacDigest(DigestAlgorithm digest) {
+        if(digest == null) {
+            throw new IllegalArgumentException("Digest must not be null");
+        }
+        this.macDigest = digest;
+    }
 
     public INTEGER getVersion() {
         return version;
@@ -153,6 +187,7 @@ public class PFX implements ASN1Value {
 
         // create a new MacData based on the encoded Auth Safes
         DigestInfo macDataMac = macData.getMac();
+
         MacData testMac = new MacData(password,
                 macData.getMacSalt().toByteArray(),
                 macData.getMacIterationCount().intValue(),
@@ -219,10 +254,87 @@ public class PFX implements ASN1Value {
         TokenException, CharConversionException
     {
 
-        //Make this alg the default mac alg.
-        AlgorithmIdentifier algID = new AlgorithmIdentifier(DigestAlgorithm.SHA256.toOID());
-        macData = new MacData( password, salt, iterationCount,
-                ASN1Util.encode(authSafes), algID );
+        AlgorithmIdentifier algID;
+
+        if (salt == null) {
+            CryptoManager cm = CryptoManager.getInstance();
+            JSSSecureRandom rand = cm.createPseudoRandomNumberGenerator();
+            salt = new byte[MacData.SALT_LENGTH];  // SALT_LENGTH from MacData
+            rand.nextBytes(salt);
+        }
+
+        if (macType == MacType.PBMAC1) {
+            // Create PBMAC1 AlgorithmIdentifier with PBKDF2 parameters
+            algID = createPBMAC1AlgorithmID(salt, iterationCount, macDigest);
+        } else {
+            // Legacy: Use configured digest
+            algID = new AlgorithmIdentifier(macDigest.toOID());
+        }
+
+        macData = new MacData(password, salt, iterationCount,
+            ASN1Util.encode(authSafes), algID);
+    }
+
+    /**
+    * Creates a PBMAC1 AlgorithmIdentifier with PBKDF2 parameters per RFC 9879.
+    *
+    * @param salt The salt for PBKDF2 key derivation
+    * @param iterationCount The PBKDF2 iteration count
+    * @param digest The digest algorithm for HMAC
+    * @return The PBMAC1 AlgorithmIdentifier
+    * @throws NoSuchAlgorithmException if the digest is unsupported
+    */
+    private AlgorithmIdentifier createPBMAC1AlgorithmID(
+        byte[] salt, int iterationCount, DigestAlgorithm digest)
+        throws NoSuchAlgorithmException
+    {
+        // Determine HMAC OID and key length from digest algorithm
+        // Use existing HMACAlgorithm constants instead of hardcoded OIDs
+
+        int keyLength = digest.getOutputSize();
+        // Get the corresponding HMAC algorithm
+        HMACAlgorithm hmacAlg = getHMACForDigest(digest);
+
+        OBJECT_IDENTIFIER hmacOID = hmacAlg.toOID();
+
+        // PRF algorithm for PBKDF2 (same HMAC algorithm)
+        AlgorithmIdentifier prfAlg = new AlgorithmIdentifier(hmacOID, new NULL());
+        PBKDF2Params pbkdf2Params = new PBKDF2Params(salt, null, iterationCount, keyLength, prfAlg);
+
+        // Construct PBKDF2 AlgorithmIdentifier
+        AlgorithmIdentifier kdfAlg = new AlgorithmIdentifier(
+            PBEAlgorithm.PBE_PKCS5_PBKDF2.toOID(), pbkdf2Params);
+
+        // Construct HMAC AlgorithmIdentifier for MAC scheme
+        AlgorithmIdentifier macAlg = new AlgorithmIdentifier(hmacOID, new NULL());
+
+        // Construct PBMAC1 parameters using dedicated ASN.1 type
+        PBMAC1Params pbmac1Params = new PBMAC1Params(kdfAlg, macAlg);
+
+        // Construct final PBMAC1 AlgorithmIdentifier
+        return new AlgorithmIdentifier(
+            PBEAlgorithm.PBE_PKCS5_PBMAC1.toOID(), pbmac1Params);
+    }
+
+    /**
+    * Maps a digest algorithm to the corresponding HMAC algorithm.
+    *
+    * @param digest The digest algorithm
+    * @return The corresponding HMACAlgorithm
+    * @throws NoSuchAlgorithmException if no HMAC exists for the digest
+    */
+    private static HMACAlgorithm getHMACForDigest(DigestAlgorithm digest)
+          throws NoSuchAlgorithmException {
+        if (digest.equals(DigestAlgorithm.SHA256)) {
+            return HMACAlgorithm.SHA256;
+        } else if (digest.equals(DigestAlgorithm.SHA384)) {
+            return HMACAlgorithm.SHA384;
+        } else if (digest.equals(DigestAlgorithm.SHA512)) {
+            return HMACAlgorithm.SHA512;
+        } else {
+            throw new NoSuchAlgorithmException(
+              "Unsupported PBMAC1 digest: " + digest);
+        }
     }
 
 

--- a/base/src/main/java/org/mozilla/jss/pkix/primitive/PBMAC1Params.java
+++ b/base/src/main/java/org/mozilla/jss/pkix/primitive/PBMAC1Params.java
@@ -1,0 +1,189 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.jss.pkix.primitive;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.mozilla.jss.asn1.ASN1Template;
+import org.mozilla.jss.asn1.ASN1Value;
+import org.mozilla.jss.asn1.InvalidBERException;
+import org.mozilla.jss.asn1.SEQUENCE;
+import org.mozilla.jss.asn1.Tag;
+
+/**
+ * PKCS #5 <i>PBMAC1-params</i> from RFC 9879.
+ *
+ * <pre>
+ * PBMAC1-params ::= SEQUENCE {
+ *   keyDerivationFunc AlgorithmIdentifier {{PBMAC1-KDFs}},
+ *   messageAuthScheme AlgorithmIdentifier {{PBMAC1-MACs}}
+ * }
+ * </pre>
+ */
+public class PBMAC1Params implements ASN1Value {
+
+    ///////////////////////////////////////////////////////////////////////
+    // members and member access
+    ///////////////////////////////////////////////////////////////////////
+    private AlgorithmIdentifier keyDerivationFunc;
+    private AlgorithmIdentifier messageAuthScheme;
+    private SEQUENCE sequence;
+
+    /**
+     * Returns the key derivation function (typically PBKDF2).
+     */
+    public AlgorithmIdentifier getKeyDerivationFunc() {
+        return keyDerivationFunc;
+    }
+
+    /**
+     * Returns the message authentication scheme (typically HMAC-SHA256/384/512).
+     */
+    public AlgorithmIdentifier getMessageAuthScheme() {
+        return messageAuthScheme;
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    // constructors
+    ///////////////////////////////////////////////////////////////////////
+
+    /**
+     * Creates PBMAC1 parameters.
+     *
+     * @param keyDerivationFunc The key derivation function AlgorithmIdentifier
+     *                          (typically PBKDF2 with salt, iterations, and PRF)
+     * @param messageAuthScheme The MAC algorithm AlgorithmIdentifier
+     *                          (typically HMAC-SHA256, HMAC-SHA384, or HMAC-SHA512)
+     */
+    public PBMAC1Params(AlgorithmIdentifier keyDerivationFunc,
+                        AlgorithmIdentifier messageAuthScheme) {
+
+        if (keyDerivationFunc == null || messageAuthScheme == null) {
+            throw new IllegalArgumentException("Parameters cannot be null");
+        }
+
+        this.keyDerivationFunc = keyDerivationFunc;
+        this.messageAuthScheme = messageAuthScheme;
+        sequence = new SEQUENCE();
+        sequence.addElement(keyDerivationFunc);
+        sequence.addElement(messageAuthScheme);
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    // DER encoding
+    ///////////////////////////////////////////////////////////////////////
+
+    private static final Tag TAG = SEQUENCE.TAG;
+
+    /**
+    * Returns the ASN.1 tag for this structure.
+    *
+    * @return The SEQUENCE tag
+    */
+    @Override
+    public Tag getTag() {
+        return TAG;
+    }
+
+    /**
+    * Encodes this PBMAC1Params to the output stream.
+    *
+    * @param ostream The output stream
+    * @throws IOException if encoding fails
+    */
+    @Override
+    public void encode(OutputStream ostream) throws IOException {
+        sequence.encode(ostream);
+    }
+
+    /**
+    * Encodes this PBMAC1Params with an implicit tag.
+    *
+    * @param implicitTag The implicit tag to use
+    * @param ostream The output stream
+    * @throws IOException if encoding fails
+    */
+    @Override
+    public void encode(Tag implicitTag, OutputStream ostream)
+        throws IOException
+    {
+        sequence.encode(implicitTag, ostream);
+    }
+
+    private static final Template templateInstance = new Template();
+
+    /**
+    * Returns the template for decoding PBMAC1Params.
+    *
+    * @return The PBMAC1Params template
+    */
+    public static Template getTemplate() {
+        return templateInstance;
+    }
+
+    /**
+     * A template class for decoding PBMAC1Params.
+     */
+    public static class Template implements ASN1Template {
+
+        private SEQUENCE.Template seqt;
+
+        /**
+        * Creates a new PBMAC1Params template.
+        */
+        public Template() {
+            seqt = new SEQUENCE.Template();
+            seqt.addElement(AlgorithmIdentifier.getTemplate());
+            seqt.addElement(AlgorithmIdentifier.getTemplate());
+        }
+
+        /**
+        * Returns whether the given tag matches this template.
+        *
+        * @param tag The tag to check
+        * @return true if the tag matches
+        */
+        @Override
+        public boolean tagMatch(Tag tag) {
+            return TAG.equals(tag);
+        }
+
+        /**
+        * Decodes a PBMAC1Params from the input stream.
+        *
+        * @param istream The input stream
+        * @return The decoded PBMAC1Params
+        * @throws InvalidBERException if decoding fails
+        * @throws IOException if an I/O error occurs
+        */
+        @Override
+        public ASN1Value decode(InputStream istream)
+            throws InvalidBERException, IOException
+        {
+            return decode(TAG, istream);
+        }
+
+        /**
+        * Decodes a PBMAC1Params with an implicit tag.
+        *
+        * @param implicitTag The implicit tag
+        * @param istream The input stream
+        * @return The decoded PBMAC1Params
+        * @throws InvalidBERException if decoding fails
+        * @throws IOException if an I/O error occurs
+        */
+        @Override
+        public ASN1Value decode(Tag implicitTag, InputStream istream)
+            throws InvalidBERException, IOException
+        {
+            SEQUENCE seq = (SEQUENCE) seqt.decode(implicitTag, istream);
+
+            return new PBMAC1Params((AlgorithmIdentifier) seq.elementAt(0),
+                                    (AlgorithmIdentifier) seq.elementAt(1));
+        }
+    }
+}

--- a/base/src/test/java/org/mozilla/jss/tests/PBMAC1Test.java
+++ b/base/src/test/java/org/mozilla/jss/tests/PBMAC1Test.java
@@ -1,0 +1,756 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.jss.tests;
+
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.asn1.SEQUENCE;
+import org.mozilla.jss.crypto.AlreadyInitializedException;
+import org.mozilla.jss.crypto.DigestAlgorithm;
+import org.mozilla.jss.pkcs12.AuthenticatedSafes;
+import org.mozilla.jss.pkcs12.MacType;
+import org.mozilla.jss.pkcs12.MacData;
+import org.mozilla.jss.pkcs12.PFX;
+import org.mozilla.jss.util.Password;
+import java.util.Calendar;
+import java.util.Date;
+import org.mozilla.jss.asn1.ASN1Util;
+import org.mozilla.jss.asn1.INTEGER;
+import org.mozilla.jss.crypto.CryptoStore;
+import org.mozilla.jss.crypto.ObjectNotFoundException;
+import org.mozilla.jss.crypto.SignatureAlgorithm;
+import org.mozilla.jss.crypto.X509Certificate;
+import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
+import org.mozilla.jss.netscape.security.pkcs.PKCS12;
+import org.mozilla.jss.netscape.security.pkcs.PKCS12Util;
+import org.mozilla.jss.pkix.cert.Certificate;
+import org.mozilla.jss.pkix.cert.CertificateInfo;
+import org.mozilla.jss.pkix.primitive.Name;
+import org.mozilla.jss.pkix.primitive.SubjectPublicKeyInfo;
+
+import org.mozilla.jss.asn1.ANY;
+import org.mozilla.jss.asn1.ASN1Value;
+import org.mozilla.jss.asn1.BMPString;
+import org.mozilla.jss.asn1.OCTET_STRING;
+import org.mozilla.jss.asn1.SET;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.crypto.EncryptionAlgorithm;
+import org.mozilla.jss.pkcs12.CertBag;
+import org.mozilla.jss.pkcs12.SafeBag;
+
+/**
+ * Test PBMAC1 (RFC 9879) MAC computation for PKCS#12.
+ */
+public class PBMAC1Test {
+
+    /**
+    * Runs all PBMAC1 tests.
+    *
+    * @param args dbdir and password file path
+    */
+    public static void main(String[] args) {
+        try {
+            if (args.length != 2) {
+                System.out.println("Usage: java org.mozilla.jss.tests.PBMAC1Test <dbdir> <passwordfile>");
+                System.exit(1);
+            }
+
+            try {
+                CryptoManager.initialize(args[0]);
+            } catch(AlreadyInitializedException e) {
+                // already initialized, it's ok
+            }
+
+            CryptoManager cm = CryptoManager.getInstance();
+            cm.setPasswordCallback(new FilePasswordCallback(args[1]));
+
+            System.out.println("Testing PBMAC1 MAC computation...\n");
+
+            // Test with SHA-256
+            testPBMAC1("SHA-256", DigestAlgorithm.SHA256, 32);
+
+            // Test with SHA-384
+            testPBMAC1("SHA-384", DigestAlgorithm.SHA384, 48);
+
+            // Test with SHA-512
+            testPBMAC1("SHA-512", DigestAlgorithm.SHA512, 64);
+
+            // Test repeatability (same inputs = same output)
+            testRepeatability();
+
+            // Test classic path
+            testClassicMAC();
+
+            //Test creating and verifying actual p12 file
+
+            testCreateP12WithPBMAC1(args[0]);
+
+            // Test creating an actual P12 with classic everything
+            testCreateP12WithClassicMAC(args[0]);
+
+            // Test creating a P12 with class MaC but KWP encryption.
+            testCreateP12WithKWP(args[0], MacType.CLASSIC);
+
+            // Test cerating a P12 with pbmac1 and KWP encryption.
+            testCreateP12WithKWP(args[0], MacType.PBMAC1);
+
+            //Test some rfc verifications
+
+            testRFC9879Vectors();
+
+            System.out.println("\nAll PBMAC1 and Classic MAC and p12 tests PASSED!");
+
+        } catch (Exception e) {
+            System.err.println("PBMAC1 test FAILED: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    /**
+    * Test PBMAC1 with a specific digest algorithm.
+    *
+    * @param name Display name for the digest
+    * @param digest The digest algorithm to test
+    * @param expectedMacLen Expected MAC output length in bytes
+    */
+    private static void testPBMAC1(String name, DigestAlgorithm digest, int expectedMacLen)
+        throws Exception {
+        System.out.println("Testing PBMAC1 with HMAC-" + name + "...");
+
+        Password password = new Password("testPassword123".toCharArray());
+        byte[] salt = new byte[20];
+        fillTestSalt(salt);
+        int iterations = 100000;
+
+        // Create minimal AuthenticatedSafes (empty is fine for MAC testing)
+        AuthenticatedSafes authSafes = new AuthenticatedSafes();
+        authSafes.addSafeContents(new SEQUENCE());
+
+        // Create PFX and configure for PBMAC1
+        PFX pfx = new PFX(authSafes);
+        pfx.setMacType(MacType.PBMAC1);
+        pfx.setMacDigest(digest);
+
+        // Compute MAC using real API
+        pfx.computeMacData(password, salt, iterations);
+
+        // Get the MacData and verify
+        MacData macData = pfx.getMacData();
+        if (macData == null || macData.getMac() == null) {
+            throw new Exception("PBMAC1 MAC computation failed - MacData is null");
+        }
+
+        // Verify MAC output length
+        byte[] macValue = macData.getMac().getDigest().toByteArray();
+        if (macValue.length != expectedMacLen) {
+            throw new Exception("PBMAC1 MAC length mismatch: expected " + expectedMacLen +
+                              " bytes, got " + macValue.length + " bytes");
+        }
+
+        System.out.println("  ✓ MAC length correct: " + macValue.length + " bytes");
+        System.out.println("  ✓ PBMAC1 with HMAC-" + name + " PASSED\n");
+
+        password.clear();
+    }
+
+    /**
+    * Verifies that identical inputs produce identical PBMAC1 output.
+    */
+    private static void testRepeatability() throws Exception {
+        System.out.println("Testing PBMAC1 repeatability (same inputs = same output)...");
+
+        Password password1 = new Password("samePassword".toCharArray());
+        Password password2 = new Password("samePassword".toCharArray());
+
+        byte[] salt = new byte[16];
+        fillTestSalt(salt);
+        int iterations = 100000;
+
+        // Create identical AuthenticatedSafes
+        AuthenticatedSafes authSafes1 = new AuthenticatedSafes();
+        authSafes1.addSafeContents(new SEQUENCE());
+
+        AuthenticatedSafes authSafes2 = new AuthenticatedSafes();
+        authSafes2.addSafeContents(new SEQUENCE());
+
+        // Compute MAC twice with same configuration
+        PFX pfx1 = new PFX(authSafes1);
+        pfx1.setMacType(MacType.PBMAC1);
+        pfx1.setMacDigest(DigestAlgorithm.SHA256);
+        pfx1.computeMacData(password1, salt, iterations);
+        byte[] mac1 = pfx1.getMacData().getMac().getDigest().toByteArray();
+
+        PFX pfx2 = new PFX(authSafes2);
+        pfx2.setMacType(MacType.PBMAC1);
+        pfx2.setMacDigest(DigestAlgorithm.SHA256);
+        pfx2.computeMacData(password2, salt, iterations);
+        byte[] mac2 = pfx2.getMacData().getMac().getDigest().toByteArray();
+
+        // Verify both MACs are identical
+        if (mac1.length != mac2.length) {
+            throw new Exception("MAC lengths differ");
+        }
+
+        for (int i = 0; i < mac1.length; i++) {
+            if (mac1[i] != mac2[i]) {
+                throw new Exception("MACs differ at byte " + i);
+            }
+        }
+
+        System.out.println("  ✓ Repeatability verified - same inputs produce same MAC");
+        System.out.println("  ✓ Repeatability test PASSED\n");
+
+        password1.clear();
+        password2.clear();
+    }
+
+    /**
+    * Verifies classic MAC path still works with default settings.
+    */
+    private static void testClassicMAC() throws Exception {
+        System.out.println("Testing Classic MAC (backward compatibility)...");
+
+        Password password = new Password("classicPassword".toCharArray());
+        byte[] salt = new byte[16];
+        fillTestSalt(salt);
+        int iterations = 100000;
+
+        // Create AuthenticatedSafes
+        AuthenticatedSafes authSafes = new AuthenticatedSafes();
+        authSafes.addSafeContents(new SEQUENCE());
+
+        // Create PFX - DON'T set MacType (should default to CLASSIC)
+        PFX pfx = new PFX(authSafes);
+
+        // Compute MAC using default (classic) algorithm
+        pfx.computeMacData(password, salt, iterations);
+
+        // Verify MAC was created
+        MacData macData = pfx.getMacData();
+        if (macData == null || macData.getMac() == null) {
+            throw new Exception("Classic MAC computation failed - MacData is null");
+        }
+
+        // Verify MAC length (SHA-256 = 32 bytes, which is the classic default)
+        byte[] macValue = macData.getMac().getDigest().toByteArray();
+        if (macValue.length != 32) {
+            throw new Exception("Classic MAC length unexpected: " + macValue.length);
+        }
+
+        System.out.println("  ✓ Classic MAC created successfully");
+        System.out.println("  ✓ MAC length: " + macValue.length + " bytes (SHA-256)");
+        System.out.println("  ✓ Classic MAC test PASSED\n");
+
+        password.clear();
+    }
+
+    /**
+     * Fill salt array with test values.
+     * For tests only - real code should use SecureRandom.
+     */
+    private static void fillTestSalt(byte[] salt) {
+        for (int i = 0; i < salt.length; i++) {
+            salt[i] = (byte) i;
+        }
+    }
+
+    /**
+    * Tests full PKCS#12 round-trip: create, export with PBMAC1, delete, re-import.
+    *
+    * @param dbdir Path to the NSS database directory
+    */
+private static void testCreateP12WithPBMAC1(String dbdir) throws Exception {
+      System.out.println("Testing PKCS#12 file creation with PBMAC1...");
+
+      CryptoManager cm = CryptoManager.getInstance();
+
+      // 1. Generate test cert and key
+      String nickname = "PBMAC1-Test" + System.currentTimeMillis();
+      java.security.KeyPair pair = generateTestCertAndKey("RSA", 2048, nickname);
+
+      System.out.println("  ✓ Generated 2048-bit RSA cert/key: " + nickname);
+
+      // 2. Get the imported certificate
+      X509Certificate nssCert = cm.findCertByNickname(nickname);
+
+      // 3. Create PKCS12 object and add cert/key
+      PKCS12 pkcs12 = new PKCS12();
+      PKCS12Util util = new PKCS12Util();
+      util.loadCertFromNSS(pkcs12, nssCert, true, false);
+
+      System.out.println("  ✓ Created PKCS12 object");
+
+      // 4. Export to file with PBMAC1
+      util.setMacType(MacType.PBMAC1);
+      util.setMacDigest(DigestAlgorithm.SHA256);
+
+      Password password = new Password("test123".toCharArray());
+      String filename = dbdir + "/test-pbmac1.p12";
+      util.storeIntoFile(pkcs12, filename, password);
+
+      System.out.println("  ✓ Exported to: " + filename);
+      System.out.println("  ✓ MAC type: PBMAC1 with HMAC-SHA256");
+
+      // 5. Delete cert/key from database
+      CryptoStore store = cm.getInternalKeyStorageToken().getCryptoStore();
+      store.deleteCert(nssCert);
+
+      System.out.println("  ✓ Deleted cert/key from database");
+
+      // 6. Verify cert is gone
+      try {
+          cm.findCertByNickname(nickname);
+          throw new Exception("Cert still exists after deletion!");
+      } catch (ObjectNotFoundException e) {
+          // Expected - cert is gone
+          System.out.println("  ✓ Verified cert was deleted");
+      }
+
+      // 7. Re-import from PKCS#12 file
+      PKCS12 pkcs12imported = util.loadFromFile(filename, password);
+      util.storeIntoNSS(pkcs12imported, password, false);
+
+      System.out.println("  ✓ Re-imported from PKCS#12 file");
+
+      // 8. Verify cert/key are restored
+      X509Certificate restoredCert = cm.findCertByNickname(nickname);
+      if (restoredCert == null) {
+          throw new Exception("Cert not restored from PKCS#12!");
+      }
+
+      System.out.println("  ✓ Cert/key successfully restored");
+
+      // 9. Final cleanup
+      store.deleteCert(restoredCert);
+      password.clear();
+
+      System.out.println("  ✓ PKCS#12 round-trip test PASSED\n");
+  }
+
+  /**
+   * Tests PKCS#12 file creation with classic MAC (backward compatibility).
+   *
+   * @param dbdir Path to the NSS database directory
+   */
+  private static void testCreateP12WithClassicMAC(String dbdir) throws Exception {
+          System.out.println("Testing PKCS#12 file creation with classic MAC...");
+
+          CryptoManager cm = CryptoManager.getInstance();
+
+          String nickname = "Classic-Test" + System.currentTimeMillis();
+          java.security.KeyPair pair = generateTestCertAndKey("RSA", 2048, nickname);
+
+          System.out.println("  ✓ Generated 2048-bit RSA cert/key: " + nickname);
+
+          X509Certificate nssCert = cm.findCertByNickname(nickname);
+
+          PKCS12 pkcs12 = new PKCS12();
+          PKCS12Util util = new PKCS12Util();
+          util.loadCertFromNSS(pkcs12, nssCert, true, false);
+
+          // Don't set MacType - use default (CLASSIC)
+          Password password = new Password("test123".toCharArray());
+          String filename = dbdir + "/test-classic.p12";
+          util.storeIntoFile(pkcs12, filename, password);
+
+          System.out.println("  ✓ Exported to: " + filename);
+          System.out.println("  ✓ MAC type: Classic (SHA-256 HMAC)");
+
+          CryptoStore store = cm.getInternalKeyStorageToken().getCryptoStore();
+          store.deleteCert(nssCert);
+
+          PKCS12 pkcs12imported = util.loadFromFile(filename, password);
+          util.storeIntoNSS(pkcs12imported, password, false);
+
+          System.out.println("  ✓ Re-imported from PKCS#12 file");
+
+          X509Certificate restoredCert = cm.findCertByNickname(nickname);
+          if (restoredCert == null) {
+              throw new Exception("Cert not restored from PKCS#12!");
+          }
+
+          System.out.println("  ✓ Cert/key successfully restored");
+
+          store.deleteCert(restoredCert);
+          password.clear();
+
+          System.out.println("  ✓ Classic MAC PKCS#12 round-trip test PASSED\n");
+      }
+
+    /**
+    * Generates a self-signed test certificate and keypair in the NSS database.
+    *
+    * @param keyType Key algorithm (RSA or EC)
+    * @param keySize Key size in bits
+    * @param nickname Certificate nickname
+    * @return The generated keypair
+    */
+    private static java.security.KeyPair generateTestCertAndKey(
+      String keyType, int keySize, String nickname) throws Exception {
+
+      CryptoManager cm = CryptoManager.getInstance();
+
+      // Generate keypair
+      java.security.KeyPairGenerator kpg =
+          java.security.KeyPairGenerator.getInstance(keyType, "Mozilla-JSS");
+      kpg.initialize(keySize);
+      java.security.KeyPair pair = kpg.genKeyPair();
+
+      // Select signature algorithm based on key type
+      SignatureAlgorithm sigAlg;
+      if (keyType.equals("RSA")) {
+          sigAlg = SignatureAlgorithm.RSASignatureWithSHA256Digest;
+      } else if (keyType.equals("EC")) {
+          sigAlg = SignatureAlgorithm.ECSignatureWithSHA256Digest;
+      } else {
+          throw new IllegalArgumentException("Unsupported key type: " + keyType);
+      }
+
+      // Create self-signed certificate
+      Name subject = new Name();
+      subject.addCountryName("US");
+      subject.addOrganizationName("Mozilla");
+      subject.addCommonName(nickname);
+
+      Calendar cal = Calendar.getInstance();
+      Date notBefore = cal.getTime();
+      cal.add(Calendar.YEAR, 1);
+      Date notAfter = cal.getTime();
+
+      // AlgorithmIdentifier construction differs by key type
+      AlgorithmIdentifier sigAlgID;
+      if (keyType.equals("RSA")) {
+          sigAlgID = new AlgorithmIdentifier(sigAlg.toOID(), null);
+      } else {
+          sigAlgID = new AlgorithmIdentifier(sigAlg.toOID());
+      }
+
+      SubjectPublicKeyInfo spki = (SubjectPublicKeyInfo) ASN1Util.decode(
+          new SubjectPublicKeyInfo.Template(), pair.getPublic().getEncoded());
+
+      CertificateInfo info = new CertificateInfo(
+          CertificateInfo.v3,
+          new INTEGER(1),
+          sigAlgID,
+          subject,  // issuer
+          notBefore,
+          notAfter,
+          subject,  // subject (self-signed)
+          spki);
+
+      Certificate cert = new Certificate(info, pair.getPrivate(), sigAlg);
+
+      // Import cert into NSS database
+      cm.importCertPackage(ASN1Util.encode(cert), nickname);
+
+      return pair;
+  }
+
+    /**
+    * Test PBMAC1 verification against RFC 9879 Appendix A test vectors.
+    * All test vectors use password "1234".
+    */
+    private static void testRFC9879Vectors() throws Exception {
+        System.out.println("Testing RFC 9879 Appendix A test vectors...\n");
+
+        // A.1: SHA-256 HMAC and PRF (MUST support)
+        String vectorA1 =
+            "MIIKigIBAzCCCgUGCSqGSIb3DQEHAaCCCfYEggnyMIIJ7jCCBGIGCSqGSIb3DQEH"
+          + "BqCCBFMwggRPAgEAMIIESAYJKoZIhvcNAQcBMFcGCSqGSIb3DQEFDTBKMCkGCSqG"
+          + "SIb3DQEFDDAcBAg9pxXxY2yscwICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQME"
+          + "ASoEEK7yYaFQDi1pYwWzm9F/fs+AggPgFIT2XapyaFgDppdvLkdvaF3HXw+zjzKb"
+          + "7xFC76DtVPhVTWVHD+kIss+jsj+XyvMwY0aCuAhAG/Dig+vzWomnsqB5ssw5/kTb"
+          + "+TMQ5PXLkNeoBmB6ArKeGc/QmCBQvQG/a6b+nXSWmxNpP+71772dmWmB8gcSJ0kF"
+          + "Fj75NrIbmNiDMCb71Q8gOzBMFf6BpXf/3xWAJtxyic+tSNETfOJa8zTZb0+lV0w9"
+          + "5eUmDrPUpuxEVbb0KJtIc63gRkcfrPtDd6Ii4Zzbzj2Evr4/S4hnrQBsiryVzJWy"
+          + "IEjaD0y6+DmG0JwMgRuGi1wBoGowi37GMrDCOyOZWC4n5wHLtYyhR6JaElxbrhxP"
+          + "H46z2USLKmZoF+YgEQgYcSBXMgP0t36+XQocFWYi2N5niy02TnctwF430FYsQlhJ"
+          + "Suma4I33E808dJuMv8T/soF66HsD4Zj46hOf4nWmas7IaoSAbGKXgIa7KhGRJvij"
+          + "xM3WOX0aqNi/8bhnxSA7fCmIy/7opyx5UYJFWGBSmHP1pBHBVmx7Ad8SAsB9MSsh"
+          + "nbGjGiUk4h0QcOi29/M9WwFlo4urePyI8PK2qtVAmpD3rTLlsmgzguZ69L0Q/CFU"
+          + "fbtqsMF0bgEuh8cfivd1DYFABEt1gypuwCUtCqQ7AXK2nQqOjsQCxVz9i9K8NDeD"
+          + "aau98VAl0To2sk3/VR/QUq0PRwU1jPN5BzUevhE7SOy/ImuJKwpGqqFljYdrQmj5"
+          + "jDe+LmYH9QGVRlfN8zuU+48FY8CAoeBeHn5AAPml0PYPVUnt3/jQN1+v+CahNVI+"
+          + "La8q1Nen+j1R44aa2I3y/pUgtzXRwK+tPrxTQbG030EU51LYJn8amPWmn3w75ZIA"
+          + "MJrXWeKj44de7u4zdUsEBVC2uM44rIHM8MFjyYAwYsey0rcp0emsaxzar+7ZA67r"
+          + "lDoXvvS3NqsnTXHcn3T9tkPRoee6L7Dh3x4Od96lcRwgdYT5BwyH7e34ld4VTUmJ"
+          + "bDEq7Ijvn4JKrwQJh1RCC+Z/ObfkC42xAm7G010u3g08xB0Qujpdg4a7VcuWrywF"
+          + "c7hLNquuaF4qoDaVwYXHH3iuX6YlJ/3siTKbYCVXPEZOAMBP9lF/OU76UMJBQNfU"
+          + "0xjDx+3AhUVgnGuCsmYlK6ETDp8qOZKGyV0KrNSGtqLx3uMhd7PETeW+ML3tDQ/0"
+          + "X9fMkcZHi4C2fXnoHV/qa2dGhBj4jjQ0Xh1poU6mxGn2Mebe2hDsBZkkBpnn7pK4"
+          + "wP/VqXdQTwqEuvzGHLVFsCuADe40ZFBmtBrf70wG7ZkO8SUZ8Zz1IX3+S024g7yj"
+          + "QRev/6x6TtkwggWEBgkqhkiG9w0BBwGgggV1BIIFcTCCBW0wggVpBgsqhkiG9w0B"
+          + "DAoBAqCCBTEwggUtMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAhTxzw+"
+          + "VptrYAICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEK9nSqc1I2t4tMVG"
+          + "bWHpdtQEggTQzCwI7j34gCTvfj6nuOSndAjShGv7mN2j7WMV0pslTpq2b9Bn3vn1"
+          + "Y0JMvL4E7sLrUzNU02pdOcfCnEpMFccNv2sQrLp1mOCKxu8OjSqHZLoKVL0ROVsZ"
+          + "8dMECLLigDlPKRiSyLErl14tErX4/zbkUaWMROO28kFbTbubQ8YoHlRUwsKW1xLg"
+          + "vfi0gRkG/zHXRfQHjX/8NStv7hXlehn7/Gy2EKPsRFhadm/iUHAfmCMkMgHTU248"
+          + "JER9+nsXltd59H+IeDpj/kbxZ+YvHow9XUZKu828d3MQnUpLZ1BfJGhMBPVwbVUD"
+          + "A40CiQBVdCoGtPJyalL28xoS3H0ILFCnwQOr6u0HwleNJPGHq78HUyH6Hwxnh0b0"
+          + "5o163r6wTFZn5cMOxpbs/Ttd+3TrxmrYpd2XnuRme3cnaYJ0ILvpc/8eLLR7SKjD"
+          + "T4JhZ0h/CfcV2WWvhpQugkY0pWrZ+EIMneB1dZB96mJVLxOi148OeSgi0PsxZMNi"
+          + "YM33rTpwQT5WqOsEyDwUQpne5b8Kkt/s7EN0LJNnPyJJRL1LcqOdr6j+6YqRtPa7"
+          + "a9oWJqMcuTP+bqzGRJh+3HDlFBw2Yzp9iadv4KmB2MzhStLUoi2MSjvnnkkd5Led"
+          + "sshAd6WbKfF7kLAHQHT4Ai6dMEO4EKkEVF9JBtxCR4JEn6C98Lpg+Lk+rfY7gHOf"
+          + "ZxtgGURwgXRY3aLUrdT55ZKgk3ExVKPzi5EhdpAau7JKhpOwyKozAp/OKWMNrz6h"
+          + "obu2Mbn1B+IA60psYHHxynBgsJHv7WQmbYh8HyGfHgVvaA8pZCYqxxjpLjSJrR8B"
+          + "Bu9H9xkTh7KlhxgreXYv19uAYbUd95kcox9izad6VPnovgFSb+Omdy6PJACPj6hF"
+          + "W6PJbucP0YPpO0VtWtQdZZ3df1P0hZ7qvKwOPFA+gKZSckgqASfygiP9V3Zc8jIi"
+          + "wjNzoDM2QT+UUJKiiGYXJUEOO9hxzFHlGj759DcNRhpgl5AgR57ofISD9yBuCAJY"
+          + "PQ/aZHPFuRTrcVG3RaIbCAS73nEznKyFaLOXfzyfyaSmyhsH253tnyL1MejC+2bR"
+          + "Eko/yldgFUxvU5JI+Q3KJ6Awj+PnduHXx71E4UwSuu2xXYMpxnQwI6rroQpZBX82"
+          + "HhqgcLV83P8lpzQwPdHjH5zkoxmWdC0+jU/tcQfNXYpJdyoaX7tDmVclLhwl9ps/"
+          + "O841pIsNLJWXwvxG6B+3LN/kw4QjwN194PopiOD7+oDm5mhttO78CrBrRxHMD/0Q"
+          + "qniZjKzSZepxlZq+J792u8vtMnuzzChxu0Bf3PhIXcJNcVhwUtr0yKe/N+NvC0tm"
+          + "p8wyik/BlndxN9eKbdTOi2wIi64h2QG8nOk66wQ/PSIJYwZl6eDNEQSzH/1mGCfU"
+          + "QnUT17UC/p+Qgenf6Auap2GWlvsJrB7u/pytz65rtjt/ouo6Ih6EwWqwVVpGXZD0"
+          + "7gVWH0Ke/Vr6aPGNvkLcmftPuDZsn9jiig3guhdeyRVf10Ox369kKWcG75q77hxE"
+          + "IzSzDyUlBNbnom9SIjut3r+qVYmWONatC6q/4D0I42Lnjd3dEyZx7jmH3g/S2ASM"
+          + "FzWr9pvXc61dsYOkdZ4PYa9XPUZxXFagZsoS3F1sU799+IJVU0tC0MExJTAjBgkq"
+          + "hkiG9w0BCRUxFgQUwWO5DorvVWYF3BWUmAw0rUEajScwfDBtMEkGCSqGSIb3DQEF"
+          + "DjA8MCwGCSqGSIb3DQEFDDAfBAhvRzw4sC4xcwICCAACASAwDAYIKoZIhvcNAgkF"
+          + "ADAMBggqhkiG9w0CCQUABCB6pW2FOdcCNj87zS64NUXG36K5aXDnFHctIk5Bf4kG"
+          + "3QQITk9UIFVTRUQCAQE=";
+
+        // A.4: Invalid - Incorrect Iteration Count (MUST reject)
+        String vectorA4 =
+            "MIIKiwIBAzCCCgUGCSqGSIb3DQEHAaCCCfYEggnyMIIJ7jCCBGIGCSqGSIb3DQEH"
+          + "BqCCBFMwggRPAgEAMIIESAYJKoZIhvcNAQcBMFcGCSqGSIb3DQEFDTBKMCkGCSqG"
+          + "SIb3DQEFDDAcBAg9pxXxY2yscwICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQME"
+          + "ASoEEK7yYaFQDi1pYwWzm9F/fs+AggPgFIT2XapyaFgDppdvLkdvaF3HXw+zjzKb"
+          + "7xFC76DtVPhVTWVHD+kIss+jsj+XyvMwY0aCuAhAG/Dig+vzWomnsqB5ssw5/kTb"
+          + "+TMQ5PXLkNeoBmB6ArKeGc/QmCBQvQG/a6b+nXSWmxNpP+71772dmWmB8gcSJ0kF"
+          + "Fj75NrIbmNiDMCb71Q8gOzBMFf6BpXf/3xWAJtxyic+tSNETfOJa8zTZb0+lV0w9"
+          + "5eUmDrPUpuxEVbb0KJtIc63gRkcfrPtDd6Ii4Zzbzj2Evr4/S4hnrQBsiryVzJWy"
+          + "IEjaD0y6+DmG0JwMgRuGi1wBoGowi37GMrDCOyOZWC4n5wHLtYyhR6JaElxbrhxP"
+          + "H46z2USLKmZoF+YgEQgYcSBXMgP0t36+XQocFWYi2N5niy02TnctwF430FYsQlhJ"
+          + "Suma4I33E808dJuMv8T/soF66HsD4Zj46hOf4nWmas7IaoSAbGKXgIa7KhGRJvij"
+          + "xM3WOX0aqNi/8bhnxSA7fCmIy/7opyx5UYJFWGBSmHP1pBHBVmx7Ad8SAsB9MSsh"
+          + "nbGjGiUk4h0QcOi29/M9WwFlo4urePyI8PK2qtVAmpD3rTLlsmgzguZ69L0Q/CFU"
+          + "fbtqsMF0bgEuh8cfivd1DYFABEt1gypuwCUtCqQ7AXK2nQqOjsQCxVz9i9K8NDeD"
+          + "aau98VAl0To2sk3/VR/QUq0PRwU1jPN5BzUevhE7SOy/ImuJKwpGqqFljYdrQmj5"
+          + "jDe+LmYH9QGVRlfN8zuU+48FY8CAoeBeHn5AAPml0PYPVUnt3/jQN1+v+CahNVI+"
+          + "La8q1Nen+j1R44aa2I3y/pUgtzXRwK+tPrxTQbG030EU51LYJn8amPWmn3w75ZIA"
+          + "MJrXWeKj44de7u4zdUsEBVC2uM44rIHM8MFjyYAwYsey0rcp0emsaxzar+7ZA67r"
+          + "lDoXvvS3NqsnTXHcn3T9tkPRoee6L7Dh3x4Od96lcRwgdYT5BwyH7e34ld4VTUmJ"
+          + "bDEq7Ijvn4JKrwQJh1RCC+Z/ObfkC42xAm7G010u3g08xB0Qujpdg4a7VcuWrywF"
+          + "c7hLNquuaF4qoDaVwYXHH3iuX6YlJ/3siTKbYCVXPEZOAMBP9lF/OU76UMJBQNfU"
+          + "0xjDx+3AhUVgnGuCsmYlK6ETDp8qOZKGyV0KrNSGtqLx3uMhd7PETeW+ML3tDQ/0"
+          + "X9fMkcZHi4C2fXnoHV/qa2dGhBj4jjQ0Xh1poU6mxGn2Mebe2hDsBZkkBpnn7pK4"
+          + "wP/VqXdQTwqEuvzGHLVFsCuADe40ZFBmtBrf70wG7ZkO8SUZ8Zz1IX3+S024g7yj"
+          + "QRev/6x6TtkwggWEBgkqhkiG9w0BBwGgggV1BIIFcTCCBW0wggVpBgsqhkiG9w0B"
+          + "DAoBAqCCBTEwggUtMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAhTxzw+"
+          + "VptrYAICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEK9nSqc1I2t4tMVG"
+          + "bWHpdtQEggTQzCwI7j34gCTvfj6nuOSndAjShGv7mN2j7WMV0pslTpq2b9Bn3vn1"
+          + "Y0JMvL4E7sLrUzNU02pdOcfCnEpMFccNv2sQrLp1mOCKxu8OjSqHZLoKVL0ROVsZ"
+          + "8dMECLLigDlPKRiSyLErl14tErX4/zbkUaWMROO28kFbTbubQ8YoHlRUwsKW1xLg"
+          + "vfi0gRkG/zHXRfQHjX/8NStv7hXlehn7/Gy2EKPsRFhadm/iUHAfmCMkMgHTU248"
+          + "JER9+nsXltd59H+IeDpj/kbxZ+YvHow9XUZKu828d3MQnUpLZ1BfJGhMBPVwbVUD"
+          + "A40CiQBVdCoGtPJyalL28xoS3H0ILFCnwQOr6u0HwleNJPGHq78HUyH6Hwxnh0b0"
+          + "5o163r6wTFZn5cMOxpbs/Ttd+3TrxmrYpd2XnuRme3cnaYJ0ILvpc/8eLLR7SKjD"
+          + "T4JhZ0h/CfcV2WWvhpQugkY0pWrZ+EIMneB1dZB96mJVLxOi148OeSgi0PsxZMNi"
+          + "YM33rTpwQT5WqOsEyDwUQpne5b8Kkt/s7EN0LJNnPyJJRL1LcqOdr6j+6YqRtPa7"
+          + "a9oWJqMcuTP+bqzGRJh+3HDlFBw2Yzp9iadv4KmB2MzhStLUoi2MSjvnnkkd5Led"
+          + "sshAd6WbKfF7kLAHQHT4Ai6dMEO4EKkEVF9JBtxCR4JEn6C98Lpg+Lk+rfY7gHOf"
+          + "ZxtgGURwgXRY3aLUrdT55ZKgk3ExVKPzi5EhdpAau7JKhpOwyKozAp/OKWMNrz6h"
+          + "obu2Mbn1B+IA60psYHHxynBgsJHv7WQmbYh8HyGfHgVvaA8pZCYqxxjpLjSJrR8B"
+          + "Bu9H9xkTh7KlhxgreXYv19uAYbUd95kcox9izad6VPnovgFSb+Omdy6PJACPj6hF"
+          + "W6PJbucP0YPpO0VtWtQdZZ3df1P0hZ7qvKwOPFA+gKZSckgqASfygiP9V3Zc8jIi"
+          + "wjNzoDM2QT+UUJKiiGYXJUEOO9hxzFHlGj759DcNRhpgl5AgR57ofISD9yBuCAJY"
+          + "PQ/aZHPFuRTrcVG3RaIbCAS73nEznKyFaLOXfzyfyaSmyhsH253tnyL1MejC+2bR"
+          + "Eko/yldgFUxvU5JI+Q3KJ6Awj+PnduHXx71E4UwSuu2xXYMpxnQwI6rroQpZBX82"
+          + "HhqgcLV83P8lpzQwPdHjH5zkoxmWdC0+jU/tcQfNXYpJdyoaX7tDmVclLhwl9ps/"
+          + "O841pIsNLJWXwvxG6B+3LN/kw4QjwN194PopiOD7+oDm5mhttO78CrBrRxHMD/0Q"
+          + "qniZjKzSZepxlZq+J792u8vtMnuzzChxu0Bf3PhIXcJNcVhwUtr0yKe/N+NvC0tm"
+          + "p8wyik/BlndxN9eKbdTOi2wIi64h2QG8nOk66wQ/PSIJYwZl6eDNEQSzH/1mGCfU"
+          + "QnUT17UC/p+Qgenf6Auap2GWlvsJrB7u/pytz65rtjt/ouo6Ih6EwWqwVVpGXZD0"
+          + "7gVWH0Ke/Vr6aPGNvkLcmftPuDZsn9jiig3guhdeyRVf10Ox369kKWcG75q77hxE"
+          + "IzSzDyUlBNbnom9SIjut3r+qVYmWONatC6q/4D0I42Lnjd3dEyZx7jmH3g/S2ASM"
+          + "FzWr9pvXc61dsYOkdZ4PYa9XPUZxXFagZsoS3F1sU799+IJVU0tC0MExJTAjBgkq"
+          + "hkiG9w0BCRUxFgQUwWO5DorvVWYF3BWUmAw0rUEajScwfTBtMEkGCSqGSIb3DQEF"
+          + "DjA8MCwGCSqGSIb3DQEFDDAfBAhvRzw4sC4xcwICCAECASAwDAYIKoZIhvcNAgkF"
+          + "ADAMBggqhkiG9w0CCQUABCB6pW2FOdcCNj87zS64NUXG36K5aXDnFHctIk5Bf4kG"
+          + "3QQITk9UIFVTRUQCAggA";
+
+        Password password = new Password("1234".toCharArray());
+
+        // Test valid vector (MUST pass)
+        testRFC9879Vector("A.1 (SHA-256 HMAC+PRF)", vectorA1, password, true);
+
+        // Test invalid vector (MUST fail)
+        testRFC9879Vector("A.4 (incorrect iteration count)", vectorA4, password, false);
+
+        password.clear();
+        System.out.println("  RFC 9879 test vectors PASSED\n");
+    }
+
+    /**
+     * Verifies a single RFC 9879 test vector.
+     *
+     * @param name Display name for the test vector
+     * @param base64Data Base64-encoded PKCS#12 data
+     * @param password Password for verification
+     * @param expectValid True if verification should succeed
+   */
+    private static void testRFC9879Vector(String name, String base64Data,
+            Password password, boolean expectValid) throws Exception {
+        System.out.println("  Testing RFC 9879 vector " + name + "...");
+
+        byte[] p12Bytes = java.util.Base64.getDecoder().decode(base64Data);
+
+        PFX.Template pfxTemplate = new PFX.Template();
+        PFX pfx = (PFX) pfxTemplate.decode(
+            new java.io.ByteArrayInputStream(p12Bytes));
+
+        StringBuffer reason = new StringBuffer();
+        boolean verified = pfx.verifyAuthSafes(password, reason);
+
+        if (expectValid && !verified) {
+            throw new Exception("RFC 9879 vector " + name +
+                " should verify but failed: " + reason);
+        } else if (!expectValid && verified) {
+            throw new Exception("RFC 9879 vector " + name +
+                " should fail verification but passed");
+        }
+
+        System.out.println("    " + (expectValid ? "verified" : "correctly rejected") +
+            (reason.length() > 0 ? " (" + reason + ")" : ""));
+    }
+
+    /**
+      * Tests PKCS#12 file creation using non-legacy KWP encryption
+      * for the private key, mirroring the KRA non-legacy recovery path.
+      *
+      * @param dbdir Path to the NSS database directory
+      * @param macType The MAC type (CLASSIC or PBMAC1)
+    */
+    private static void testCreateP12WithKWP(String dbdir, MacType macType) throws Exception {
+          System.out.println("Testing PKCS#12 file creation with KWP encryption + " + macType.name() + " MAC...");
+
+          CryptoManager cm = CryptoManager.getInstance();
+          CryptoToken ct = cm.getInternalKeyStorageToken();
+
+          // 1. Generate test cert and key
+          String nickname = "KWP-Test" + System.currentTimeMillis();
+          java.security.KeyPair pair = generateTestCertAndKey("RSA", 2048, nickname);
+
+          System.out.println("  Generated 2048-bit RSA cert/key: " + nickname);
+
+          // 2. Get the certificate and private key
+          X509Certificate nssCert = cm.findCertByNickname(nickname);
+          org.mozilla.jss.crypto.PrivateKey priKey =
+              (org.mozilla.jss.crypto.PrivateKey) pair.getPrivate();
+
+          // 3. Encrypt private key using KWP path (non-legacy)
+          Password pass = new Password("test123".toCharArray());
+          EncryptionAlgorithm encAlg = EncryptionAlgorithm.fromString("AES/None/PKCS5Padding/Kwp/256");
+          if (encAlg == null) {
+              throw new Exception("KWP algorithm unavailable; this test would not exercise the KWP path");
+          }
+
+          byte[] epkiBytes = ct.getCryptoStore().getEncryptedPrivateKeyInfo(
+              null /* no passConverter for non-legacy */,
+              pass,
+              encAlg,
+              0 /* iterations (use default) */,
+              priKey);
+
+          if (epkiBytes == null) {
+              throw new Exception("getEncryptedPrivateKeyInfo returned null");
+          }
+
+          System.out.println("  Encrypted private key with: " + encAlg);
+
+          ASN1Value key = new ANY(epkiBytes);
+
+          // 4. Build cert bag
+          byte[] localKeyId = createLocalKeyId(nssCert);
+          SET certAttrs = createBagAttrs(nickname, localKeyId);
+          ASN1Value cert = new OCTET_STRING(nssCert.getEncoded());
+          SafeBag certBag = new SafeBag(SafeBag.CERT_BAG,
+              new CertBag(CertBag.X509_CERT_TYPE, cert),
+              certAttrs);
+
+          SEQUENCE encSafeContents = new SEQUENCE();
+          encSafeContents.addElement(certBag);
+
+          // 5. Build key bag
+          SET keyAttrs = createBagAttrs(nickname, localKeyId);
+          SafeBag keyBag = new SafeBag(
+              SafeBag.PKCS8_SHROUDED_KEY_BAG, key, keyAttrs);
+
+          SEQUENCE safeContents = new SEQUENCE();
+          safeContents.addElement(keyBag);
+
+          // 6. Build AuthenticatedSafes and PFX
+          AuthenticatedSafes authSafes = new AuthenticatedSafes();
+          authSafes.addSafeContents(safeContents);
+          authSafes.addSafeContents(encSafeContents);
+
+          PFX pfx = new PFX(authSafes);
+          pfx.setMacType(macType);
+          pfx.setMacDigest(DigestAlgorithm.SHA256);
+
+          pfx.computeMacData(pass, null, 100000);
+
+          // 7. Write to file
+          String filename = dbdir + "/test-kwp-" + macType.name().toLowerCase() + ".p12";
+          java.io.FileOutputStream fos = new java.io.FileOutputStream(filename);
+          pfx.encode(fos);
+          fos.close();
+
+          System.out.println("  Exported to: " + filename);
+
+          // 8. Cleanup
+          CryptoStore store = ct.getCryptoStore();
+          store.deleteCert(nssCert);
+          pass.clear();
+
+          System.out.println("  PKCS#12 with KWP encryption test PASSED\n");
+      }
+
+      /**
+       * Creates a local key ID from a certificate's SHA-1 fingerprint.
+       *
+       * @param cert The certificate
+       * @return The SHA-1 digest of the encoded certificate
+      */
+      private static byte[] createLocalKeyId(X509Certificate cert)
+          throws Exception {
+          java.security.MessageDigest md =
+              java.security.MessageDigest.getInstance("SHA-1");
+          return md.digest(cert.getEncoded());
+      }
+
+      /**
+       * Creates PKCS#12 bag attributes with friendly name and local key ID.
+       *
+       * @param nickname The friendly name
+       * @param localKeyId The local key ID
+       * @return The attribute SET
+      */
+      private static SET createBagAttrs(String nickname, byte[] localKeyId)
+          throws Exception {
+          SET attrs = new SET();
+
+          SEQUENCE nicknameAttr = new SEQUENCE();
+          nicknameAttr.addElement(SafeBag.FRIENDLY_NAME);
+          SET nicknameSet = new SET();
+          nicknameSet.addElement(new BMPString(nickname));
+          nicknameAttr.addElement(nicknameSet);
+          attrs.addElement(nicknameAttr);
+
+          SEQUENCE localKeyIdAttr = new SEQUENCE();
+          localKeyIdAttr.addElement(SafeBag.LOCAL_KEY_ID);
+          SET localKeyIdSet = new SET();
+          localKeyIdSet.addElement(new OCTET_STRING(localKeyId));
+          localKeyIdAttr.addElement(localKeyIdSet);
+          attrs.addElement(localKeyIdAttr);
+
+          return attrs;
+      }
+
+}

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -98,6 +98,13 @@ macro(jss_tests)
         NAME "JSS_Test_PR_FileDesc"
         COMMAND "org.mozilla.jss.tests.TestPRFD"
     )
+
+    jss_test_java(
+        NAME "PBMAC1_Test"
+        COMMAND "org.mozilla.jss.tests.PBMAC1Test" "${RESULTS_NSSDB_OUTPUT_DIR}"  "${PASSWORD_FILE}"
+        DEPENDS "Setup_DBs"
+    )
+
     jss_test_java(
         NAME "JSS_Test_Raw_SSL"
         COMMAND "org.mozilla.jss.tests.TestRawSSL" "${RESULTS_NSSDB_OUTPUT_DIR}"

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -538,6 +538,7 @@ JSS_5.10.0 {
     global:
 Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateMLKEMKeyPair;
 Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateMLKEMKeyPairWithOpFlags;
+Java_org_mozilla_jss_pkcs12_MacData_nativeComputePBMAC1;
     local:
         *;
 };

--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyGenerator.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyGenerator.c
@@ -614,3 +614,185 @@ finish:
     PK11_FreeSymKey(result);
     return resultObj;
 }
+
+JNIEXPORT jbyteArray JNICALL
+  Java_org_mozilla_jss_pkcs12_MacData_nativeComputePBMAC1(
+      JNIEnv *env, jobject this,
+      jobject token,
+      jbyteArray passwordArray,
+      jbyteArray dataArray,
+      jbyteArray pbmac1AlgIDArray,
+      jobject hmacAlgorithm)
+  {
+      PK11SlotInfo *slot = NULL;
+      SECItem *password = NULL;
+      SECItem *data = NULL;
+      SECItem *pbmac1AlgIDItem = NULL;
+      SECOidTag hmacAlgTag;
+      PK11SymKey *key = NULL;
+      SECAlgorithmID *pbmac1AlgID = NULL;
+      PK11Context *context = NULL;
+      SECItem macItem = {siBuffer, NULL, 0};
+      jbyteArray result = NULL;
+      unsigned int macLen = 0;
+      CK_MECHANISM_TYPE hmacMech;
+      SECStatus rv;
+
+      PR_ASSERT(env != NULL && this != NULL);
+
+      if (token == NULL || passwordArray == NULL || pbmac1AlgIDArray == NULL ||
+          dataArray == NULL || hmacAlgorithm == NULL) {
+          JSS_throw(env, NULL_POINTER_EXCEPTION);
+          goto finish;
+      }
+
+      // Get slot from token
+      if (JSS_PK11_getTokenSlotPtr(env, token, &slot) != PR_SUCCESS) {
+          goto finish;
+      }
+
+      if (slot == NULL) {
+          JSS_throwMsg(env, TOKEN_EXCEPTION, "Failed to get slot from token");
+          goto finish;
+      }
+
+      // Convert Java byte arrays to SECItems
+      password = JSS_ByteArrayToSECItem(env, passwordArray);
+      if (password == NULL) {
+          goto finish;
+      }
+
+      // Convert PBKDF2 AlgorithmID bytes to SECItem
+      pbmac1AlgIDItem = JSS_ByteArrayToSECItem(env, pbmac1AlgIDArray);
+      if (pbmac1AlgIDItem == NULL) {
+           goto finish;
+      }
+
+      pbmac1AlgID = PR_Calloc(1, sizeof(SECAlgorithmID));
+      if (pbmac1AlgID == NULL) {
+          JSS_throw(env, OUT_OF_MEMORY_ERROR);
+          goto finish;
+      }
+
+      if (SEC_ASN1DecodeItem(
+          NULL,
+          pbmac1AlgID,
+          SEC_ASN1_GET(SECOID_AlgorithmIDTemplate),
+          pbmac1AlgIDItem
+      ) != SECSuccess) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to decode PBMAC1 AlgorithmID");
+          goto finish;
+      }
+
+      data = JSS_ByteArrayToSECItem(env, dataArray);
+      if (data == NULL) {
+          goto finish;
+      }
+
+      // Convert HMAC algorithm to SECOidTag
+      hmacAlgTag = JSS_getOidTagFromAlg(env, hmacAlgorithm);
+      if (hmacAlgTag == SEC_OID_UNKNOWN) {
+          JSS_throwMsg(env, INVALID_PARAMETER_EXCEPTION,
+              "Unknown HMAC algorithm");
+          goto finish;
+      }
+
+      // Determine HMAC output length and mechanism based on algorithm
+      switch (hmacAlgTag) {
+          case SEC_OID_HMAC_SHA256:
+              macLen = 32;
+              hmacMech = CKM_SHA256_HMAC;
+              break;
+          case SEC_OID_HMAC_SHA384:
+              macLen = 48;
+              hmacMech = CKM_SHA384_HMAC;
+              break;
+          case SEC_OID_HMAC_SHA512:
+              macLen = 64;
+              hmacMech = CKM_SHA512_HMAC;
+              break;
+          default:
+              JSS_throwMsg(env, INVALID_PARAMETER_EXCEPTION,
+                  "Unsupported HMAC algorithm for PBMAC1");
+              goto finish;
+      }
+
+      key = PK11_PBEKeyGen(slot, pbmac1AlgID, password, PR_FALSE, NULL);
+
+      if (key == NULL) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to derive key for PBMAC1");
+          goto finish;
+      }
+
+      // Allocate buffer for HMAC output
+      macItem.data = (unsigned char *)PORT_Alloc(macLen);
+      if (macItem.data == NULL) {
+          JSS_throw(env, OUT_OF_MEMORY_ERROR);
+          goto finish;
+      }
+      macItem.len = macLen;
+
+      SECItem noParam = {siBuffer, NULL, 0};
+      context = PK11_CreateContextBySymKey(hmacMech, CKA_SIGN, key, &noParam);
+
+      if (context == NULL) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to create HMAC context for PBMAC1");
+          goto finish;
+      }
+
+      rv = PK11_DigestBegin(context);
+      if (rv != SECSuccess) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to begin HMAC operation");
+          goto finish;
+      }
+
+      rv = PK11_DigestOp(context, data->data, data->len);
+      if (rv != SECSuccess) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to process data for HMAC");
+          goto finish;
+      }
+
+      rv = PK11_DigestFinal(context, macItem.data, &macLen, macItem.len);
+      macItem.len = macLen;
+
+      if (rv != SECSuccess) {
+          JSS_throwMsgPrErr(env, TOKEN_EXCEPTION,
+              "Failed to finalize HMAC operation");
+          goto finish;
+      }
+
+      // Convert result to Java byte array
+      result = JSS_SECItemToByteArray(env, &macItem);
+
+  finish:
+      if (password != NULL) {
+          SECITEM_ZfreeItem(password, PR_TRUE);
+      }
+
+      if (pbmac1AlgIDItem != NULL) {
+          SECITEM_FreeItem(pbmac1AlgIDItem, PR_TRUE);
+      }
+
+      if (data != NULL) {
+          SECITEM_FreeItem(data, PR_TRUE);
+      }
+      if (pbmac1AlgID != NULL) {
+          SECOID_DestroyAlgorithmID(pbmac1AlgID, PR_TRUE);
+      }
+      if (key != NULL) {
+          PK11_FreeSymKey(key);
+      }
+      if (context != NULL) {
+          PK11_DestroyContext(context, PR_TRUE);
+      }
+      if (macItem.data != NULL) {
+          PORT_ZFree(macItem.data, macItem.len);
+      }
+
+      return result;
+  }

--- a/native/src/main/native/org/mozilla/jss/util/jssutil.c
+++ b/native/src/main/native/org/mozilla/jss/util/jssutil.c
@@ -1082,7 +1082,7 @@ JSS_ExportEncryptedPrivKeyInfoV2(
     // The size value from the first PK11_WrapPrivKey does not account for AES_BLOCK_SIZE
 
     if(isKeyWrapKWP) {
-      epki->encryptedData.len  += 8;
+      epki->encryptedData.len  += 16;
     }
 
     encBufLen = epki->encryptedData.len;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PBMAC1 (RFC 9879) added as an alternative PKCS#12 MAC; MAC scheme and digest are now configurable with secure defaults.
  * Public PBMAC1 parameter type and a public salt-length constant exposed for interoperability.
  * Native support for PBMAC1 MAC computation added.

* **Bug Fixes / Stability**
  * Stronger validation for MAC settings; null inputs rejected and sensitive data wiped.
  * Buffer sizing for a key-wrap mode adjusted for correctness.

* **Tests**
  * New PBMAC1 test covering HMAC/SHA variants, determinism, RFC vectors, and PKCS#12 export/import; integrated into the test suite.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/jss/pull/1088)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->