### PR TITLE
Fix CVE-2026-78323: require real CA trust in JSSTrustManager

### DIFF
--- a/base/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
+++ b/base/src/main/java/org/mozilla/jss/provider/javax/crypto/JSSTrustManager.java
@@ -458,15 +458,15 @@ public class JSSTrustManager implements X509TrustManager {
         try {
             CryptoManager manager = CryptoManager.getInstance();
             for (org.mozilla.jss.crypto.X509Certificate cert : manager.getCACerts()) {
-                logger.debug("JSSTrustManager:  - " + cert.getSubjectDN());
-
-                try {
-                    PK11Cert caCert = (PK11Cert) cert;
-                    caCert.checkValidity();
-                    caCerts.add(caCert);
-
-                } catch (Exception e) {
-                    logger.debug("JSSTrustManager: " + e.getClass().getName() + ": " + e.getMessage());
+                if (isTrustAnchor(cert)) {
+                    try {
+                        PK11Cert caCert = (PK11Cert) cert;
+                        caCert.checkValidity();
+                        caCerts.add(caCert);
+                        logger.debug("JSSTrustManager:  - " + cert.getSubjectDN());
+                    } catch (Exception e) {
+                        logger.debug("JSSTrustManager: " + e.getClass().getName() + ": " + e.getMessage());
+                    }
                 }
             }
 


### PR DESCRIPTION
getAcceptedIssuers() built its candidate issuer list from CryptoManager.getCACerts(), which returns every certificate NSS considers structurally CA-shaped (basicConstraints CA:TRUE), regardless of whether it carries an actual trust flag. checkSignature() then accepted any presented chain whose signature matched an entry in that list, without ever consulting trust flags.

As a result, a CA certificate imported with only VALID_CA — e.g. the issuing chain routinely stored during certificate enrollment via CERT_ImportCAChainTrusted(), which deliberately withholds TRUSTED_CA — was treated as a full trust anchor for all subsequent TLS connections, letting a forged leaf certificate from such a CA be accepted as if issued by a legitimately trusted authority.

Require isTrustAnchor() (TRUSTED_CA / TRUSTED_CLIENT_CA / NS_TRUSTED_CA on the cert's SSL trust flags) before a CA certificate is added to the accepted-issuers list in getAcceptedIssuersFromCACerts(), matching the filtering already applied on the token-scoped path and NSS's own certUsageSSLCA trust semantics.

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate trust handling by including only verified trust-anchor certificates.
  * Continued validating certificate validity and recording certificate-processing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->