### PR TITLE
Add ML-KEM and ML-DSA key archival and recovery support

### DIFF
--- a/base/src/main/java/org/mozilla/jss/JSSProvider.java
+++ b/base/src/main/java/org/mozilla/jss/JSSProvider.java
@@ -292,11 +292,15 @@ public final class JSSProvider extends java.security.Provider {
             "org.mozilla.jss.provider.java.security.KeyFactorySpi1_2");
         put("KeyFactory.EC",
             "org.mozilla.jss.provider.java.security.KeyFactorySpi1_2");
+        put("KeyFactory.ML-DSA",
+            "org.mozilla.jss.provider.java.security.KeyFactorySpi1_2");
         put("KeyFactory.ML-DSA-44",
             "org.mozilla.jss.provider.java.security.KeyFactorySpi1_2");
         put("KeyFactory.ML-DSA-65",
             "org.mozilla.jss.provider.java.security.KeyFactorySpi1_2");
         put("KeyFactory.ML-DSA-87",
+            "org.mozilla.jss.provider.java.security.KeyFactorySpi1_2");
+        put("KeyFactory.ML-KEM",
             "org.mozilla.jss.provider.java.security.KeyFactorySpi1_2");
         put("KeyFactory.ML-KEM-512",
             "org.mozilla.jss.provider.java.security.KeyFactorySpi1_2");

--- a/base/src/main/java/org/mozilla/jss/crypto/PrivateKey.java
+++ b/base/src/main/java/org/mozilla/jss/crypto/PrivateKey.java
@@ -19,6 +19,16 @@ public interface PrivateKey extends java.security.PrivateKey {
     public static final Type RSA = Type.RSA;
     public static final Type DSA = Type.DSA;
     public static final Type EC = Type.EC;
+    public static final Type MLKEM512 = Type.MLKEM512;
+    public static final Type MLKEM768 = Type.MLKEM768;
+    /** Generic ML-KEM alias; resolves to ML-KEM-768 (NIST security level 3). */
+    public static final Type MLKEM = Type.MLKEM;
+    public static final Type MLKEM1024 = Type.MLKEM1024;
+    public static final Type MLDSA44 = Type.MLDSA44;
+    public static final Type MLDSA65 = Type.MLDSA65;
+    /** Generic ML-DSA alias; resolves to ML-DSA-65 (NIST security level 3). */
+    public static final Type MLDSA = Type.MLDSA;
+    public static final Type MLDSA87 = Type.MLDSA87;
     public static final Type DiffieHellman = Type.DiffieHellman;
 
     /**
@@ -115,6 +125,7 @@ public interface PrivateKey extends java.security.PrivateKey {
                 OBJECT_IDENTIFIER.KEM_ALGORITHM.subBranch(1), "ML-KEM-512", CKK_ML_KEM);
         public static final Type MLKEM768 = new Type(
                 OBJECT_IDENTIFIER.KEM_ALGORITHM.subBranch(2), "ML-KEM-768", CKK_ML_KEM);
+        /** Generic ML-KEM alias; resolves to ML-KEM-768 (NIST security level 3). */
         public static final Type MLKEM = MLKEM768;
         public static final Type MLKEM1024 = new Type(
                 OBJECT_IDENTIFIER.KEM_ALGORITHM.subBranch(3), "ML-KEM-1024", CKK_ML_KEM);
@@ -122,6 +133,7 @@ public interface PrivateKey extends java.security.PrivateKey {
                 OBJECT_IDENTIFIER.SIGN_ALGORITHM.subBranch(17), "ML-DSA-44", CKK_ML_DSA);
         public static final Type MLDSA65 = new Type(
                 OBJECT_IDENTIFIER.SIGN_ALGORITHM.subBranch(18), "ML-DSA-65", CKK_ML_DSA);
+        /** Generic ML-DSA alias; resolves to ML-DSA-65 (NIST security level 3). */
         public static final Type MLDSA = MLDSA65;
         public static final Type MLDSA87 = new Type(
                 OBJECT_IDENTIFIER.SIGN_ALGORITHM.subBranch(19), "ML-DSA-87", CKK_ML_DSA);

--- a/base/src/main/java/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs11/PK11KeyWrapper.java
@@ -27,6 +27,8 @@ import org.mozilla.jss.crypto.KeyWrapper;
 import org.mozilla.jss.crypto.PrivateKey;
 import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.TokenException;
+import org.mozilla.jss.asn1.BIT_STRING;
+import org.mozilla.jss.pkix.primitive.SubjectPublicKeyInfo;
 import org.mozilla.jss.util.NativeEnclosure;
 import org.mozilla.jss.util.NativeProxy;
 import org.slf4j.Logger;
@@ -434,8 +436,10 @@ public final class PK11KeyWrapper implements KeyWrapper {
 
         byte[] publicValue = extractPublicValue(publicKey, type);
         /* If first byte is null, omit it.
-         * It can be null due to how BigInteger.toByteArray() is specified. */
-        if (publicValue.length > 0 && publicValue[0] == 0) {
+         * It can be null due to how BigInteger.toByteArray() is specified.
+         * Only apply this to RSA/DSA which use BigInteger, not to raw byte types (EC, ML-KEM, ML-DSA). */
+        if ((type == PrivateKey.RSA || type == PrivateKey.DSA) &&
+            publicValue.length > 0 && publicValue[0] == 0) {
             publicValue = Arrays.copyOfRange(publicValue, 1, publicValue.length);
         }
 
@@ -502,6 +506,29 @@ public final class PK11KeyWrapper implements KeyWrapper {
                     "match type of private key which is DSA");
             }
             return ((DSAPublicKey)publicKey).getY().toByteArray();
+        } else if (type == PrivateKey.MLKEM512 || type == PrivateKey.MLKEM768 ||
+                   type == PrivateKey.MLKEM1024 ||
+                   type == PrivateKey.MLDSA44  || type == PrivateKey.MLDSA65 ||
+                   type == PrivateKey.MLDSA87) {
+            // Extract raw public key bytes from SubjectPublicKeyInfo for PQC keys.
+            // TODO: Replace with PK11MLKEMPublicKey/PK11MLDSAPublicKey.getKeyByteArray()
+            //       when available in JSS.
+            try {
+                SubjectPublicKeyInfo spki = new SubjectPublicKeyInfo(publicKey);
+                BIT_STRING publicKeyBits = spki.getSubjectPublicKey();
+
+                // Verify byte-alignment (ML-KEM/ML-DSA keys are always whole bytes per FIPS 203/204)
+                if (publicKeyBits.getPadCount() != 0) {
+                    throw new InvalidKeyException(
+                        "PQC public key BIT STRING has unexpected padding bits: " +
+                        publicKeyBits.getPadCount());
+                }
+
+                return publicKeyBits.getBits();
+            } catch (org.mozilla.jss.asn1.InvalidBERException e) {
+                throw new InvalidKeyException(
+                    "Failed to extract " + type + " public key from SPKI", e);
+            }
         } else {
             throw new InvalidKeyException("Unknown private key type: " + type);
         }
@@ -666,10 +693,17 @@ public final class PK11KeyWrapper implements KeyWrapper {
             return KeyPairAlgorithm.RSAFamily;
         } else if (type == PrivateKey.DSA) {
             return KeyPairAlgorithm.DSAFamily;
-        } else {
-            assert( type == PrivateKey.EC);
+        } else if (type == PrivateKey.EC) {
             return KeyPairAlgorithm.ECFamily;
-	}
+        } else if (type == PrivateKey.MLKEM512 || type == PrivateKey.MLKEM768 ||
+                   type == PrivateKey.MLKEM1024) {
+            return KeyPairAlgorithm.MLKEMFamily;
+        } else if (type == PrivateKey.MLDSA44 || type == PrivateKey.MLDSA65 ||
+                   type == PrivateKey.MLDSA87) {
+            return KeyPairAlgorithm.MLDSAFamily;
+        } else {
+            throw new IllegalArgumentException("Unknown private key type: " + type);
+        }
     }
 
     private static Algorithm

--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyWrapper.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyWrapper.c
@@ -425,7 +425,16 @@ Java_org_mozilla_jss_pkcs11_PK11KeyWrapper_nativeUnwrapPrivWithSym
         goto finish;
     }
 
-    keyType = PK11_GetKeyType(keyTypeMech, 0);
+    /* Workaround: NSS PK11_GetKeyType() doesn't map PKCS#11 v3.2 PQC mechanisms
+     * Without this, it returns CKK_GENERIC_SECRET (0x10) which also works,
+     * but using the proper key types is clearer and more correct */
+    if (keyTypeMech == CKM_ML_KEM_KEY_PAIR_GEN || keyTypeMech == CKM_ML_KEM) {
+        keyType = CKK_ML_KEM;  /* 0x49 from PKCS#11 v3.2 */
+    } else if (keyTypeMech == CKM_ML_DSA_KEY_PAIR_GEN || keyTypeMech == CKM_ML_DSA) {
+        keyType = CKK_ML_DSA;  /* 0x48 from PKCS#11 v3.2 */
+    } else {
+        keyType = PK11_GetKeyType(keyTypeMech, 0);
+    }
 
     /* special case nethsm and lunasa*/
     if( isNethsm ) {
@@ -465,6 +474,26 @@ Java_org_mozilla_jss_pkcs11_PK11KeyWrapper_nativeUnwrapPrivWithSym
     case CKK_X9_42_DH:
         attribs[0] = CKA_DERIVE;
         numAttribs = 1;
+	break;
+    case CKK_ML_KEM:
+        /* ML-KEM is a KEM (Key Encapsulation Mechanism), not a signature key
+         * Set CKA_DECAPSULATE to indicate intended usage per PKCS#11 v3.2 */
+        numAttribs = 1;
+        attribs[0] = CKA_DECAPSULATE;
+        if (isExtractable) {
+            attribs[1] = CKA_EXTRACTABLE;
+            numAttribs = 2;
+        }
+	break;
+    case CKK_ML_DSA:
+        /* ML-DSA is a digital signature algorithm
+         * Set CKA_SIGN to indicate intended usage per PKCS#11 v3.2 */
+        numAttribs = 1;
+        attribs[0] = CKA_SIGN;
+        if (isExtractable) {
+            attribs[1] = CKA_EXTRACTABLE;
+            numAttribs = 2;
+        }
 	break;
     default:
         /* unknown key type */


### PR DESCRIPTION
    This commit adds support for ML-KEM (Module-Lattice-Based Key
    Encapsulation Mechanism) and ML-DSA (Module-Lattice-Based Digital
    Signature Algorithm) key archival and recovery in JSS.
    
    - JSSProvider.java: Add KeyFactory.ML-KEM and KeyFactory.ML-DSA
      generic aliases for KeyFactory support
    
    - PrivateKey.java:
      * Add top-level constants for both ML-KEM and ML-DSA
        (MLKEM512, MLKEM768, MLKEM, MLKEM1024, MLDSA44, MLDSA65, MLDSA, MLDSA87)
      * Add javadoc documenting generic aliases (MLKEM→MLKEM768, MLDSA→MLDSA65)
    
    - PK11KeyWrapper.java:
      * Add unified ML-KEM and ML-DSA public key extraction using SubjectPublicKeyInfo
        (de-duplicated into single branch for easier maintenance)
      * Add BIT_STRING padding verification to ensure byte-alignment per FIPS 203/204
      * Update algFromType() to return MLKEMFamily and MLDSAFamily
      * Fix leading-zero stripping to only apply to RSA/DSA (preserves EC/PQC bytes)
      * Catch specific InvalidBERException instead of generic Exception
    
    - PK11KeyWrapper.c:
      * Add workarounds for NSS PK11_GetKeyType() not mapping ML-KEM and ML-DSA mechanisms
      * Add CKK_ML_KEM case with CKA_DECAPSULATE attribute per PKCS#11 v3.2
        (KEMs use CKA_DECAPSULATE, similar to DH/ECDH using CKA_DERIVE)
      * Add CKK_ML_DSA case with CKA_SIGN attribute per PKCS#11 v3.2
        (ML-DSA is a signature algorithm)
    
    ML-KEM support has been tested and verified to work with hsmCompatVerify tool.
    ML-DSA support is added for forward-thinking purposes. It is untested but
    follows the same pattern as ML-KEM.
    
    IDM-5475 IDM-5817 IDM-6295
    Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for post-quantum cryptography algorithms: ML-DSA (variants 44, 65, 87) and ML-KEM (variants 512, 768, 1024)
  * Extended KeyFactory provider to support generic algorithm names for post-quantum algorithms
  * Enabled proper key unwrapping and extraction for post-quantum key types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/jss/pull/1098)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->