### PR TITLE
Fix TLS 1.3 post-handshake authentication hanging at 100% CPU

### DIFF
--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -1382,6 +1382,16 @@ public class JSSEngineReferenceImpl extends JSSEngine {
                     seen_exception = true;
                 }
             }
+
+            // TLS 1.3 post-handshake auth: PR.Read() may have processed a
+            // CertificateRequest, putting the Certificate response in write_buf.
+            // Break so the caller can call wrap() to send it.
+            if (handshake_already_complete && !seen_exception
+                && Buffer.ReadCapacity(write_buf) > 0) {
+                handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+                break;
+            }
+
         } while (this_src_write != 0 || this_dst_write != 0);
 
         SSLException checkException = checkSSLAlerts();

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -47,6 +47,7 @@ public class JSSSocketChannel extends SocketChannel {
     private ByteBuffer writeBuffer;
 
     private boolean handshakeCompleted = false;
+    private boolean pendingPostHandshake = false;
 
     public JSSSocketChannel(JSSSocket sslSocket, SocketChannel parent, Socket parentSocket, ReadableByteChannel readChannel, WritableByteChannel writeChannel, JSSEngine engine) throws IOException {
         super(null);
@@ -251,6 +252,10 @@ public class JSSSocketChannel extends SocketChannel {
             return -1;
         }
 
+        if (pendingPostHandshake) {
+            flushPostHandshake();
+        }
+
         long unwrapped = 0;
         long decrypted = 0;
 
@@ -298,6 +303,12 @@ public class JSSSocketChannel extends SocketChannel {
 
                 readBuffer.compact();
 
+                // Handle TLS 1.3 post-handshake auth (CertificateRequest)
+                if (result.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_WRAP
+                    && handshakeCompleted) {
+                    flushPostHandshake();
+                }
+
                 // If we consumed bytes, there is now room in readBuffer for some
                 // more.  Even if dsts are full, we may be able to consume more
                 // bytes in another call to unwrap().
@@ -316,12 +327,39 @@ public class JSSSocketChannel extends SocketChannel {
         return (int) write(new ByteBuffer[] { src });
     }
 
+    private void flushPostHandshake() throws IOException {
+        if (!pendingPostHandshake) {
+            writeBuffer.clear();
+        }
+        SSLEngineResult wr;
+        do {
+            wr = engine.wrap(new ByteBuffer[0], 0, 0, writeBuffer);
+            writeBuffer.flip();
+            while (writeBuffer.hasRemaining()) {
+                int n = writeChannel.write(writeBuffer);
+                if (n == 0) {
+                    writeBuffer.compact();
+                    pendingPostHandshake = true;
+                    return;
+                }
+            }
+            writeBuffer.compact();
+        } while (wr.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_WRAP);
+        pendingPostHandshake = false;
+    }
+
     @Override
     public synchronized long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
         if (outboundClosed) {
             return -1;
         }
 
+        if (pendingPostHandshake) {
+            flushPostHandshake();
+            if (pendingPostHandshake) {
+                return 0;
+            }
+        }
         writeBuffer.clear();
 
         ByteBuffer dst = writeBuffer;


### PR DESCRIPTION
Fix TLS 1.3 post-handshake authentication hanging at 100% CPU
    
    When a TLS 1.3 server sends a post-handshake CertificateRequest to a
    JSS client, the unwrap() do-while loop spins indefinitely. PR.Read()
    processes the request and queues the Certificate response in write_buf,
    but the loop never breaks to let the caller call wrap() to flush it.
    
    In JSSEngineReferenceImpl, detect pending write data after a completed
    handshake and signal NEED_WRAP to break the loop.
    
    In JSSSocketChannel, add flushPostHandshake() to drive wrap() and
    send the Certificate response. Handle non-blocking channels by
    preserving pending output when writeChannel.write() returns 0 and
    retrying on the next read() or write() call.
    
    Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2490607
    
    Signed-off-by: Thomas Woerner <twoerner@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS 1.3 post-handshake authentication handling.
  * Ensured generated authentication responses are sent correctly during secure channel reads.
  * Improved handshake processing for socket-based connections requiring additional outbound records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->