### PR TITLE
Remove finalize() from PK11Cipher to prevent premature GC race

### DIFF
--- a/base/src/main/java/org/mozilla/jss/pkcs11/PK11Cipher.java
+++ b/base/src/main/java/org/mozilla/jss/pkcs11/PK11Cipher.java
@@ -293,11 +293,6 @@ public final class PK11Cipher
     }
 
     @Override
-    public void finalize() throws Throwable {
-        close();
-    }
-
-    @Override
     public void close() throws Exception {
         if (contextProxy != null) {
             try {


### PR DESCRIPTION
PK11Cipher's native methods (updateContext, finalizeContext) are declared static, so the JVM does not pin the PK11Cipher instance during JNI execution. Under GC pressure the JIT can determine the PK11Cipher is unreachable while a static native call is in progress, triggering finalize() on the finalizer thread. This calls close() which calls contextProxy.close(), destroying the native PK11Context and nulling mPointer while the worker thread still holds a JNI reference to the same CipherContextProxy. The subsequent JSS_getPtrFromProxy reads NULL, and PK11_DigestFinal(NULL) crashes with SIGSEGV.

Removing finalize() breaks this chain. Native resource cleanup is still guaranteed by CipherContextProxy's own NativeProxy.finalize(), which only runs when the proxy itself is unreachable (no JNI local refs), so no race is possible. Explicit cleanup via AutoCloseable close() is preserved.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cipher resource cleanup by relying on explicit closure.
  * Prevented cleanup from occurring unexpectedly during automatic object finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->