### PR TITLE
Integrate TLS 1.3 post-handshake authentication into the handshake state machine

### DIFF
--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -201,6 +201,13 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     protected boolean is_inbound_closed;
 
     /**
+     * Whether PR.Read() inside unwrap() detected a TLS 1.3 post-handshake
+     * auth event (e.g. CertificateRequest) that produced new data in
+     * write_buf. Cleared after wrap() drains the response.
+     */
+    protected boolean post_handshake_auth_pending;
+
+    /**
      * Set of configuration options to enable via SSL_OptionSet(...).
      */
     protected HashMap<Integer, Integer> config;
@@ -1064,6 +1071,10 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     public boolean isOutboundDone() {
         logger.debug("JSSEngine.isOutboundDone()? " + is_outbound_closed);
         return is_outbound_closed;
+    }
+
+    public boolean isPostHandshakeAuthPending() {
+        return post_handshake_auth_pending;
     }
 
     /**

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -1382,6 +1382,16 @@ public class JSSEngineReferenceImpl extends JSSEngine {
                     seen_exception = true;
                 }
             }
+
+            // TLS 1.3 post-handshake auth: PR.Read() may have processed a
+            // CertificateRequest, putting the Certificate response in write_buf.
+            // Break so the caller can call wrap() to send it.
+            if (handshake_already_complete && !seen_exception
+                && Buffer.ReadCapacity(write_buf) > 0) {
+                handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+                break;
+            }
+
         } while (this_src_write != 0 || this_dst_write != 0);
 
         SSLException checkException = checkSSLAlerts();

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -1126,6 +1126,14 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
             ssl_exception = checkSSLAlerts();
             seen_exception = (ssl_exception != null);
+
+            // TLS 1.3 post-handshake: NSS may have queued response data
+            // (e.g. Certificate for a CertificateRequest).
+            if (!seen_exception && Buffer.ReadCapacity(write_buf) > 0) {
+                debug("JSSEngine.updateHandshakeState() - post-handshake NEED_WRAP");
+                handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+            }
+
             return;
         }
 
@@ -1149,6 +1157,26 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
             ssl_exception = checkSSLAlerts();
             seen_exception = (ssl_exception != null);
+            return;
+        }
+
+        // Post-handshake state: the initial handshake completed but
+        // handshake_state is not NOT_HANDSHAKING or FINISHED (e.g. set to
+        // NEED_WRAP by the write_buf check above). Transition back to
+        // NOT_HANDSHAKING once write_buf is drained; do NOT fall through
+        // to ForceHandshake/fireHandshakeComplete.
+        if (!step_handshake && ssl_fd.handshakeComplete) {
+            debug("JSSEngine.updateHandshakeState() - post-handshake, write_buf.read=" + Buffer.ReadCapacity(write_buf));
+            unknown_state_count = 0;
+
+            ssl_exception = checkSSLAlerts();
+            seen_exception = (ssl_exception != null);
+
+            if (!seen_exception && Buffer.ReadCapacity(write_buf) > 0) {
+                handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+            } else {
+                handshake_state = SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+            }
             return;
         }
 
@@ -1363,6 +1391,7 @@ public class JSSEngineReferenceImpl extends JSSEngine {
             updateHandshakeState();
 
             int max_dst_size = computeSize(dsts, offset, length);
+            long write_buf_before = Buffer.ReadCapacity(write_buf);
             byte[] app_buffer = PR.Read(ssl_fd, max_dst_size);
             int error = PR.GetError();
             debug("JSSEngine.unwrap() - " + app_buffer + " error=" + errorText(error));
@@ -1383,12 +1412,22 @@ public class JSSEngineReferenceImpl extends JSSEngine {
                 }
             }
 
+            // TLS 1.3 post-handshake auth: PR.Read() may have triggered the
+            // async cert-auth callback (e.g. validating a client's
+            // post-handshake certificate) without producing any write_buf
+            // output. Report NEED_TASK here since result.getHandshakeStatus()
+            // (unlike engine.getHandshakeStatus()) won't otherwise reflect it.
+            if (checkNeedCertValidation()) {
+                break;
+            }
+
             // TLS 1.3 post-handshake auth: PR.Read() may have processed a
             // CertificateRequest, putting the Certificate response in write_buf.
-            // Break so the caller can call wrap() to send it.
+            // Detect this by checking if PR.Read() increased write_buf.
             if (handshake_already_complete && !seen_exception
-                && Buffer.ReadCapacity(write_buf) > 0) {
+                && Buffer.ReadCapacity(write_buf) > write_buf_before) {
                 handshake_state = SSLEngineResult.HandshakeStatus.NEED_WRAP;
+                post_handshake_auth_pending = true;
                 break;
             }
 
@@ -1417,7 +1456,8 @@ public class JSSEngineReferenceImpl extends JSSEngine {
         if (is_inbound_closed) {
             debug("Socket is currently closed.");
             handshake_status = SSLEngineResult.Status.CLOSED;
-        } else if (handshake_already_complete && src_capacity > 0 && app_data == 0) {
+        } else if (handshake_already_complete && src_capacity > 0 && app_data == 0
+                   && handshake_state != SSLEngineResult.HandshakeStatus.NEED_WRAP) {
             debug("Underflowed: produced no application data when we expected to.");
             handshake_status = SSLEngineResult.Status.BUFFER_UNDERFLOW;
         }
@@ -1705,6 +1745,10 @@ public class JSSEngineReferenceImpl extends JSSEngine {
                 debug("JSSEngine.wrap(): not writing from write_buf into NULL dst");
             }
         } while (this_src_write != 0 || this_dst_write != 0);
+
+        if (post_handshake_auth_pending && Buffer.ReadCapacity(write_buf) == 0) {
+            post_handshake_auth_pending = false;
+        }
 
         // Check for new outbound alerts to the peer and fire the related events
         SSLException newSSLException = checkSSLAlerts();

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -47,6 +47,7 @@ public class JSSSocketChannel extends SocketChannel {
     private ByteBuffer writeBuffer;
 
     private boolean handshakeCompleted = false;
+    private boolean pendingPostHandshake = false;
 
     public JSSSocketChannel(JSSSocket sslSocket, SocketChannel parent, Socket parentSocket, ReadableByteChannel readChannel, WritableByteChannel writeChannel, JSSEngine engine) throws IOException {
         super(null);
@@ -251,6 +252,10 @@ public class JSSSocketChannel extends SocketChannel {
             return -1;
         }
 
+        if (pendingPostHandshake) {
+            flushPostHandshake();
+        }
+
         long unwrapped = 0;
         long decrypted = 0;
 
@@ -298,6 +303,12 @@ public class JSSSocketChannel extends SocketChannel {
 
                 readBuffer.compact();
 
+                // Handle TLS 1.3 post-handshake auth (CertificateRequest)
+                if (result.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_WRAP
+                    && handshakeCompleted) {
+                    flushPostHandshake();
+                }
+
                 // If we consumed bytes, there is now room in readBuffer for some
                 // more.  Even if dsts are full, we may be able to consume more
                 // bytes in another call to unwrap().
@@ -316,12 +327,39 @@ public class JSSSocketChannel extends SocketChannel {
         return (int) write(new ByteBuffer[] { src });
     }
 
+    private void flushPostHandshake() throws IOException {
+        if (!pendingPostHandshake) {
+            writeBuffer.clear();
+        }
+        SSLEngineResult wr;
+        do {
+            wr = engine.wrap(new ByteBuffer[0], 0, 0, writeBuffer);
+            writeBuffer.flip();
+            while (writeBuffer.hasRemaining()) {
+                int n = writeChannel.write(writeBuffer);
+                if (n == 0) {
+                    writeBuffer.compact();
+                    pendingPostHandshake = true;
+                    return;
+                }
+            }
+            writeBuffer.compact();
+        } while (wr.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_WRAP);
+        pendingPostHandshake = false;
+    }
+
     @Override
     public synchronized long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
         if (outboundClosed) {
             return -1;
         }
 
+        if (pendingPostHandshake) {
+            flushPostHandshake();
+            if (pendingPostHandshake) {
+                return 0;
+            }
+        }
         writeBuffer.clear();
 
         ByteBuffer dst = writeBuffer;

--- a/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
+++ b/base/src/main/java/org/mozilla/jss/ssl/javax/JSSSocketChannel.java
@@ -47,7 +47,7 @@ public class JSSSocketChannel extends SocketChannel {
     private ByteBuffer writeBuffer;
 
     private boolean handshakeCompleted = false;
-    private boolean pendingPostHandshake = false;
+    private boolean postHandshakePending = false;
 
     public JSSSocketChannel(JSSSocket sslSocket, SocketChannel parent, Socket parentSocket, ReadableByteChannel readChannel, WritableByteChannel writeChannel, JSSEngine engine) throws IOException {
         super(null);
@@ -252,14 +252,18 @@ public class JSSSocketChannel extends SocketChannel {
             return -1;
         }
 
-        if (pendingPostHandshake) {
-            flushPostHandshake();
-        }
-
         long unwrapped = 0;
         long decrypted = 0;
+        int postHandshakeOps = 0;
 
         try {
+            if (postHandshakePending) {
+                flushPostHandshake();
+                if (postHandshakePending) {
+                    return 0;
+                }
+            }
+
             SSLEngineResult result;
             do {
                 int n = remoteRead();
@@ -303,10 +307,39 @@ public class JSSSocketChannel extends SocketChannel {
 
                 readBuffer.compact();
 
-                // Handle TLS 1.3 post-handshake auth (CertificateRequest)
-                if (result.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_WRAP
-                    && handshakeCompleted) {
-                    flushPostHandshake();
+                // Handle NEED_WRAP and NEED_TASK after handshake completion.
+                // NEED_WRAP may come from post-handshake auth (CertificateRequest)
+                // or from leftover ciphertext in write_buf; both need flushing,
+                // but only genuine post-handshake auth counts toward the safety limit.
+                if (handshakeCompleted) {
+                    SSLEngineResult.HandshakeStatus hsStatus = result.getHandshakeStatus();
+                    if (hsStatus == SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+                        boolean isPostHandshake = engine.isPostHandshakeAuthPending();
+                        flushPostHandshake();
+                        if (postHandshakePending) {
+                            return decrypted;
+                        }
+                        if (isPostHandshake) {
+                            postHandshakeOps++;
+                        }
+                    } else if (hsStatus == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+                        Runnable task = engine.getDelegatedTask();
+                        if (task != null) {
+                            task.run();
+                        }
+                        postHandshakeOps++;
+                        // After task, a NEED_WRAP may follow (e.g. to send
+                        // the auth result). Flush it now like finishConnect().
+                        if (engine.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+                            flushPostHandshake();
+                            if (postHandshakePending) {
+                                return decrypted;
+                            }
+                        }
+                    }
+                    if (postHandshakeOps > 10) {
+                        throw new IOException("Exceeded maximum post-handshake operations during read");
+                    }
                 }
 
                 // If we consumed bytes, there is now room in readBuffer for some
@@ -322,30 +355,56 @@ public class JSSSocketChannel extends SocketChannel {
         return decrypted;
     }
 
-    @Override
-    public int write(ByteBuffer src) throws IOException {
-        return (int) write(new ByteBuffer[] { src });
-    }
-
     private void flushPostHandshake() throws IOException {
-        if (!pendingPostHandshake) {
+        if (!postHandshakePending) {
             writeBuffer.clear();
         }
+
         SSLEngineResult wr;
+        SSLEngineResult.HandshakeStatus hsStatus;
         do {
             wr = engine.wrap(new ByteBuffer[0], 0, 0, writeBuffer);
+
+            if (wr.getStatus() != SSLEngineResult.Status.OK
+                && wr.getStatus() != SSLEngineResult.Status.CLOSED) {
+                postHandshakePending = false;
+                throw new IOException("Unexpected status from post-handshake wrap: " + wr);
+            }
+
             writeBuffer.flip();
             while (writeBuffer.hasRemaining()) {
                 int n = writeChannel.write(writeBuffer);
                 if (n == 0) {
                     writeBuffer.compact();
-                    pendingPostHandshake = true;
+                    postHandshakePending = true;
                     return;
                 }
             }
+
+            if (wr.bytesProduced() == 0
+                && wr.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+                postHandshakePending = false;
+                throw new IOException("Post-handshake wrap stalled, producing no data");
+            }
+
+            hsStatus = wr.getHandshakeStatus();
+            if (hsStatus == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+                Runnable task = engine.getDelegatedTask();
+                if (task != null) {
+                    task.run();
+                }
+                hsStatus = engine.getHandshakeStatus();
+            }
+
             writeBuffer.compact();
-        } while (wr.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_WRAP);
-        pendingPostHandshake = false;
+        } while (hsStatus == SSLEngineResult.HandshakeStatus.NEED_WRAP);
+
+        postHandshakePending = false;
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        return (int) write(new ByteBuffer[] { src });
     }
 
     @Override
@@ -354,12 +413,13 @@ public class JSSSocketChannel extends SocketChannel {
             return -1;
         }
 
-        if (pendingPostHandshake) {
+        if (postHandshakePending) {
             flushPostHandshake();
-            if (pendingPostHandshake) {
+            if (postHandshakePending) {
                 return 0;
             }
         }
+
         writeBuffer.clear();
 
         ByteBuffer dst = writeBuffer;

--- a/base/src/test/java/org/mozilla/jss/tests/TestJSSSocketChannel.java
+++ b/base/src/test/java/org/mozilla/jss/tests/TestJSSSocketChannel.java
@@ -1,0 +1,375 @@
+package org.mozilla.jss.tests;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.security.KeyStore;
+import java.util.Arrays;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.provider.javax.crypto.JSSNativeTrustManager;
+import org.mozilla.jss.ssl.javax.JSSParameters;
+import org.mozilla.jss.ssl.javax.JSSSocket;
+
+public class TestJSSSocketChannel {
+
+    static X509KeyManager[] keyManagers;
+    static X509TrustManager[] trustManagers;
+
+    public static void initialize(String[] args) throws Exception {
+        CryptoManager cm = CryptoManager.getInstance();
+        cm.setPasswordCallback(new FilePasswordCallback(args[1]));
+
+        KeyStore ks = KeyStore.getInstance("PKCS11", "Mozilla-JSS");
+        ks.load(null, null);
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NssX509", "Mozilla-JSS");
+        kmf.init(ks, null);
+
+        KeyManager[] kms = kmf.getKeyManagers();
+        keyManagers = new X509KeyManager[kms.length];
+        for (int i = 0; i < kms.length; i++) {
+            keyManagers[i] = (X509KeyManager) kms[i];
+        }
+
+        trustManagers = new X509TrustManager[] { new JSSNativeTrustManager() };
+    }
+
+    static JSSSocket createJSSSocket(SSLContext ctx, Socket raw, String alias, boolean clientMode, int port) throws Exception {
+        JSSSocket sock = new JSSSocket();
+        sock.consumeSocket(raw);
+        sock.setSSLContext(ctx);
+        if (clientMode) {
+            sock.initEngine("localhost", port);
+        } else {
+            sock.initEngine();
+        }
+        JSSParameters params = new JSSParameters();
+        params.setAliases(Arrays.asList(alias.split(",")));
+        params.setHostname("localhost");
+        sock.setSSLParameters(params);
+        sock.setUseClientMode(clientMode);
+        sock.setKeyManagers(keyManagers);
+        sock.setTrustManagers(trustManagers);
+        return sock;
+    }
+
+    static byte[] readWithRetry(InputStream in, long timeoutMs) throws Exception {
+        byte[] buf = new byte[4096];
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        int total = 0;
+        while (total == 0) {
+            if (System.currentTimeMillis() > deadline) {
+                throw new IOException("Read timed out after " + timeoutMs + "ms");
+            }
+            int n = in.read(buf, total, buf.length - total);
+            if (n < 0) {
+                throw new IOException("Unexpected EOF");
+            }
+            total += n;
+            if (total == 0) {
+                Thread.sleep(50);
+            }
+        }
+        return Arrays.copyOf(buf, total);
+    }
+
+    static byte[] readExactly(InputStream in, int count, long timeoutMs) throws Exception {
+        byte[] buf = new byte[count];
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        int total = 0;
+        while (total < count) {
+            if (System.currentTimeMillis() > deadline) {
+                throw new IOException("Read timed out after " + timeoutMs + "ms (got " + total + " of " + count + " bytes)");
+            }
+            int n = in.read(buf, total, count - total);
+            if (n < 0) {
+                throw new IOException("Unexpected EOF after " + total + " of " + count + " bytes");
+            }
+            if (n == 0) {
+                Thread.sleep(50);
+            }
+            total += n;
+        }
+        return buf;
+    }
+
+    static void assertEqual(String expected, byte[] actual, String context) {
+        String actualStr = new String(actual);
+        if (!expected.equals(actualStr)) {
+            throw new RuntimeException(context + ": expected '" + expected + "', got '" + actualStr + "'");
+        }
+    }
+
+    public static void testPostHandshakeAuth(SSLContext ctx, String clientAlias, String serverAlias) throws Exception {
+        System.out.println("TestJSSSocketChannel: testPostHandshakeAuth");
+
+        final Exception[] serverError = { null };
+
+        ServerSocket ss = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+        int port = ss.getLocalPort();
+
+        Thread serverThread = new Thread(() -> {
+            try {
+                Socket rawServer = ss.accept();
+                JSSSocket server = createJSSSocket(ctx, rawServer, serverAlias, false, 0);
+                server.setEnabledProtocols(new String[] { "TLSv1.3" });
+
+                server.startHandshake();
+                System.out.println("  server: initial handshake complete");
+
+                OutputStream sOut = server.getOutputStream();
+                InputStream sIn = server.getInputStream();
+
+                sOut.write("hello from server".getBytes());
+                sOut.flush();
+
+                assertEqual("hello from client", readWithRetry(sIn, 10000), "server initial read");
+                System.out.println("  server: initial data exchange OK");
+
+                // Enable client auth and trigger post-handshake auth
+                server.setWantClientAuth(true);
+                server.setNeedClientAuth(true);
+                server.startHandshake();
+
+                sOut.write("post-auth data".getBytes());
+                sOut.flush();
+                System.out.println("  server: sent post-handshake-auth data");
+
+                assertEqual("post-auth reply", readWithRetry(sIn, 10000), "server post-auth read");
+
+                SSLSession session = server.getSession();
+                assert session.getPeerCertificates() != null : "Expected peer certificates";
+                assert session.getPeerCertificates().length > 0 : "Expected at least one peer certificate";
+                System.out.println("  server: verified " + session.getPeerCertificates().length + " peer cert(s)");
+
+                // Send >18KB to verify large writes work after
+                // post-handshake auth.
+                byte[] largeData = new byte[32 * 1024];
+                for (int i = 0; i < largeData.length; i++) {
+                    largeData[i] = (byte) (i & 0xFF);
+                }
+                sOut.write(largeData);
+                sOut.flush();
+                System.out.println("  server: sent " + largeData.length + " bytes post-auth");
+
+                assertEqual("large-data-ok", readWithRetry(sIn, 10000), "server large data ack");
+
+                // Signal the client it is OK to close now. This prevents
+                // the client's close_notify from arriving while the server
+                // is still processing the post-handshake auth response.
+                sOut.write("done".getBytes());
+                sOut.flush();
+
+                server.close();
+            } catch (Exception e) {
+                serverError[0] = e;
+            }
+        });
+        serverThread.setDaemon(true);
+        serverThread.start();
+
+        try {
+            Socket rawClient = new Socket(InetAddress.getLoopbackAddress(), port);
+            JSSSocket client = createJSSSocket(ctx, rawClient, clientAlias, true, port);
+            client.setEnabledProtocols(new String[] { "TLSv1.3" });
+
+            client.startHandshake();
+            System.out.println("  client: initial handshake complete");
+
+            OutputStream cOut = client.getOutputStream();
+            InputStream cIn = client.getInputStream();
+
+            assertEqual("hello from server", readWithRetry(cIn, 10000), "client initial read");
+
+            cOut.write("hello from client".getBytes());
+            cOut.flush();
+            System.out.println("  client: initial data exchange OK");
+
+            // This read triggers post-handshake auth processing
+            // in JSSSocketChannel.read() → flushPostHandshake()
+            assertEqual("post-auth data", readWithRetry(cIn, 10000), "client post-auth read");
+            System.out.println("  client: post-handshake auth completed transparently");
+
+            cOut.write("post-auth reply".getBytes());
+            cOut.flush();
+
+            // Receive the large (>18KB) post-auth transfer
+            int largeSize = 32 * 1024;
+            byte[] largeReceived = readExactly(cIn, largeSize, 10000);
+            for (int i = 0; i < largeSize; i++) {
+                if (largeReceived[i] != (byte) (i & 0xFF)) {
+                    throw new RuntimeException("Large data mismatch at byte " + i);
+                }
+            }
+            System.out.println("  client: received and verified " + largeSize + " bytes post-auth");
+            cOut.write("large-data-ok".getBytes());
+            cOut.flush();
+
+            // Wait for server ack before closing, so close_notify doesn't
+            // race with the server's read of the post-handshake auth response.
+            assertEqual("done", readWithRetry(cIn, 10000), "client done-ack read");
+
+            client.close();
+        } finally {
+            serverThread.join(30000);
+            ss.close();
+        }
+
+        if (serverError[0] != null) {
+            throw new RuntimeException("Server thread failed", serverError[0]);
+        }
+
+        if (serverThread.isAlive()) {
+            throw new RuntimeException("Server thread did not finish in time");
+        }
+
+        System.out.println("TestJSSSocketChannel: testPostHandshakeAuth PASSED");
+    }
+
+    public static void testMultipleMessagesAfterPostHandshakeAuth(SSLContext ctx, String clientAlias, String serverAlias) throws Exception {
+        System.out.println("TestJSSSocketChannel: testMultipleMessagesAfterPostHandshakeAuth");
+
+        final Exception[] serverError = { null };
+
+        ServerSocket ss = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+        int port = ss.getLocalPort();
+
+        Thread serverThread = new Thread(() -> {
+            try {
+                Socket rawServer = ss.accept();
+                JSSSocket server = createJSSSocket(ctx, rawServer, serverAlias, false, 0);
+                server.setEnabledProtocols(new String[] { "TLSv1.3" });
+
+                server.startHandshake();
+
+                OutputStream sOut = server.getOutputStream();
+                InputStream sIn = server.getInputStream();
+
+                // Initial data exchange to settle the connection
+                sOut.write("ping".getBytes());
+                sOut.flush();
+                assertEqual("pong", readWithRetry(sIn, 10000), "server initial read");
+
+                // Trigger post-handshake auth
+                server.setWantClientAuth(true);
+                server.setNeedClientAuth(true);
+                server.startHandshake();
+
+                sOut.write("auth-trigger".getBytes());
+                sOut.flush();
+
+                assertEqual("ack", readWithRetry(sIn, 10000), "server ack read");
+
+                // Multiple round trips after post-handshake auth
+                for (int i = 0; i < 5; i++) {
+                    String msg = "server-msg-" + i;
+                    sOut.write(msg.getBytes());
+                    sOut.flush();
+
+                    String expected = "client-msg-" + i;
+                    assertEqual(expected, readWithRetry(sIn, 10000), "server round " + i);
+                }
+
+                sOut.write("done".getBytes());
+                sOut.flush();
+
+                server.close();
+            } catch (Exception e) {
+                serverError[0] = e;
+            }
+        });
+        serverThread.setDaemon(true);
+        serverThread.start();
+
+        try {
+            Socket rawClient = new Socket(InetAddress.getLoopbackAddress(), port);
+            JSSSocket client = createJSSSocket(ctx, rawClient, clientAlias, true, port);
+            client.setEnabledProtocols(new String[] { "TLSv1.3" });
+
+            client.startHandshake();
+
+            OutputStream cOut = client.getOutputStream();
+            InputStream cIn = client.getInputStream();
+
+            assertEqual("ping", readWithRetry(cIn, 10000), "client initial read");
+            cOut.write("pong".getBytes());
+            cOut.flush();
+
+            assertEqual("auth-trigger", readWithRetry(cIn, 10000), "client auth-trigger read");
+
+            cOut.write("ack".getBytes());
+            cOut.flush();
+
+            // Multiple round trips after post-handshake auth
+            for (int i = 0; i < 5; i++) {
+                String expected = "server-msg-" + i;
+                assertEqual(expected, readWithRetry(cIn, 10000), "client round " + i);
+
+                String msg = "client-msg-" + i;
+                cOut.write(msg.getBytes());
+                cOut.flush();
+            }
+
+            assertEqual("done", readWithRetry(cIn, 10000), "client done-ack read");
+
+            client.close();
+        } finally {
+            serverThread.join(30000);
+            ss.close();
+        }
+
+        if (serverError[0] != null) {
+            throw new RuntimeException("Server thread failed", serverError[0]);
+        }
+
+        if (serverThread.isAlive()) {
+            throw new RuntimeException("Server thread did not finish in time");
+        }
+
+        System.out.println("TestJSSSocketChannel: testMultipleMessagesAfterPostHandshakeAuth PASSED");
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("Initializing CryptoManager...");
+        initialize(args);
+
+        if (!org.mozilla.jss.JSSProvider.ENABLE_JSSENGINE) {
+            System.out.println("JSSEngine not enabled, skipping.");
+            return;
+        }
+
+        String clientAlias = args[2];
+        String serverAlias = args[3];
+
+        // Check TLS 1.3 support
+        SSLContext ctx = SSLContext.getInstance("TLS", "Mozilla-JSS");
+        ctx.init(keyManagers, trustManagers, null);
+
+        String[] supported = ctx.createSSLEngine().getSupportedProtocols();
+        boolean tls13 = false;
+        for (String p : supported) {
+            if ("TLSv1.3".equals(p)) {
+                tls13 = true;
+                break;
+            }
+        }
+        if (!tls13) {
+            System.out.println("TLS 1.3 not supported, skipping.");
+            return;
+        }
+
+        testPostHandshakeAuth(ctx, clientAlias, serverAlias);
+        testMultipleMessagesAfterPostHandshakeAuth(ctx, clientAlias, serverAlias);
+    }
+}

--- a/cmake/JSSTests.cmake
+++ b/cmake/JSSTests.cmake
@@ -327,6 +327,11 @@ macro(jss_tests)
         DEPENDS "Generate_known_RSA_cert_pair"
     )
 
+    jss_test_java(
+        NAME "JSSSocketChannel_PostHandshakeAuth"
+        COMMAND "org.mozilla.jss.tests.TestJSSSocketChannel" "${RESULTS_NSSDB_OUTPUT_DIR}" "${PASSWORD_FILE}" "Client_RSA" "Server_RSA"
+        DEPENDS "SSLEngine_RSA"
+    )
 
     if(NOT FIPS_ENABLED)
         jss_test_java(


### PR DESCRIPTION
  ## Summary

  Builds on #1115 (Thomas Woerner's fix for the TLS 1.3 post-handshake
  auth hang) by folding post-handshake auth into the existing handshake
  state machine instead of a separate parallel path. This closes gaps
  found in review:
  
  - `flushPostHandshake()` had no status check, so a `BUFFER_OVERFLOW`
    on the Certificate response could spin the loop at 100% CPU — the
    same bug class the original PR fixed, just relocated.
  - The root-cause path in `updateHandshakeState()` was unfixed, so
    other post-handshake message types could hit the same stall.
  - `write_buf > 0` alone can't distinguish real post-handshake auth
    from leftover ciphertext.
  - `NEED_TASK` (cert validation) wasn't fully driven during flush.
  - Non-blocking channels had no way to preserve partial writes.

  ## Changes
  
  - **`JSSEngine.java`** — Adds `post_handshake_auth_pending`, set only
    when `PR.Read()` demonstrably grows `write_buf`, to disambiguate
    real post-handshake auth from leftover ciphertext.
  - **`JSSEngineReferenceImpl.java`** — Integrates post-handshake
    handling into `updateHandshakeState()`, guards the spurious
    `BUFFER_UNDERFLOW` report, clears the flag once `write_buf` drains.
  - **`JSSSocketChannel.java`** — Hardens `flushPostHandshake()` with a
    status check, stall detection, and full `NEED_TASK` handling;
    `read()`/`write()` retry a pending flush and return 0 correctly for
    non-blocking channels.

  ## Known limitations (standard TLS/SSLEngine behavior, not specific to this change)
  
  - Write-only usage never processes a pending `CertificateRequest`
    (no `read()` call means no `PR.Read()`).
  - A full destination buffer delays processing until the next `read()`
    with available space; no data is lost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for TLS 1.3 post-handshake authentication and certificate responses.
  - TLS engines now signal when post-handshake data requires transmission.
  - Socket channels flush pending handshake data before application traffic, including partial non-blocking writes.

- **Bug Fixes**
  - Improved handshake state handling after the initial handshake.
  - Prevented incorrect underflow reports while handshake responses are pending.
  - Improved delegated task handling and detection of stalled post-handshake operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->