### PR TITLE
Add build options for ML-DSA and ML-KEM

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -64,7 +64,11 @@ jobs:
             zip
 
     - name: Build with CMake
-      run: ./build.sh
+      run: |
+        # the current NSS on Debian/Ubuntu does not support ML-DSA nor ML-KEM
+        # https://wiki.debian.org/DebianReleases
+        # https://packages.debian.org/source/trixie/nss
+        ./build.sh --without-mldsa --without-mlkem
 
     - name: Build with Maven
       run: mvn --batch-mode package
@@ -114,7 +118,8 @@ jobs:
 
     - name: Build with CMake
       run: |
-        docker exec jss ./build.sh --cmake='/usr/bin/cmake -DENABLE_NSS_VERSION_PQC_DEF=ON'
+        # the current NSS on Fedora supports ML-DSA and ML-KEM
+        docker exec jss ./build.sh
 
     - name: Build with Maven
       run: |
@@ -314,7 +319,8 @@ jobs:
 
     - name: Build JSS
       run: |
-        docker exec -w /root/jss/build jss cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_NSS_VERSION_PQC_DEF=ON ..
+        # the current NSS on Fedora supports ML-DSA and ML-KEM
+        docker exec -w /root/jss/build jss cmake -DCMAKE_BUILD_TYPE=Debug ..
         docker exec -w /root/jss/build jss make all
       env:
         SANDBOX: 1

--- a/.github/workflows/external-application-connection-tests.yml
+++ b/.github/workflows/external-application-connection-tests.yml
@@ -138,7 +138,9 @@ jobs:
               -c ssl_key_file=/var/lib/postgresql/server.key
 
       - name: Build the tests
-        run: docker exec jss ./build.sh --work-dir=./build --cmake='/usr/bin/cmake -DENABLE_NSS_VERSION_PQC_DEF=ON'
+        run: |
+          # the current NSS on Fedora supports ML-DSA and ML-KEM
+          docker exec jss ./build.sh --work-dir=./build
 
       - name: Test connection with java
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,12 @@ option(TEST_WITH_INTERNET "When enabled, runs various tests which require an int
 # that need to be reflected into JSS SSLCipher.c (auth_alg_defs[])
 # Some OS platforms not yet have such defs.
 #
-option(ENABLE_NSS_VERSION_PQC_DEF "Enable PQC DEF to match NSS" OFF)
+option(WITH_MLDSA "Enable ML-DSA" ON)
+option(WITH_MLKEM "Enable ML-KEM" ON)
+
+if (NOT WITH_MLDSA)
+    set(WITH_MLKEM OFF)
+endif()
 
 option(WITH_JAVA "Build Java binaries." TRUE)
 option(WITH_NATIVE "Build native binaries." TRUE)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,8 @@ jobs:
     displayName: Install build dependencies
 
   - script: |
-      docker exec -w /root/src runner ./build.sh --cmake='/usr/bin/cmake -DENABLE_NSS_VERSION_PQC_DEF=ON'
+      # the current NSS on Fedora supports ML-DSA and ML-KEM
+      docker exec -w /root/src runner ./build.sh
     displayName: Build JSS binaries, Javadoc, and run tests
 
 - job: BuildTest_apt
@@ -97,7 +98,11 @@ jobs:
           zip
     displayName: Install build dependencies
 
-  - script: ./build.sh
+  - script: |
+      # the current NSS on Debian/Ubuntu does not support ML-DSA nor ML-KEM
+      # https://wiki.debian.org/DebianReleases
+      # https://packages.debian.org/source/trixie/nss
+      ./build.sh --without-mldsa --without-mlkem
     displayName: Build JSS binaries, Javadoc, and run tests
     env:
       JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64

--- a/base/src/test/java/org/mozilla/jss/tests/JCASigTest.java
+++ b/base/src/test/java/org/mozilla/jss/tests/JCASigTest.java
@@ -66,7 +66,7 @@ public class JCASigTest {
     }
 
     public static void main(String args[]) throws Exception {
-        boolean testPQC = Boolean.parseBoolean(System.getProperty("test.NSS_PQC", "False"));
+        boolean testMLDSA = Boolean.parseBoolean(System.getProperty("TEST_MLDSA", "true"));
 
         CryptoManager manager;
         KeyPairGenerator kpgen;
@@ -130,7 +130,7 @@ public class JCASigTest {
         sigTest("SHA-384/EC", keyPair);
         sigTest("SHA-512/EC", keyPair);
 
-        if (testPQC) {
+        if (testMLDSA) {
             kpgen = java.security.KeyPairGenerator.getInstance("ML-DSA-44");
             keyPair = kpgen.genKeyPair();
             provider = kpgen.getProvider();
@@ -184,14 +184,14 @@ public class JCASigTest {
             sigTest("ML-DSA", keyPair);
 
             // Test with generic ML-DSA-87 key and ML-DSA-44 signature. It throws
-            // InvalidKeyException and because of key signature mismatch 
+            // InvalidKeyException and because of key signature mismatch
             try {
                 sigTest("ML-DSA-44", keyPair);
                 assert(false);
             } catch(InvalidKeyException ex) {
             }
 
-            // Test with generic ML-DSA-87 key and ML-DSA-87 signature 
+            // Test with generic ML-DSA-87 key and ML-DSA-87 signature
             sigTest("ML-DSA-87", keyPair);
         }
     }

--- a/base/src/test/java/org/mozilla/jss/tests/TestKeyGen.java
+++ b/base/src/test/java/org/mozilla/jss/tests/TestKeyGen.java
@@ -31,7 +31,8 @@ import org.mozilla.jss.util.Base64OutputStream;
 public class TestKeyGen {
 
     public static void main(String[] args) {
-      boolean testPQC = Boolean.parseBoolean(System.getProperty("test.NSS_PQC", "False"));
+        boolean testMLDSA = Boolean.parseBoolean(System.getProperty("TEST_MLDSA", "true"));
+        boolean testMLKEM = Boolean.parseBoolean(System.getProperty("TEST_MLKEM", "true"));
       try {
         CryptoManager manager;
         java.security.KeyPair keyPair;
@@ -62,7 +63,7 @@ public class TestKeyGen {
 
         //Get rid of all the DSA keygen tests and the small keysize and exponent RSA tests.
         //This is due to evolving nss policy changes away from weaker algs.
-      
+
         // 2048-bit RSA with default exponent
         System.out.println("Generating 2048-bit RSA KeyPair!");
         for (int cntr=0; cntr<5; cntr++ ) {
@@ -97,7 +98,7 @@ public class TestKeyGen {
         keyPair = kpg.genKeyPair();
         System.out.println("Generated 521-bit EC KeyPair!");
 
-        if (testPQC) {
+        if (testMLDSA) {
             // ML-DSA default
             kpg = java.security.KeyPairGenerator.getInstance("ML-DSA", "Mozilla-JSS");
             kpg.initialize(44);
@@ -134,7 +135,9 @@ public class TestKeyGen {
             kpg.initialize(param);
             keyPair = kpg.genKeyPair();
             System.out.println("Generated ML-DSA with parameter ML-DSA-87!");
+        }
 
+        if (testMLKEM) {
             // ML-KEM-768 initialisation
             kpg = java.security.KeyPairGenerator.getInstance("ML-KEM-768", "Mozilla-JSS");
             keyPair = kpg.genKeyPair();
@@ -142,7 +145,7 @@ public class TestKeyGen {
 
             // ML-KEM-768 initialisation with named parameter
             kpg = java.security.KeyPairGenerator.getInstance("ML-KEM", "Mozilla-JSS");
-            param = new NamedParameterSpec("ML-KEM-768");
+            NamedParameterSpec param = new NamedParameterSpec("ML-KEM-768");
             kpg.initialize(param);
             keyPair = kpg.genKeyPair();
             System.out.println("Generated ML-KEM with parameter ML-KEM-768!");

--- a/build.sh
+++ b/build.sh
@@ -40,6 +40,9 @@ WITH_TIMESTAMP=
 WITH_COMMIT_ID=
 DIST=
 
+WITH_MLDSA=true
+WITH_MLKEM=true
+
 WITH_JAVA=true
 WITH_NATIVE=true
 WITH_JAVADOC=true
@@ -69,6 +72,8 @@ usage() {
     echo "    --with-timestamp       Append timestamp to RPM version number."
     echo "    --with-commit-id       Append commit ID to RPM version number."
     echo "    --dist=<name>          Distribution name (e.g. fc28)."
+    echo "    --without-mldsa        Do not enable ML-DSA."
+    echo "    --without-mlkem        Do not enable ML-KEM."
     echo "    --without-java         Do not build Java binaries."
     echo "    --without-native       Do not build native binaries."
     echo "    --without-javadoc      Do not build Javadoc package."
@@ -246,6 +251,13 @@ while getopts v-: arg ; do
             ;;
         dist=?*)
             DIST="$LONG_OPTARG"
+            ;;
+        without-mldsa)
+            WITH_MLDSA=false
+            WITH_MLKEM=false
+            ;;
+        without-mlkem)
+            WITH_MLKEM=false
             ;;
         without-java)
             WITH_JAVA=false
@@ -453,6 +465,14 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
 
     if [ "$PHASE" != "" ] ; then
         OPTIONS+=(-DPHASE="$PHASE")
+    fi
+
+    if [ "$WITH_MLDSA" = false ] ; then
+        OPTIONS+=(-DWITH_MLDSA=FALSE)
+    fi
+
+    if [ "$WITH_MLKEM" = false ] ; then
+        OPTIONS+=(-DWITH_MLKEM=FALSE)
     fi
 
     if [ "$WITH_JAVA" = false ] ; then

--- a/cmake/JSSConfig.cmake
+++ b/cmake/JSSConfig.cmake
@@ -140,8 +140,12 @@ macro(jss_config_cflags)
         list(APPEND JSS_RAW_C_FLAGS "-O2")
     endif()
 
-    if(ENABLE_NSS_VERSION_PQC_DEF)
-        list(APPEND JSS_RAW_C_FLAGS "-DNSS_VERSION_PQC_DEF")
+    if(WITH_MLDSA)
+        list(APPEND JSS_RAW_C_FLAGS "-DJSS_MLDSA_ENABLED")
+    endif()
+
+    if(WITH_MLKEM)
+        list(APPEND JSS_RAW_C_FLAGS "-DJSS_MLKEM_ENABLED")
     endif()
 
     list(APPEND JSS_RAW_C_FLAGS "-Wall")

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -177,7 +177,7 @@ macro(jss_tests)
         COMMAND "org.mozilla.jss.tests.GenerateTestCert" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}" "30" "localhost" "SHA-256/EC" "CA_ECDSA" "Server_ECDSA" "Client_ECDSA"
         DEPENDS "Generate_known_RSA_cert_pair"
     )
-    if(ENABLE_NSS_VERSION_PQC_DEF)
+    if(WITH_MLDSA)
         jss_test_java(
             NAME "Generate_known_MLDSA_cert_pair"
 	    COMMAND "org.mozilla.jss.tests.GenerateTestCert" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}" "40" "localhost" "ML-DSA" "CA_MLDSA" "Server_MLDSA" "Client_MLDSA"
@@ -224,7 +224,7 @@ macro(jss_tests)
         COMMAND "org.mozilla.jss.tests.JCAKeyWrap" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
         DEPENDS "Setup_DBs"
     )
-    if(ENABLE_NSS_VERSION_PQC_DEF)
+    if(WITH_MLKEM)
         jss_test_java(
             NAME "KeyEncapsulating"
 	    COMMAND "org.mozilla.jss.tests.KeyEncapsulating" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}"
@@ -319,7 +319,7 @@ macro(jss_tests)
 	COMMAND "org.mozilla.jss.tests.TestSSLEngine" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}" "Client_ECDSA" "Server_RSA,Server_ECDSA"
         DEPENDS "SSLEngine_RSA"
     )
-    if(ENABLE_NSS_VERSION_PQC_DEF)
+    if(WITH_MLDSA)
         jss_test_java(
             NAME "SSLEngine_MLDSA"
 	    COMMAND "org.mozilla.jss.tests.TestSSLEngine" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}" "Client_MLDSA" "Server_MLDSA"
@@ -388,7 +388,7 @@ macro(jss_tests)
             DEPENDS "Generate_FIPS_known_RSA_cert_pair"
             MODE "FIPS"
         )
-        if(ENABLE_NSS_VERSION_PQC_DEF)
+        if(WITH_MLDSA)
             jss_test_java(
                 NAME "Generate_FIPS_known_MLDSA_cert_pair"
 	        COMMAND "org.mozilla.jss.tests.GenerateTestCert" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}" "40" "localhost" "ML-DSA" "CA_MLDSA" "Server_MLDSA" "Client_MLDSA"
@@ -439,7 +439,7 @@ macro(jss_tests)
             DEPENDS "Enable_FipsMODE"
             MODE "FIPS"
         )
-        if(ENABLE_NSS_VERSION_PQC_DEF)
+        if(WITH_MLKEM)
             jss_test_java(
                 NAME "KeyEncapsulating_FIPSMODE"
 		COMMAND "org.mozilla.jss.tests.KeyEncapsulating" "${RESULTS_NSSDB_FIPS_OUTPUT_DIR}" "${PASSWORD_FILE}"
@@ -483,7 +483,7 @@ macro(jss_tests)
             DEPENDS "SSLEngine_RSA_FIPSMODE" "SSLEngine_ECDSA"
             MODE "FIPS"
         )
-        if(ENABLE_NSS_VERSION_PQC_DEF)
+        if(WITH_MLDSA)
             jss_test_java(
                 NAME "SSLEngine_MLDSA_FIPSMODE"
 	        COMMAND "org.mozilla.jss.tests.TestSSLEngine" "${RESULTS_NSSDB_FIPS_OUTPUT_DIR}" "${PASSWORD_FILE}" "Client_MLDSA" "Server_MLDSA"
@@ -587,8 +587,12 @@ function(jss_test_java)
         list(APPEND EXEC_COMMAND "-Djava.util.logging.config.file=${PROJECT_SOURCE_DIR}/tools/logging.properties")
     endif()
 
-    if(ENABLE_NSS_VERSION_PQC_DEF)
-        list(APPEND EXEC_COMMAND "-Dtest.NSS_PQC=True")
+    if(NOT WITH_MLDSA)
+        list(APPEND EXEC_COMMAND "-DTEST_MLDSA=false")
+    endif()
+
+    if(NOT WITH_MLKEM)
+        list(APPEND EXEC_COMMAND "-DTEST_MLKEM=false")
     endif()
 
     set(EXEC_COMMAND "${EXEC_COMMAND};${TEST_JAVA_COMMAND}")

--- a/jss.spec
+++ b/jss.spec
@@ -70,13 +70,20 @@ ExcludeArch: i686
 # NSS
 ################################################################################
 
-# Support PQC on Fedora 42 and RHEL 8 or later.
+%if 0%{?rhel}
 
-%global         fedora_pqc_support 42
-%global         rhel_pqc_support 8
+# the current NSS on RHEL only supports ML-DSA
+%define nss_version 3.112
+%global with_mldsa 1
+%undefine with_mlkem
 
-%if 0%{?fedora} >= %{fedora_pqc_support} || 0%{?rhel} >= %{rhel_pqc_support}
-%global enable_nss_version_pqc_def_flag -DENABLE_NSS_VERSION_PQC_DEF=ON
+%else
+
+# the current NSS on Fedora supports both ML-DSA and ML-DSA
+%define nss_version 3.123
+%global with_mldsa 1
+%global with_mlkem 1
+
 %endif
 
 ################################################################################
@@ -144,13 +151,8 @@ BuildRequires:  unzip
 
 BuildRequires:  gcc-c++
 
-%if 0%{?rhel}
-BuildRequires:  nss-devel >= 3.112
-BuildRequires:  nss-tools >= 3.112
-%else
-BuildRequires:  nss-devel >= 3.123
-BuildRequires:  nss-tools >= 3.123
-%endif
+BuildRequires:  nss-devel >= %{nss_version}
+BuildRequires:  nss-tools >= %{nss_version}
 
 BuildRequires:  %{java_devel}
 BuildRequires:  mvn(org.apache.commons:commons-lang3)
@@ -172,11 +174,7 @@ This only works with gcj. Other JREs require that JCE providers be signed.
 
 Summary:        %{product_name}
 
-%if 0%{?rhel}
-Requires:       nss >= 3.112
-%else
-Requires:       nss >= 3.123
-%endif
+Requires:       nss >= %{nss_version}
 
 Requires:       %{java_headless}
 Requires:       mvn(org.apache.commons:commons-lang3)
@@ -407,9 +405,11 @@ touch %{_vpath_builddir}/.targets/finished_generate_javadocs
     --lib-dir=%{_libdir} \
     --sysconf-dir=%{_sysconfdir} \
     --share-dir=%{_datadir} \
-    --cmake="%{__cmake} %{?enable_nss_version_pqc_def_flag}" \
+    --cmake="%{__cmake}" \
     --java-home=%{java_home} \
     --jni-dir=%{_jnidir} \
+    %{!?with_mldsa:--without-mldsa} \
+    %{!?with_mlkem:--without-mlkem} \
     %{?with_maven:--without-java} \
     %{?with_maven:--without-javadoc} \
     %{!?with_tests:--without-tests} \

--- a/native/src/main/native/org/mozilla/jss/crypto/Algorithm.c
+++ b/native/src/main/native/org/mozilla/jss/crypto/Algorithm.c
@@ -181,13 +181,15 @@ JSS_AlgInfo JSS_AlgTable[NUM_ALGS] = {
 
 /* 84 */    {SEC_OID_HMAC_SHA1, SEC_OID_TAG},
 
-#ifdef NSS_VERSION_PQC_DEF
+#ifdef JSS_MLDSA_ENABLED
 /* 85 */    {CKM_ML_DSA_KEY_PAIR_GEN, PK11_MECH},
 /* 86 */    {CKM_ML_DSA, PK11_MECH},
 /* 87 */    {SEC_OID_ML_DSA_SIGNATURE, SEC_OID_TAG},
 
+#ifdef JSS_MLKEM_ENABLED
 /* 88 */    {CKM_ML_KEM_KEY_PAIR_GEN, PK11_MECH},
 /* 89 */    {CKM_ML_KEM, PK11_MECH},
+#endif
 #endif
 
 /* REMEMBER TO UPDATE NUM_ALGS!!! (in Algorithm.h) */

--- a/native/src/main/native/org/mozilla/jss/crypto/Algorithm.h
+++ b/native/src/main/native/org/mozilla/jss/crypto/Algorithm.h
@@ -24,11 +24,16 @@ typedef struct JSS_AlgInfoStr {
     JSS_AlgType type;
 } JSS_AlgInfo;
 
-#ifdef NSS_VERSION_PQC_DEF
+#ifdef JSS_MLDSA_ENABLED
+#ifdef JSS_MLKEM_ENABLED
 #define NUM_ALGS 90
+#else
+#define NUM_ALGS 88
+#endif
 #else
 #define NUM_ALGS 85
 #endif
+
 extern JSS_AlgInfo JSS_AlgTable[];
 extern CK_ULONG JSS_symkeyUsage[];
 

--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11KeyPairGenerator.c
@@ -435,7 +435,7 @@ Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateMLDSAKeyPair
   (JNIEnv *env, jobject this, jobject token, jint size, 
     jboolean temporary, jint sensitive, jint extractable)
 {
-#ifdef NSS_VERSION_PQC_DEF
+#ifdef JSS_MLDSA_ENABLED
     jobject keyPair=NULL;
 
     CK_ML_DSA_PARAMETER_SET_TYPE  param;
@@ -480,7 +480,7 @@ Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateMLDSAKeyPairWithOpFlags
     jboolean temporary, jint sensitive, jint extractable,
     jint op_flags, jint op_flags_mask)
 {
-#ifdef NSS_VERSION_PQC_DEF
+#ifdef JSS_MLDSA_ENABLED
     jobject keyPair=NULL;
 
     CK_ML_DSA_PARAMETER_SET_TYPE  param;
@@ -501,7 +501,6 @@ Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateMLDSAKeyPairWithOpFlags
     } 
 
     PR_ASSERT(env!=NULL && this!=NULL && token!=NULL);
-
 
     keyPair = PK11KeyPairGeneratorWithOpFlags(env, this, token,
                 CKM_ML_DSA_KEY_PAIR_GEN, &param, temporary, 
@@ -526,7 +525,7 @@ Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateMLKEMKeyPair
   (JNIEnv *env, jobject this, jobject token, jint size,
     jboolean temporary, jint sensitive, jint extractable)
 {
-#ifdef NSS_VERSION_PQC_DEF
+#ifdef JSS_MLKEM_ENABLED
     jobject keyPair=NULL;
 
     CK_ML_KEM_PARAMETER_SET_TYPE  param;
@@ -568,7 +567,7 @@ Java_org_mozilla_jss_pkcs11_PK11KeyPairGenerator_generateMLKEMKeyPairWithOpFlags
     jboolean temporary, jint sensitive, jint extractable,
     jint op_flags, jint op_flags_mask)
 {
-#ifdef NSS_VERSION_PQC_DEF
+#ifdef JSS_MLKEM_ENABLED
     jobject keyPair=NULL;
 
     CK_ML_KEM_PARAMETER_SET_TYPE  param;

--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11PrivKey.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11PrivKey.c
@@ -180,13 +180,15 @@ Java_org_mozilla_jss_pkcs11_PK11PrivKey_getKeyType
     case ecKey:
         keyTypeFieldName = EC_KEYTYPE_FIELD;
         break;
-#ifdef NSS_VERSION_PQC_DEF
-    case kyberKey:
-        keyTypeFieldName = MLKEM_KEYTYPE_FIELD;
-        break;
+#ifdef JSS_MLDSA_ENABLED
     case mldsaKey:
         keyTypeFieldName = MLDSA_KEYTYPE_FIELD;
         break;
+#ifdef JSS_MLKEM_ENABLED
+    case kyberKey:
+        keyTypeFieldName = MLKEM_KEYTYPE_FIELD;
+        break;
+#endif
 #endif
     default:
         PR_ASSERT(PR_FALSE);
@@ -233,7 +235,7 @@ Java_org_mozilla_jss_pkcs11_PK11PrivKey_getMLKeyParam
     PRThread * VARIABLE_MAY_NOT_BE_USED pThread;
     SECKEYPrivateKey *privk;
     CK_ULONG paramSet = CK_UNAVAILABLE_INFORMATION;
-#ifdef NSS_VERSION_PQC_DEF
+#ifdef JSS_MLDSA_ENABLED
     SECItem  item;
     SECStatus rv;
 #endif
@@ -249,9 +251,9 @@ Java_org_mozilla_jss_pkcs11_PK11PrivKey_getMLKeyParam
     }
     PR_ASSERT(privk!=NULL);
 
-// The implmenetation could be improved using MLDSA helper functions but for
+// The implementation could be improved using MLDSA helper functions but for
 // now they are kept private. 
-#ifdef NSS_VERSION_PQC_DEF
+#ifdef JSS_MLDSA_ENABLED
     rv =  PK11_ReadRawAttribute(PK11_TypePrivKey, privk, CKA_PARAMETER_SET, &item);
     if (rv != SECSuccess) {
         JSS_throwMsg(env, TOKEN_EXCEPTION, "Key type not supported.");
@@ -266,8 +268,8 @@ Java_org_mozilla_jss_pkcs11_PK11PrivKey_getMLKeyParam
     paramSet = *(CK_ULONG *)item.data;
     PORT_Free(item.data);
 #else
-        JSS_throwMsg(env, TOKEN_EXCEPTION, "Key type not supported.");
-        goto finish;
+    JSS_throwMsg(env, TOKEN_EXCEPTION, "Key type not supported.");
+    goto finish;
 #endif
 
 finish:
@@ -484,17 +486,24 @@ JSS_PK11_getKeyType(JNIEnv *env, jobject keyTypeObj)
         DH_KEYTYPE_FIELD,
         KEA_KEYTYPE_FIELD,
         EC_KEYTYPE_FIELD
-#ifdef NSS_VERSION_PQC_DEF
-       ,
-        MLDSA_KEYTYPE_FIELD,
-        MLKEM_KEYTYPE_FIELD
+#ifdef JSS_MLDSA_ENABLED
+        , MLDSA_KEYTYPE_FIELD
+#ifdef JSS_MLKEM_ENABLED
+        , MLKEM_KEYTYPE_FIELD
+#endif
 #endif
     };
-#ifdef NSS_VERSION_PQC_DEF
+
+#ifdef JSS_MLDSA_ENABLED
+#ifdef JSS_MLKEM_ENABLED
     int numTypes = 8;
+#else
+    int numTypes = 7;
+#endif
 #else
     int numTypes = 6;
 #endif
+
     KeyType keyTypes[] = {
         rsaKey,
         dsaKey,
@@ -502,10 +511,11 @@ JSS_PK11_getKeyType(JNIEnv *env, jobject keyTypeObj)
         dhKey,
         keaKey,
         ecKey
-#ifdef NSS_VERSION_PQC_DEF
-       ,
-        mldsaKey,
-        kyberKey
+#ifdef JSS_MLDSA_ENABLED
+        , mldsaKey
+#ifdef JSS_MLKEM_ENABLED
+        , kyberKey
+#endif
 #endif
     };
     jobject field;

--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11PubKey.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11PubKey.c
@@ -251,13 +251,15 @@ Java_org_mozilla_jss_pkcs11_PK11PubKey_getKeyType
     case keaKey:
         keyTypeFieldName = KEA_KEYTYPE_FIELD;
         break;
-#ifdef NSS_VERSION_PQC_DEF
-    case kyberKey:
-        keyTypeFieldName = MLKEM_KEYTYPE_FIELD;
-        break;
+#ifdef JSS_MLDSA_ENABLED
     case mldsaKey:
         keyTypeFieldName = MLDSA_KEYTYPE_FIELD;
         break;
+#ifdef JSS_MLKEM_ENABLED
+    case kyberKey:
+        keyTypeFieldName = MLKEM_KEYTYPE_FIELD;
+        break;
+#endif
 #endif
     default:
         PR_ASSERT(PR_FALSE);

--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11Store.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11Store.c
@@ -939,7 +939,7 @@ Java_org_mozilla_jss_pkcs11_PK11Store_importEncryptedPrivateKeyInfo(
         case ecKey:
             pubValue = &pubKey->u.ec.publicValue;
             break;
-#ifdef NSS_VERSION_PQC_DEF
+#ifdef JSS_MLDSA_ENABLED
         case mldsaKey:
             pubValue = &pubKey->u.mldsa.publicValue;
             break;

--- a/native/src/main/native/org/mozilla/jss/ssl/SSLCipher.c
+++ b/native/src/main/native/org/mozilla/jss/ssl/SSLCipher.c
@@ -19,15 +19,15 @@ static const CK_MECHANISM_TYPE auth_alg_defs[] = {
     CKM_RSA_PKCS,          /* ssl_auth_rsa_sign */
     CKM_RSA_PKCS_PSS,      /* ssl_auth_rsa_pss */
     CKM_NSS_HKDF_SHA256,   /* ssl_auth_psk (just check for HKDF) */
-#ifndef NSS_VERSION_PQC_DEF
     CKM_INVALID_MECHANISM  /* ssl_auth_tls13_any */
-#else
-    CKM_INVALID_MECHANISM,  /* ssl_auth_tls13_any */
+#ifdef JSS_MLDSA_ENABLED
+    ,
     CKM_ML_DSA,            /* ssl_auth_mldsa (same mech for each) */
-    CKM_ML_DSA,            /* ssl_auth_mldsa (key determines the*/
-    CKM_ML_DSA            /* ssl_auth_mldsa  parameter set) */
+    CKM_ML_DSA,            /* ssl_auth_mldsa (key determines the */
+    CKM_ML_DSA             /* ssl_auth_mldsa  parameter set) */
 #endif
 };
+
 PR_STATIC_ASSERT(PR_ARRAY_SIZE(auth_alg_defs) == ssl_auth_size);
 
 /* Copied from NSS 3.97's ssl3con.c. */


### PR DESCRIPTION
The build scripts have been updated to provide options to build without ML-DSA or ML-KEM since some platforms might only have a partial or no support of PQC. Note that if ML-DSA is disabled ML-KEM will be disabled as well, but ML-KEM can be disabled without affecting ML-DSA.

The following params have been replaced with more specific params:
- `ENABLE_NSS_VERSION_PQC_DEF`
- `NSS_VERSION_PQC_DEF`
- `test.NSS_PQC`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Independent build options to enable or disable ML-DSA and ML-KEM support.

* **Improvements**
  * CI, packaging, and native builds now align ML feature selection with platform NSS capabilities.
  * Test runs and JVM test flags respect the new ML-DSA/ML-KEM toggles.

* **Chores**
  * Replaced single PQC flag with separate ML-DSA/ML-KEM feature toggles across builds, packaging, and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->