### PR TITLE
Validate PK11Context before use in PK11Cipher native calls

### DIFF
--- a/native/src/main/native/org/mozilla/jss/pkcs11/PK11Cipher.c
+++ b/native/src/main/native/org/mozilla/jss/pkcs11/PK11Cipher.c
@@ -256,7 +256,20 @@ JSS_PK11_getCipherContext(JNIEnv *env, jobject proxy, PK11Context **pContext)
 
     PR_ASSERT(env!=NULL && proxy!=NULL && pContext!=NULL);
 
-    return JSS_getPtrFromProxy(env, proxy, (void**)pContext);
+    if( JSS_getPtrFromProxy(env, proxy, (void**)pContext) != PR_SUCCESS) {
+        return PR_FAILURE;
+    }
+
+    /* Make sure the pointer is OK. If the underlying context has already
+     * been released (or was never valid), fail cleanly here instead of
+     * letting a NULL PK11Context reach NSS. */
+    if( *pContext == NULL ) {
+        PR_ASSERT(PR_FALSE);
+        JSS_throwMsg(env, TOKEN_EXCEPTION, "Cipher context is no longer valid");
+        return PR_FAILURE;
+    }
+
+    return PR_SUCCESS;
 }
 
 /***********************************************************************


### PR DESCRIPTION
JSS_PK11_getCipherContext extracted the PK11Context pointer from a CipherContextProxy without checking it for NULL, unlike the analogous JSS_PK11_getSigContext used by PK11Signature. If the underlying context was ever invalid (e.g. already released), the NULL pointer was passed straight into PK11_CipherOp/PK11_DigestFinal, crashing the whole JVM with a SIGSEGV instead of failing the single operation.

Now a NULL context throws a catchable TokenException at the JSS/NSS boundary, matching PK11Signature's existing behavior.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or expired cipher contexts.
  * Reports a clear token-related error instead of continuing with an unavailable context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->