### PR TITLE
Fix use-after-free crash in JSSEngineReferenceImpl finalizer

### DIFF
--- a/.github/workflows/pki-ca-test.yml
+++ b/.github/workflows/pki-ca-test.yml
@@ -616,6 +616,12 @@ jobs:
           docker exec pki pki-server start --wait
           docker exec pki pkidestroy -i pki-tomcat -s CA -v
 
+      - name: Check for PKI core dumps
+        if: failure()
+        run: |
+          docker exec pki ls -l
+          docker exec pki find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check DS server systemd journal
         if: always()
         run: |

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -2,6 +2,7 @@ package org.mozilla.jss.ssl.javax;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.ref.Reference;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.ByteBuffer;
@@ -1344,6 +1345,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         }
 
         tryCleanup();
+        Reference.reachabilityFence(this);
         return new SSLEngineResult(handshake_status, handshake_state, wire_data, app_data);
     }
 
@@ -1664,6 +1666,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         }
 
         tryCleanup();
+        Reference.reachabilityFence(this);
         return new SSLEngineResult(handshake_status, handshake_state, app_data, wire_data);
     }
 
@@ -1690,6 +1693,11 @@ public class JSSEngineReferenceImpl extends JSSEngine {
     @Override
     public synchronized void cleanup() {
         debug("JSSEngine: cleanup()");
+
+        // Set closed_fd BEFORE calling closeInbound()/closeOutbound() to prevent
+        // them from calling PR.Shutdown() on ssl_fd that is about to be freed.
+        // This avoids a use-after-free crash in the finalizer thread.
+        closed_fd = true;
 
         if (!is_inbound_closed) {
             debug("JSSEngine: cleanup() - closing opened inbound socket");
@@ -1731,12 +1739,10 @@ public class JSSEngineReferenceImpl extends JSSEngine {
     }
 
     private void cleanupSSLFD() {
-        if (!closed_fd && ssl_fd != null) {
-            // Set closed_fd BEFORE freeing native resources to prevent
-            // concurrent calls to closeInbound()/closeOutbound() from
+        if (ssl_fd != null) {
+            // closed_fd is already set to true in cleanup() before this is called.
+            // This prevents concurrent calls to closeInbound()/closeOutbound() from
             // attempting PR.Shutdown() on ssl_fd that is being freed.
-            closed_fd = true;
-
             try {
                 SSL.RemoveCallbacks(ssl_fd);
                 ssl_fd.close();


### PR DESCRIPTION
Set `closed_fd` before calling `closeInbound()/closeOutbound()` in cleanup() to prevent them from calling `PR.Shutdown()` on `ssl_fd` that is being freed. This fixes a SIGSEGV crash where `PR.Shutdown()` attempted to write TLS close_notify alerts to NSS buffers during cleanup.

The crash occurred because `cleanup()` called `closeOutbound()` which checked `!closed_fd` and invoked `PR.Shutdown()`, but `cleanupSSLFD()` set `closed_fd` too late. Moving `closed_fd = true` to the start of `cleanup()` prevents the native `PR.Shutdown()` call while still freeing all resources properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash during SSL connection cleanup that could occur in background processing threads.

* **Tests**
  * Enhanced PKI test diagnostics to automatically collect and display core dump information when test failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->