### PR TITLE
Fix: DOGTAG-4585: 

### DIFF
--- a/src/main/java/org/mozilla/jss/crypto/Algorithm.c
+++ b/src/main/java/org/mozilla/jss/crypto/Algorithm.c
@@ -208,6 +208,16 @@ JSS_RegisterDynamicOids(void)
             newOIDTags[i] = tag;
         }
     }
+
+    /* Update JSS_AlgTable with runtime-resolved OID tags so that
+     * JSS_getOidTagFromAlg returns the correct tag regardless of
+     * which NSS version JSS was compiled against. */
+    if (rv == SECSuccess) {
+        JSS_AlgTable[81].val = newOIDTags[0];  /* AES_128_KEY_WRAP_KWP */
+        JSS_AlgTable[82].val = newOIDTags[1];  /* AES_192_KEY_WRAP_KWP */
+        JSS_AlgTable[83].val = newOIDTags[2];  /* AES_256_KEY_WRAP_KWP */
+    }
+
     return rv;
 }
 

--- a/src/main/java/org/mozilla/jss/pkcs11/PK11Store.c
+++ b/src/main/java/org/mozilla/jss/pkcs11/PK11Store.c
@@ -694,7 +694,7 @@ Java_org_mozilla_jss_pkcs11_PK11Store_getEncryptedPrivateKeyInfo(
                    slot,
         algTag,     /* PBE algorithm to encrypt the  key with */
         SEC_OID_UNKNOWN,     /* Encryption algorithm to Encrypt the key with */
-        SEC_OID_UNKNOWN,     /* Hash algorithm for PRF */
+        SEC_OID_HMAC_SHA256,     /* Use SHA-256 for PRF, not default */
         pwItem,      /* password for PBE encryption */
         privk, /* encrypt this private key */
         iterations,        /* interations for PBE alg */


### PR DESCRIPTION
SSKG Fails on Thales HSM with error CKR_ATTRIBUTE_VALUE_INVALID (RHCS 10.4)

Simple JSS fixes for this overall effort. Includes both dynamic KWP encryption alg registration fix.