### PR TITLE
Update java build to java jdk 25

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '25'
         distribution: 'adopt'
 
     - name: Install dependencies
@@ -59,7 +59,7 @@ jobs:
             libopentest4j-java \
             libslf4j-java \
             maven \
-            openjdk-21-jdk \
+            openjdk-25-jdk \
             unzip \
             zip
 

--- a/.github/workflows/code-analysis-pull.yml
+++ b/.github/workflows/code-analysis-pull.yml
@@ -99,10 +99,10 @@ jobs:
           git fetch jss
           git rebase jss/${{ needs.retrieve-pr.outputs.pr-base }}
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 25
           distribution: 'adopt'
 
       - name: Cache SonarCloud packages

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 25
           distribution: 'adopt'
 
       - name: Cache SonarCloud packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'adopt'
 
       - name: Configure settings.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
           libnss3-tools \
           libopentest4j-java \
           libslf4j-java \
-          openjdk-21-jdk \
+          openjdk-25-jdk \
           unzip \
           zip
     displayName: Install build dependencies

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -64,7 +64,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>21</release>
+                    <release>23</release>
                     <compilerArgs>
                         <arg>-proc:none</arg>
                         <arg>-h</arg><arg>${project.build.directory}/include/_jni</arg>


### PR DESCRIPTION
KEM algorithms are supported from Java 23 so the jdk has to be updated in order to build the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated Java Development Kit version from 17/21 to 25 across all continuous integration and code analysis pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/jss/pull/1097)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->