### PR TITLE
Fix default ML-DSA signing

### DIFF
--- a/base/src/main/java/org/mozilla/jss/crypto/SignatureAlgorithm.java
+++ b/base/src/main/java/org/mozilla/jss/crypto/SignatureAlgorithm.java
@@ -121,8 +121,6 @@ public class SignatureAlgorithm extends Algorithm {
     MLDSA65 = new SignatureAlgorithm(CKM_ML_DSA, "ML-DSA-65",
             null, null, OBJECT_IDENTIFIER.SIGN_ALGORITHM.subBranch(18) );
 
-    public static final SignatureAlgorithm MLDSA = MLDSA65;
-
     public static final SignatureAlgorithm
     MLDSA87 = new SignatureAlgorithm(CKM_ML_DSA, "ML-DSA-87",
             null, null, OBJECT_IDENTIFIER.SIGN_ALGORITHM.subBranch(19) );

--- a/base/src/main/java/org/mozilla/jss/netscape/security/util/Cert.java
+++ b/base/src/main/java/org/mozilla/jss/netscape/security/util/Cert.java
@@ -79,8 +79,6 @@ public class Cert {
             return SignatureAlgorithm.RSAPSSSignatureWithSHA384Digest;
         else if (algname.equals("SHA512withRSA/PSS"))
             return SignatureAlgorithm.RSAPSSSignatureWithSHA512Digest;
-        else if (algname.equals("ML-DSA"))
-            return SignatureAlgorithm.MLDSA;
         else if (algname.equals("ML-DSA-44"))
             return SignatureAlgorithm.MLDSA44;
         else if (algname.equals("ML-DSA-65"))

--- a/base/src/main/java/org/mozilla/jss/provider/java/security/JSSSignatureSpi.java
+++ b/base/src/main/java/org/mozilla/jss/provider/java/security/JSSSignatureSpi.java
@@ -13,13 +13,17 @@ import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.SignatureException;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.NamedParameterSpec;
 import java.security.spec.X509EncodedKeySpec;
+import org.mozilla.jss.asn1.ASN1Util;
 
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.PrivateKey;
 import org.mozilla.jss.crypto.SignatureAlgorithm;
 import org.mozilla.jss.crypto.TokenException;
 import org.mozilla.jss.crypto.TokenSupplierManager;
+import org.mozilla.jss.pkcs11.KeyType;
+import org.mozilla.jss.pkix.primitive.SubjectPublicKeyInfo;
 
 public class JSSSignatureSpi extends java.security.SignatureSpi {
 
@@ -74,10 +78,28 @@ public class JSSSignatureSpi extends java.security.SignatureSpi {
             throw new InvalidKeyException();
         }
         privk = (PrivateKey)privateKey;
-
+        SignatureAlgorithm effectiveAlg = this.alg;
+        if (privk.getAlgorithm().equals(KeyType.MLDSA.toString()) &&
+                privk.getParams() instanceof NamedParameterSpec param) {
+            if (effectiveAlg == null) {
+                effectiveAlg = switch(param.getName()) {
+                    case "ML-DSA-44" -> SignatureAlgorithm.MLDSA44;
+                    case "ML-DSA-65" -> SignatureAlgorithm.MLDSA65;
+                    case "ML-DSA-87" -> SignatureAlgorithm.MLDSA87;
+                    default -> throw new NoSuchAlgorithmException("Signature algorithm not defined for " + param.getName());
+                };
+            } else {
+                if (!effectiveAlg.toString().equals(param.getName())) {
+                    throw new InvalidKeyException("Invalid " + param.getName() + " parameter for " + effectiveAlg);
+                }
+            }
+        }
         token = privk.getOwningToken();
 
-        return token.getSignatureContext(alg);
+        if (effectiveAlg == null) {
+            throw new NoSuchAlgorithmException("Signature algorithm not defined");
+        }
+        return token.getSignatureContext(effectiveAlg);
     }
 
     @Override
@@ -87,8 +109,6 @@ public class JSSSignatureSpi extends java.security.SignatureSpi {
         try {
             CryptoToken token =
               TokenSupplierManager.getTokenSupplier().getThreadToken();
-            sig = token.getSignatureContext(alg);
-
             // convert the public key into a JSS public key if necessary
             if( ! (publicKey instanceof org.mozilla.jss.pkcs11.PK11PubKey) ) {
                 if( ! publicKey.getFormat().equalsIgnoreCase("X.509") ) {
@@ -102,11 +122,24 @@ public class JSSSignatureSpi extends java.security.SignatureSpi {
                     publicKey.getAlgorithm(), "Mozilla-JSS");
                 publicKey = fact.generatePublic(encodedKey);
             }
-
+            SignatureAlgorithm effectiveAlg = this.alg;
+            if (publicKey.getAlgorithm().equals(KeyType.MLDSA.toString())) {
+                SignatureAlgorithm keyAlg = getKeyAlg(publicKey.getEncoded());
+                if (effectiveAlg == null) {
+                    effectiveAlg = keyAlg;
+                } else {
+                    if (!effectiveAlg.equals(keyAlg)) {
+                        throw new InvalidKeyException("Key variant " + keyAlg +
+                                  " does not match signature algorithm " + effectiveAlg);
+                    }
+                }
+            }
+            if (effectiveAlg == null) {
+              throw new NoSuchAlgorithmException("Signature algorithm not defined");
+            }
+            sig = token.getSignatureContext(effectiveAlg);
             sig.initVerify(publicKey);
-        } catch(NoSuchProviderException e) {
-            throw new InvalidKeyException("Unable to convert non-JSS key to JSS key: " + e.getMessage(), e);
-        } catch(java.security.spec.InvalidKeySpecException e) {
+        } catch(NoSuchProviderException | java.security.spec.InvalidKeySpecException e) {
             throw new InvalidKeyException("Unable to convert non-JSS key to JSS key: " + e.getMessage(), e);
         } catch(java.security.NoSuchAlgorithmException e) {
             throw new InvalidKeyException("Algorithm not supported: " + e.getMessage(), e);
@@ -189,6 +222,22 @@ public class JSSSignatureSpi extends java.security.SignatureSpi {
             "name/value parameters not supported");
     }
 
+    private SignatureAlgorithm getKeyAlg(byte[] encoded)
+            throws InvalidKeyException {
+        if (encoded == null) {
+            throw new InvalidKeyException("Unable to determine key algorithm");
+        }
+        try {
+            SubjectPublicKeyInfo spki = (SubjectPublicKeyInfo)
+                          ASN1Util.decode(new SubjectPublicKeyInfo.Template(), encoded);
+             SignatureAlgorithm keyAlg = SignatureAlgorithm.fromOID(
+                     spki.getAlgorithmIdentifier().getOID());
+             return keyAlg;
+        } catch (Exception ex) {
+            throw new InvalidKeyException("Unable to determine key algorithm", ex);
+        }
+    }
+
     @Deprecated(since="5.0.1", forRemoval=true)
     public static class DSA extends JSSSignatureSpi {
         public DSA() {
@@ -268,7 +317,7 @@ public class JSSSignatureSpi extends java.security.SignatureSpi {
     }
     public static class MLDSA extends JSSSignatureSpi {
         public MLDSA() {
-            super(SignatureAlgorithm.MLDSA65);
+            super(null);
         }
     }
     public static class MLDSA44 extends JSSSignatureSpi {

--- a/base/src/test/java/org/mozilla/jss/tests/GenerateTestCert.java
+++ b/base/src/test/java/org/mozilla/jss/tests/GenerateTestCert.java
@@ -109,7 +109,7 @@ public class GenerateTestCert {
         } else if (alg.equalsIgnoreCase("SHA-512/EC")) {
             sigAlg = SignatureAlgorithm.ECSignatureWithSHA512Digest;
         } else if (alg.equalsIgnoreCase("ML-DSA")) {
-            sigAlg = SignatureAlgorithm.MLDSA;
+            sigAlg = SignatureAlgorithm.MLDSA65;
         } else { usage(); }
 
         if (alg.endsWith("RSA")) {

--- a/base/src/test/java/org/mozilla/jss/tests/JCASigTest.java
+++ b/base/src/test/java/org/mozilla/jss/tests/JCASigTest.java
@@ -4,6 +4,7 @@
 
 package org.mozilla.jss.tests;
 
+import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
@@ -144,6 +145,7 @@ public class JCASigTest {
                 System.exit(1);
             }
 
+            // Test with ML-DSA-44 key and generic ML-DSA signature
             sigTest("ML-DSA", keyPair);
 
             kpgen = java.security.KeyPairGenerator.getInstance("ML-DSA");
@@ -160,6 +162,8 @@ public class JCASigTest {
                 System.exit(1);
             }
 
+            // Test with generic ML-DSA key (convert to ML-DSA-65) and
+            // generic ML-DSA signature
             sigTest("ML-DSA", keyPair);
 
             kpgen = java.security.KeyPairGenerator.getInstance("ML-DSA-87");
@@ -176,8 +180,19 @@ public class JCASigTest {
                 System.exit(1);
             }
 
+            // Test with generic ML-DSA-87 key and generic ML-DSA signature
             sigTest("ML-DSA", keyPair);
-            
+
+            // Test with generic ML-DSA-87 key and ML-DSA-44 signature. It throws
+            // InvalidKeyException and because of key signature mismatch 
+            try {
+                sigTest("ML-DSA-44", keyPair);
+                assert(false);
+            } catch(InvalidKeyException ex) {
+            }
+
+            // Test with generic ML-DSA-87 key and ML-DSA-87 signature 
+            sigTest("ML-DSA-87", keyPair);
         }
     }
 }


### PR DESCRIPTION
According to JEP 497 [1], the ML-DSA signature algorithm should behave as follows:
- When instantiated as "ML-DSA" (generic), it accepts any ML-DSA-44, ML-DSA-65, or ML-DSA-87 key and uses the key's variant
- When instantiated with a specific variant (e.g., "ML-DSA-65"), it only accepts keys of that variant, throwing InvalidKeyException otherwise

Previously, the generic "ML-DSA" was hardcoded to "ML-DSA-65", which worked in practice because NSS uses the key's variant regardless of the signature algorithm parameter. However, this violated the JEP 497 specification.

This commit implements the correct behavior:
- Generic ML-DSA signature extracts the variant from the key (NamedParameterSpec for private keys, OID from X.509 encoding for public keys)
- Specific ML-DSA variants validate that the key matches

1. https://openjdk.org/jeps/497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the ML-DSA-87 signature variant.
  * Signature variant is now auto-detected from key parameters or encoded public key.

* **Breaking Changes**
  * The generic "ML-DSA" name no longer resolves; callers must use ML-DSA-44, ML-DSA-65, or ML-DSA-87 explicitly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/jss/pull/1103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->