### PR TITLE
Fix dynamic oid registration of KWP encryption algorithm mismatch.

### DIFF
--- a/native/src/main/native/org/mozilla/jss/crypto/Algorithm.c
+++ b/native/src/main/native/org/mozilla/jss/crypto/Algorithm.c
@@ -220,6 +220,16 @@ JSS_RegisterDynamicOids(void)
             newOIDTags[i] = tag;
         }
     }
+
+    /* Update JSS_AlgTable with runtime-resolved OID tags so that
+     * JSS_getOidTagFromAlg returns the correct tag regardless of
+     * which NSS version JSS was compiled against. */
+    if (rv == SECSuccess) {
+        JSS_AlgTable[81].val = newOIDTags[0];  /* AES_128_KEY_WRAP_KWP */
+        JSS_AlgTable[82].val = newOIDTags[1];  /* AES_192_KEY_WRAP_KWP */
+        JSS_AlgTable[83].val = newOIDTags[2];  /* AES_256_KEY_WRAP_KWP */
+    }
+
     return rv;
 }
 


### PR DESCRIPTION
Fix KWP encryption oid registration mismatch issue:

When JSS initializes, it dynamically registers three KWP OIDs with NSS — AES-128, AES-192, and AES-256 variants of Key Wrap with Padding — to enable KWP as an encryption
  algorithm within NSS's PBES2 framework for wrapping private keys into EncryptedPrivateKeyInfo blobs (used in P12 files). These OIDs are not built into NSS's OID table, so
  JSS defines them in its header as SEC_OID_TOTAL + 0, SEC_OID_TOTAL + 1, and SEC_OID_TOTAL + 2. SEC_OID_TOTAL is the count of built-in OIDs in NSS, which changes as NSS
  adds new OIDs across versions — for example, it's 364 in NSS 3.79, 389 in the RHEL build of NSS 3.101, and 396 in NSS 3.112. These values get baked into the JSS binary at
  compile time and stored in JSS_AlgTable, where they're used to look up the OID tag when performing crypto operations. At runtime, SECOID_AddEntry() registers the KWP OIDs
  and returns the correct tag for the running NSS version, but prior to this fix, the returned tags were stored in a separate newOIDTags[] array and JSS_AlgTable was never
  updated — it still held the compile-time values. When the build-time and runtime NSS versions differed, JSS would pass the wrong OID tag (e.g., 391 instead of 398),
  causing NSS to reject it with SEC_ERROR_INVALID_ALGORITHM (-8186). The fix simply updates the JSS_AlgTable entries with the runtime-resolved tags from SECOID_AddEntry()
  during initialization, ensuring the correct OID tag is used regardless of which NSS version JSS was compiled against.


Assisted by: Claude Sonnet 4.5, for diagnosing the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AES key-wrapping support by ensuring AES-128, AES-192, and AES-256 algorithms use their correctly resolved runtime identifiers.
  * Enhances reliability for cryptographic operations involving AES key wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->